### PR TITLE
Fix untranslated Vensim constructs and unresolved references (#492, #494)

### DIFF
--- a/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimExprTranslator.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimExprTranslator.java
@@ -57,6 +57,7 @@ public final class VensimExprTranslator {
             "(?i)RANDOM\\s+UNIFORM\\s*\\(");
     private static final Pattern PULSE_TRAIN_PATTERN = Pattern.compile(
             "(?i)PULSE\\s+TRAIN\\s*\\(");
+    private static final Pattern NOT_EQUAL_PATTERN = Pattern.compile("<>");
     private static final Pattern CARET_PATTERN = Pattern.compile("\\^");
     private static final Pattern TIME_VAR_PATTERN = Pattern.compile(
             "(?i)\\bTime\\b");
@@ -151,6 +152,9 @@ public final class VensimExprTranslator {
         // the next logical operator or closing paren. For simple cases, we insert not(
         // and find the end of the operand.
         expr = translateNot(expr);
+
+        // 4a. Not-equal operator: <> → !=
+        expr = NOT_EQUAL_PATTERN.matcher(expr).replaceAll("!=");
 
         // 5. XIDZ and ZIDZ
         expr = translateXidz(expr, warnings);

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimImporter.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimImporter.java
@@ -261,9 +261,11 @@ public class VensimImporter implements ModelImporter {
             return;
         }
 
-        // Data variable (operator ":=")
+        // Data variable (operator ":=") — create placeholder constant so references resolve
         if (operator.equals(":=")) {
-            warnings.add("Data variable '" + eq.name() + "' skipped (not supported)");
+            builder.aux(new AuxDef(displayName, comment, "0", unit));
+            warnings.add("Data variable '" + eq.name()
+                    + "' imported as constant 0 (external data source not supported)");
             return;
         }
 
@@ -288,6 +290,14 @@ public class VensimImporter implements ModelImporter {
                 builder.aux(new AuxDef(displayName, comment, tr.expression(), unit));
                 warnings.addAll(tr.warnings());
             }
+            return;
+        }
+
+        // Bare variable name with no equation — create placeholder constant
+        if (operator.isEmpty() && expression.isEmpty()) {
+            builder.aux(new AuxDef(displayName, comment, "0", unit));
+            warnings.add("Variable '" + eq.name()
+                    + "' has no equation; imported as constant 0");
             return;
         }
 

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/model/expr/ExprDependencies.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/model/expr/ExprDependencies.java
@@ -15,12 +15,17 @@ public final class ExprDependencies {
     /** Built-in function names (uppercase) that should not be treated as model element references. */
     private static final Set<String> BUILTIN_FUNCTIONS = Set.of(
             "ABS", "SQRT", "LN", "EXP", "LOG", "SIN", "COS", "TAN",
-            "INT", "ROUND", "MODULO", "POWER", "MIN", "MAX", "SUM", "MEAN",
-            "SMOOTH", "SMOOTHI", "SMOOTH3", "SMOOTH3I", "DELAY1", "DELAY3", "DELAY_FIXED",
+            "ARCSIN", "ARCCOS", "ARCTAN", "SIGN",
+            "INT", "ROUND", "MODULO", "QUANTUM", "POWER", "MIN", "MAX",
+            "SUM", "MEAN", "VMIN", "VMAX", "PROD",
+            "INITIAL",
+            "SMOOTH", "SMOOTHI", "SMOOTH3", "SMOOTH3I",
+            "DELAY1", "DELAY1I", "DELAY3", "DELAY3I", "DELAY_FIXED",
             "STEP", "RAMP", "PULSE", "PULSE_TRAIN",
             "TREND", "FORECAST", "NPV",
             "RANDOM_NORMAL", "RANDOM_UNIFORM",
-            "LOOKUP", "IF", "TIME", "DT"
+            "XIDZ", "ZIDZ",
+            "LOOKUP", "IF", "TIME", "DT", "PI"
     );
 
     private ExprDependencies() {

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimExprTranslatorTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimExprTranslatorTest.java
@@ -512,6 +512,38 @@ class VensimExprTranslatorTest {
     }
 
     @Nested
+    @DisplayName("Not-equal operator translation (#492)")
+    class NotEqualOperator {
+
+        @Test
+        void shouldTranslateNotEqualOperator() {
+            var result = VensimExprTranslator.translate("x <> 0", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("x != 0");
+        }
+
+        @Test
+        void shouldTranslateNotEqualInIfThenElse() {
+            var result = VensimExprTranslator.translate(
+                    "IF THEN ELSE(adjust <> 0, 1, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("IF(adjust != 0, 1, 0)");
+        }
+
+        @Test
+        void shouldTranslateMultipleNotEquals() {
+            var result = VensimExprTranslator.translate(
+                    "IF THEN ELSE(x <> 0 :AND: y <> 0, 1, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).contains("!=");
+            assertThat(result.expression()).doesNotContain("<>");
+        }
+
+        @Test
+        void shouldNotAffectLessThanOrGreaterThan() {
+            var result = VensimExprTranslator.translate("x < 0", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("x < 0");
+        }
+    }
+
+    @Nested
     @DisplayName("Edge cases")
     class EdgeCases {
 

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimImporterTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimImporterTest.java
@@ -210,8 +210,9 @@ class VensimImporterTest {
                     """;
 
             ImportResult result = importer.importModel(mdl, "Test");
-            assertThat(result.warnings()).anyMatch(w -> w.contains("Data variable"));
-            assertThat(result.definition().parameters()).hasSize(3); // only built-in constants
+            assertThat(result.warnings()).anyMatch(w -> w.contains("imported as constant 0"));
+            // Data variable creates a placeholder auxiliary (value 0) plus 3 built-in constants
+            assertThat(result.definition().auxiliaries()).hasSize(4);
             // All auxiliaries are literal (no formula auxes)
             assertThat(result.definition().auxiliaries().stream().filter(a -> !a.isLiteral()).toList())
                     .isEmpty();
@@ -1229,6 +1230,296 @@ class VensimImporterTest {
 
             // Should compile without "references unknown element" errors
             CompiledModel compiled = new ModelCompiler().compile(result.definition());
+            assertThat(compiled).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("INITIAL function reference resolution (#494)")
+    class InitialFunctionReference {
+
+        @Test
+        void shouldCompileModelWithInitialFunction() {
+            // INITIAL(expr) should be recognized as a built-in function,
+            // not flagged as "references unknown element: INITIAL"
+            String mdl = """
+                    target = 100
+                    \t~\tWidgets
+                    \t~\t
+                    \t|
+
+                    baseline = INITIAL(target)
+                    \t~\tWidgets
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // Should compile without "references unknown element: INITIAL"
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+        }
+
+        @Test
+        void shouldCompileModelWithInitialInStockInit() {
+            // Pattern from WFKAL.MDL: INITIAL used in stock initial value expression
+            String mdl = """
+                    desired = 50
+                    \t~\tPerson
+                    \t~\t
+                    \t|
+
+                    initial level = INITIAL(desired)
+                    \t~\tPerson
+                    \t~\t
+                    \t|
+
+                    Stock = INTEG(inflow, initial level)
+                    \t~\tPerson
+                    \t~\t
+                    \t|
+
+                    inflow = 10
+                    \t~\tPerson/Day
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Data variable placeholder import (#494)")
+    class DataVariablePlaceholder {
+
+        @Test
+        void shouldCreatePlaceholderForDataVariable() {
+            // Vensim := operator marks data variables (external data source).
+            // The importer should create a constant 0 placeholder so references resolve.
+            String mdl = """
+                    external input := 0
+                    \t~\tWidgets/Day
+                    \t~\t
+                    \t|
+
+                    output = external input * 2
+                    \t~\tWidgets/Day
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // Data variable should create a placeholder auxiliary
+            assertThat(def.auxiliaries().stream()
+                    .anyMatch(a -> a.name().equals("external input"))).isTrue();
+
+            // Should compile without "references unknown element"
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+        }
+
+        @Test
+        void shouldCreatePlaceholderForBareNameVariable() {
+            // Some Vensim variables have no equation at all (just a name, unit, comment).
+            // Pattern from WFKAL.MDL: "sales" with no equation.
+            String mdl = """
+                    sales
+                    \t~\tWidgets/Month
+                    \t~\t
+                    \t|
+
+                    revenue = sales * 10
+                    \t~\tDollars/Month
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tMonth
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tMonth
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tMonth
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // Bare variable should create a placeholder auxiliary
+            assertThat(def.auxiliaries().stream()
+                    .anyMatch(a -> a.name().equals("sales"))).isTrue();
+
+            // Should compile without "references unknown element: sales"
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+        }
+
+        @Test
+        void shouldWarnAboutDataVariableImport() {
+            String mdl = """
+                    data input := 0
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            assertThat(result.warnings()).anyMatch(w -> w.contains("imported as constant 0"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Not-equal operator in equations (#492)")
+    class NotEqualOperator {
+
+        @Test
+        void shouldCompileModelWithNotEqualOperator() {
+            // Vensim uses <> for not-equal; Shrewd uses !=
+            String mdl = """
+                    trigger = IF THEN ELSE(value <> 0, 1, 0)
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    value = 5
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // Should compile without parse errors
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+        }
+
+        @Test
+        void shouldCompileNotEqualInStockRate() {
+            // Pattern from change.mdl: <> used in INTEG rate expression
+            String mdl = """
+                    counter = INTEG(IF THEN ELSE(level <> 0, 1 / TIME STEP, 0), 0)
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    level = 5
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            CompiledModel compiled = new ModelCompiler().compile(def);
             assertThat(compiled).isNotNull();
         }
     }

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/model/expr/ExprDependenciesTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/model/expr/ExprDependenciesTest.java
@@ -95,6 +95,31 @@ class ExprDependenciesTest {
     }
 
     @Test
+    void shouldNotTreatInitialAsElementReference() {
+        // INITIAL(expr) is a built-in function — should not appear in deps (#494)
+        Expr expr = ExprParser.parse("INITIAL(target)");
+        Set<String> deps = ExprDependencies.extract(expr);
+        assertThat(deps).containsExactly("target");
+        assertThat(deps).doesNotContain("INITIAL");
+    }
+
+    @Test
+    void shouldNotTreatArcsinAsElementReference() {
+        Expr expr = ExprParser.parse("ARCSIN(x)");
+        Set<String> deps = ExprDependencies.extract(expr);
+        assertThat(deps).containsExactly("x");
+        assertThat(deps).doesNotContain("ARCSIN");
+    }
+
+    @Test
+    void shouldNotTreatQuantumAsElementReference() {
+        Expr expr = ExprParser.parse("QUANTUM(x, 5)");
+        Set<String> deps = ExprDependencies.extract(expr);
+        assertThat(deps).contains("x");
+        assertThat(deps).doesNotContain("QUANTUM");
+    }
+
+    @Test
     void shouldNotAddMultiArgFunctionNamesAsDeps() {
         // Multi-arg built-in functions should NOT have their name added
         Expr expr = ExprParser.parse("MIN(x, y)");


### PR DESCRIPTION
## Summary
- **#492**: Translate Vensim `<>` (not-equal) operator to `!=`. Most other #492 parse failures were caused by the double UTF-8 header bug already fixed in #491.
- **#494**: Add 14 missing built-in functions to `ExprDependencies.BUILTIN_FUNCTIONS` (INITIAL, ARCSIN, etc.) so the validator stops flagging them as unknown elements. Create placeholder constants for data variables (`:=`) and bare-name variables instead of skipping them.

## Test plan
- [x] 4 new VensimExprTranslator tests for `<>` → `!=` translation
- [x] 2 new VensimImporter tests for `<>` in compiled models
- [x] 2 new VensimImporter tests for INITIAL function compilation
- [x] 3 new VensimImporter tests for data variable placeholders
- [x] 3 new ExprDependencies tests for built-in function exclusion
- [x] Updated existing `shouldSkipDataVariableWithWarning` test
- [x] Full test suite: 1932 tests pass
- [x] SpotBugs clean