### PR TITLE
Apply fractional DT from simulation settings

### DIFF
--- a/shrewd-app/src/main/java/systems/courant/shrewd/app/canvas/SimulationSettingsDialog.java
+++ b/shrewd-app/src/main/java/systems/courant/shrewd/app/canvas/SimulationSettingsDialog.java
@@ -26,6 +26,7 @@ public class SimulationSettingsDialog extends Dialog<SimulationSettings> {
     private final ComboBox<String> timeStepCombo;
     private final TextField durationField;
     private final ComboBox<String> durationUnitCombo;
+    private final TextField dtField;
 
     public SimulationSettingsDialog(SimulationSettings existing) {
         setTitle("Simulation Settings");
@@ -37,15 +38,20 @@ public class SimulationSettingsDialog extends Dialog<SimulationSettings> {
         durationField.setId("simDuration");
         durationUnitCombo = new ComboBox<>(FXCollections.observableArrayList(TIME_UNIT_OPTIONS));
         durationUnitCombo.setId("simDurationUnit");
+        dtField = new TextField();
+        dtField.setId("simDt");
+        dtField.setPromptText("e.g. 0.25");
 
         if (existing != null) {
             timeStepCombo.setValue(existing.timeStep());
             durationField.setText(formatDuration(existing.duration()));
             durationUnitCombo.setValue(existing.durationUnit());
+            dtField.setText(formatDuration(existing.dt()));
         } else {
             timeStepCombo.setValue("Day");
             durationField.setText("100");
             durationUnitCombo.setValue("Day");
+            dtField.setText("1");
         }
 
         GridPane grid = new GridPane();
@@ -59,17 +65,21 @@ public class SimulationSettingsDialog extends Dialog<SimulationSettings> {
         grid.add(durationField, 1, 1);
         grid.add(new Label("Duration Unit:"), 0, 2);
         grid.add(durationUnitCombo, 1, 2);
+        grid.add(new Label("DT:"), 0, 3);
+        grid.add(dtField, 1, 3);
 
         getDialogPane().setContent(grid);
 
         ButtonType okButton = new ButtonType("OK", ButtonBar.ButtonData.OK_DONE);
         getDialogPane().getButtonTypes().addAll(okButton, ButtonType.CANCEL);
 
-        // Validate: disable OK when duration is not a positive number
+        // Validate: disable OK when duration or DT is not a positive number
         getDialogPane().lookupButton(okButton).disableProperty().bind(
                 Bindings.createBooleanBinding(
-                        () -> !isValidDuration(durationField.getText()),
-                        durationField.textProperty()
+                        () -> !isValidPositiveNumber(durationField.getText())
+                                || !isValidPositiveNumber(dtField.getText()),
+                        durationField.textProperty(),
+                        dtField.textProperty()
                 )
         );
 
@@ -78,7 +88,8 @@ public class SimulationSettingsDialog extends Dialog<SimulationSettings> {
                 return new SimulationSettings(
                         timeStepCombo.getValue(),
                         Double.parseDouble(durationField.getText().trim()),
-                        durationUnitCombo.getValue()
+                        durationUnitCombo.getValue(),
+                        Double.parseDouble(dtField.getText().trim())
                 );
             }
             return null;
@@ -92,7 +103,7 @@ public class SimulationSettingsDialog extends Dialog<SimulationSettings> {
         return String.valueOf(value);
     }
 
-    private static boolean isValidDuration(String text) {
+    private static boolean isValidPositiveNumber(String text) {
         if (text == null || text.isBlank()) {
             return false;
         }

--- a/shrewd-app/src/test/java/systems/courant/shrewd/app/canvas/SimulationSettingsDialogFxTest.java
+++ b/shrewd-app/src/test/java/systems/courant/shrewd/app/canvas/SimulationSettingsDialogFxTest.java
@@ -51,10 +51,12 @@ class SimulationSettingsDialogFxTest {
         ComboBox<?> timeStep = robot.lookup("#simTimeStep").queryAs(ComboBox.class);
         TextField duration = robot.lookup("#simDuration").queryAs(TextField.class);
         ComboBox<?> durationUnit = robot.lookup("#simDurationUnit").queryAs(ComboBox.class);
+        TextField dt = robot.lookup("#simDt").queryAs(TextField.class);
 
         assertThat(timeStep.getValue()).isEqualTo("Day");
         assertThat(duration.getText()).isEqualTo("100");
         assertThat(durationUnit.getValue()).isEqualTo("Day");
+        assertThat(dt.getText()).isEqualTo("1");
     }
 
     @Test
@@ -65,10 +67,21 @@ class SimulationSettingsDialogFxTest {
         ComboBox<?> timeStep = robot.lookup("#simTimeStep").queryAs(ComboBox.class);
         TextField duration = robot.lookup("#simDuration").queryAs(TextField.class);
         ComboBox<?> durationUnit = robot.lookup("#simDurationUnit").queryAs(ComboBox.class);
+        TextField dt = robot.lookup("#simDt").queryAs(TextField.class);
 
         assertThat(timeStep.getValue()).isEqualTo("Week");
         assertThat(duration.getText()).isEqualTo("52");
         assertThat(durationUnit.getValue()).isEqualTo("Week");
+        assertThat(dt.getText()).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("Dialog populates fractional DT from existing settings")
+    void populatesFractionalDt(FxRobot robot) {
+        showDialog(new SimulationSettings("Day", 100, "Day", 0.25));
+
+        TextField dt = robot.lookup("#simDt").queryAs(TextField.class);
+        assertThat(dt.getText()).isEqualTo("0.25");
     }
 
     @Test
@@ -133,6 +146,38 @@ class SimulationSettingsDialogFxTest {
                         .filter(bt -> bt.getButtonData().isDefaultButton())
                         .findFirst().orElseThrow());
         assertThat(okButton.isDisabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("OK button is disabled when DT is empty")
+    void okDisabledWhenDtEmpty(FxRobot robot) {
+        showDialog(null);
+
+        TextField dt = robot.lookup("#simDt").queryAs(TextField.class);
+        robot.clickOn(dt).eraseText(dt.getText().length());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        Node okButton = dialogPane.lookupButton(
+                dialogPane.getButtonTypes().stream()
+                        .filter(bt -> bt.getButtonData().isDefaultButton())
+                        .findFirst().orElseThrow());
+        assertThat(okButton.isDisabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("OK button is disabled when DT is negative")
+    void okDisabledWhenDtNegative(FxRobot robot) {
+        showDialog(null);
+
+        TextField dt = robot.lookup("#simDt").queryAs(TextField.class);
+        robot.clickOn(dt).eraseText(dt.getText().length()).write("-0.5");
+        WaitForAsyncUtils.waitForFxEvents();
+
+        Node okButton = dialogPane.lookupButton(
+                dialogPane.getButtonTypes().stream()
+                        .filter(bt -> bt.getButtonData().isDefaultButton())
+                        .findFirst().orElseThrow());
+        assertThat(okButton.isDisabled()).isTrue();
     }
 
     @Test

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/model/compile/CompiledModel.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/model/compile/CompiledModel.java
@@ -131,6 +131,7 @@ public class CompiledModel {
         TimeUnit timeStep = unitRegistry.resolveTimeUnit(settings.timeStep());
         TimeUnit durationUnit = unitRegistry.resolveTimeUnit(settings.durationUnit());
         simTimeUnitHolder[0] = timeStep;
+        setDt(settings.dt());
         Simulation sim = new Simulation(model, timeStep, new Quantity(settings.duration(), durationUnit));
         installStepSync(sim);
         return sim;

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/model/compile/CompiledModelTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/model/compile/CompiledModelTest.java
@@ -201,6 +201,32 @@ class CompiledModelTest {
         }
 
         @Test
+        void shouldApplyDtFromDefaultSettings() {
+            ModelDefinition withDt = new ModelDefinition(
+                    "TestModel", null, null,
+                    List.of(new StockDef("Population", 100, "things")),
+                    List.of(new FlowDef("Growth", "Population * 0.1", "Minute", null, "Population")),
+                    List.of(), List.of(), List.of(), List.of(), List.of(), List.of(),
+                    List.of(),
+                    new SimulationSettings("Minute", 10.0, "Minute", 0.25),
+                    null);
+            CompiledModel compiledWithDt = new CompiledModel(
+                    model, List.of(), withDt, stepHolder, dtHolder,
+                    new systems.courant.shrewd.measure.TimeUnit[1], new UnitRegistry());
+
+            compiledWithDt.createSimulation();
+            assertThat(compiledWithDt.getDt()).isEqualTo(0.25);
+            assertThat(dtHolder[0]).isEqualTo(0.25);
+        }
+
+        @Test
+        void shouldDefaultDtToOneFromDefaultSettings() {
+            // The setUp() source uses the 3-arg SimulationSettings constructor (dt defaults to 1.0)
+            compiled.createSimulation();
+            assertThat(compiled.getDt()).isEqualTo(1.0);
+        }
+
+        @Test
         void shouldThrowIfNoDefaultSettings() {
             ModelDefinition noDefaults = new ModelDefinition(
                     "NoDefaults", null, null,


### PR DESCRIPTION
Fixes #133

## Summary
- Wire `settings.dt()` into `CompiledModel.createSimulation()` so fractional DT values from imported models are applied at runtime
- Add DT input field to SimulationSettingsDialog with validation
- Add engine and dialog tests