### PR TITLE
Fix lookup table parse failures and multi-word name corruption

### DIFF
--- a/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/MdlParser.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/MdlParser.java
@@ -81,9 +81,16 @@ public final class MdlParser {
         if (content.startsWith("\uFEFF")) {
             content = content.substring(1);
         }
-        // Strip {UTF-8} encoding header
-        if (content.startsWith("{UTF-8}")) {
-            content = content.substring(7);
+        // Strip {UTF-8} encoding headers — some Vensim files emit multiple
+        // (e.g., "{UTF-8}\n{UTF-8}\n"), so strip repeatedly
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            String trimmed = content.stripLeading();
+            if (trimmed.startsWith("{UTF-8}")) {
+                content = trimmed.substring(7);
+                changed = true;
+            }
         }
         return content;
     }

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimExprTranslator.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimExprTranslator.java
@@ -511,6 +511,7 @@ public final class VensimExprTranslator {
         // Lookup data format: [(xmin,ymin)-(xmax,ymax)],(x1,y1),(x2,y2),...
         // or ([(xmin,ymin)-(xmax,ymax)],(x1,y1),(x2,y2),...)  (WITH LOOKUP wrapping)
         // or just (x1,y1),(x2,y2),...
+        // or flat CSV: x1,x2,...,xN,y1,y2,...,yN (older Vensim format)
         String cleaned = data.strip();
 
         // Strip Vensim range annotation: [(xmin,ymin)-(xmax,ymax)]
@@ -532,6 +533,7 @@ public final class VensimExprTranslator {
             cleaned = cleaned.strip();
         }
 
+        // Try parenthesized pair format: (x1,y1),(x2,y2),...
         List<double[]> points = new ArrayList<>();
         Pattern pairPattern = Pattern.compile(
                 "\\(\\s*(-?[\\d.eE+\\-]+)\\s*,\\s*(-?[\\d.eE+\\-]+)\\s*\\)");
@@ -546,15 +548,44 @@ public final class VensimExprTranslator {
             }
         }
 
-        if (points.size() < 2) {
+        if (points.size() >= 2) {
+            double[] xValues = new double[points.size()];
+            double[] yValues = new double[points.size()];
+            for (int i = 0; i < points.size(); i++) {
+                xValues[i] = points.get(i)[0];
+                yValues[i] = points.get(i)[1];
+            }
+            return Optional.of(new double[][]{xValues, yValues});
+        }
+
+        // Fall back to flat CSV format: x1,x2,...,xN,y1,y2,...,yN
+        // Used by older Vensim versions (e.g., BURNOUT.MDL, WORLD.MDL)
+        return parseFlatCsvLookup(cleaned);
+    }
+
+    private static Optional<double[][]> parseFlatCsvLookup(String data) {
+        Pattern numberPattern = Pattern.compile("-?[\\d.eE+\\-]+");
+        Matcher m = numberPattern.matcher(data);
+        List<Double> values = new ArrayList<>();
+        while (m.find()) {
+            try {
+                values.add(Double.parseDouble(m.group()));
+            } catch (NumberFormatException ex) {
+                log.debug("Skip malformed flat lookup value: {}", m.group(), ex);
+            }
+        }
+
+        // Need an even number of values >= 4 (at least 2 x + 2 y)
+        if (values.size() < 4 || values.size() % 2 != 0) {
             return Optional.empty();
         }
 
-        double[] xValues = new double[points.size()];
-        double[] yValues = new double[points.size()];
-        for (int i = 0; i < points.size(); i++) {
-            xValues[i] = points.get(i)[0];
-            yValues[i] = points.get(i)[1];
+        int half = values.size() / 2;
+        double[] xValues = new double[half];
+        double[] yValues = new double[half];
+        for (int i = 0; i < half; i++) {
+            xValues[i] = values.get(i);
+            yValues[i] = values.get(half + i);
         }
         return Optional.of(new double[][]{xValues, yValues});
     }

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimExprTranslatorTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimExprTranslatorTest.java
@@ -458,6 +458,60 @@ class VensimExprTranslatorTest {
     }
 
     @Nested
+    @DisplayName("Flat CSV lookup parsing (#490)")
+    class FlatCsvLookup {
+
+        @Test
+        void shouldParseFlatCsvLookupData() {
+            // Format used by BURNOUT.MDL: x values then y values, no parentheses
+            var result = VensimExprTranslator.parseLookupPoints(
+                    "0,0.2,0.4,0.6,0.8,1,0,0.2,0.4,0.6,0.8,1");
+            assertThat(result).isPresent();
+            double[][] points = result.get();
+            assertThat(points[0]).containsExactly(0, 0.2, 0.4, 0.6, 0.8, 1);
+            assertThat(points[1]).containsExactly(0, 0.2, 0.4, 0.6, 0.8, 1);
+        }
+
+        @Test
+        void shouldParseFlatCsvWithNewlines() {
+            // As it appears in .mdl files: x values on one line, y on next
+            var result = VensimExprTranslator.parseLookupPoints(
+                    "0, 1, 2, 3, 4, 5,\n1.05, 1, 0.9, 0.7, 0.6, 0.55");
+            assertThat(result).isPresent();
+            double[][] points = result.get();
+            assertThat(points[0]).hasSize(6);
+            assertThat(points[1]).hasSize(6);
+            assertThat(points[0][0]).isEqualTo(0);
+            assertThat(points[0][5]).isEqualTo(5);
+            assertThat(points[1][0]).isEqualTo(1.05);
+            assertThat(points[1][5]).isEqualTo(0.55);
+        }
+
+        @Test
+        void shouldPreferPairFormatOverFlatCsv() {
+            // When (x,y) pairs are present, use that format
+            var result = VensimExprTranslator.parseLookupPoints(
+                    "(0,0),(1,1),(2,4)");
+            assertThat(result).isPresent();
+            double[][] points = result.get();
+            assertThat(points[0]).containsExactly(0, 1, 2);
+            assertThat(points[1]).containsExactly(0, 1, 4);
+        }
+
+        @Test
+        void shouldRejectOddNumberOfFlatCsvValues() {
+            var result = VensimExprTranslator.parseLookupPoints("0, 1, 2");
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldRejectTooFewFlatCsvValues() {
+            var result = VensimExprTranslator.parseLookupPoints("0, 1");
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
     @DisplayName("Edge cases")
     class EdgeCases {
 

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimImporterTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimImporterTest.java
@@ -1021,6 +1021,219 @@ class VensimImporterTest {
     }
 
     @Nested
+    @DisplayName("Double UTF-8 header handling (#491)")
+    class DoubleUtf8Header {
+
+        @Test
+        void shouldHandleDoubleUtf8Header() {
+            // Many Vensim files (e.g., RABFOX.MDL, DELIV.MDL) have two {UTF-8} headers.
+            // The second must be stripped or it corrupts the first variable name.
+            String mdl = """
+                    {UTF-8}
+                    {UTF-8}
+
+                    fox births = Fox Population * fox birth rate
+                    \t~\tFox/Year
+                    \t~\t
+                    \t|
+
+                    Fox Population = INTEG(fox births, 30)
+                    \t~\tFox
+                    \t~\t
+                    \t|
+
+                    fox birth rate = 0.25
+                    \t~\t1/Year
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tYear
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 50
+                    \t~\tYear
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tYear
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // The first variable should have a clean name, not "{UTF-8}..." prefix
+            AuxDef aux = def.auxiliaries().stream()
+                    .filter(a -> a.name().equals("fox births"))
+                    .findFirst().orElseThrow();
+            // Multi-word name replacement should work in the equation
+            assertThat(aux.equation()).isEqualTo("Fox_Population * fox_birth_rate");
+        }
+
+        @Test
+        void shouldCompileModelWithDoubleUtf8Header() {
+            // Verifies the full pipeline works with double headers
+            String mdl = """
+                    {UTF-8}
+                    {UTF-8}
+
+                    new customers = shipments / products per customer
+                    \t~\tPerson/Week
+                    \t~\t
+                    \t|
+
+                    Customers = INTEG(new customers, 100)
+                    \t~\tPerson
+                    \t~\t
+                    \t|
+
+                    products per customer = 1
+                    \t~\tMachine/Person
+                    \t~\t
+                    \t|
+
+                    shipments = 50
+                    \t~\tMachine/Week
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tWeek
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 100
+                    \t~\tWeek
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tWeek
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // Should compile without "Unexpected character" errors
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+
+            // Verify the flow equation uses normalized names
+            FlowDef flow = def.flows().stream()
+                    .filter(f -> f.name().contains("Customers"))
+                    .findFirst().orElseThrow();
+            assertThat(flow.equation()).isEqualTo("new_customers");
+        }
+    }
+
+    @Nested
+    @DisplayName("Flat CSV lookup tables (#490)")
+    class FlatCsvLookupImport {
+
+        @Test
+        void shouldImportFlatCsvLookupTable() {
+            // Format used by BURNOUT.MDL and WORLD.MDL
+            String mdl = """
+                    effect = effect lookup(input)
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    effect lookup(
+                    \t0,0.2,0.4,0.6,0.8,1,
+                    \t0,0.2,0.4,0.6,0.8,1)
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    input = 0.5
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // Lookup table should be parsed successfully
+            assertThat(def.lookupTables()).hasSize(1);
+            LookupTableDef lt = def.lookupTables().get(0);
+            assertThat(lt.name()).isEqualTo("effect lookup");
+            assertThat(lt.xValues()).hasSize(6);
+            assertThat(lt.yValues()).hasSize(6);
+
+            // No warnings about failing to parse lookup data
+            assertThat(result.warnings().stream()
+                    .filter(w -> w.contains("Could not parse lookup"))
+                    .toList()).isEmpty();
+        }
+
+        @Test
+        void shouldCompileModelWithFlatCsvLookup() {
+            String mdl = """
+                    effect = effect lookup(input)
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    effect lookup(
+                    \t0,0.5,1,
+                    \t0,0.5,1)
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    input = 0.5
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+
+            // Should compile without "references unknown element" errors
+            CompiledModel compiled = new ModelCompiler().compile(result.definition());
+            assertThat(compiled).isNotNull();
+        }
+    }
+
+    @Nested
     @DisplayName("Rate term decomposition")
     class RateTermDecomposition {
 


### PR DESCRIPTION
## Summary
- **#490**: `parseLookupPoints` now handles flat CSV lookup format (`x1,x2,...,y1,y2,...`) used by older Vensim models (BURNOUT, WORLD, etc.), in addition to `(x,y)` pair format
- **#491**: `MdlParser.stripHeader` strips all `{UTF-8}` encoding headers (40 of 59 test files have duplicates); the second header was corrupting the first variable name in `vensimNames`, breaking multi-word name replacement

## Test plan
- [x] New tests for flat CSV lookup parsing (5 tests in VensimExprTranslatorTest)
- [x] New tests for double UTF-8 header handling (2 tests in VensimImporterTest)
- [x] New tests for flat CSV lookup import and compile (2 tests in VensimImporterTest)
- [x] All existing tests pass
- [x] SpotBugs clean