### PR TITLE
Add subscript expansion and MESSAGE/SIMULTANEOUS no-ops (#495, #498)

### DIFF
--- a/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimExprTranslator.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimExprTranslator.java
@@ -58,6 +58,10 @@ public final class VensimExprTranslator {
     private static final Pattern PULSE_TRAIN_PATTERN = Pattern.compile(
             "(?i)PULSE\\s+TRAIN\\s*\\(");
     private static final Pattern NOT_EQUAL_PATTERN = Pattern.compile("<>");
+    private static final Pattern MESSAGE_PATTERN = Pattern.compile(
+            "(?i)MESSAGE\\s*\\(");
+    private static final Pattern SIMULTANEOUS_PATTERN = Pattern.compile(
+            "(?i)SIMULTANEOUS\\s*\\(");
     private static final Pattern CARET_PATTERN = Pattern.compile("\\^");
     private static final Pattern TIME_VAR_PATTERN = Pattern.compile(
             "(?i)\\bTime\\b");
@@ -175,11 +179,17 @@ public final class VensimExprTranslator {
         // 8a. GAME(expr) → expr (pass-through; GAME is Vensim's interactive override)
         expr = translateGame(expr);
 
-        // 8b. RANDOM UNIFORM → RANDOM_UNIFORM, RANDOM NORMAL → RANDOM_NORMAL
+        // 8b. MESSAGE(args) → 0 (Vensim interactive messaging, no-op in Shrewd)
+        expr = translateMessage(expr);
+
+        // 8c. SIMULTANEOUS(args) → 0 (solver hint, no-op for Euler integration)
+        expr = translateSimultaneous(expr);
+
+        // 8d. RANDOM UNIFORM → RANDOM_UNIFORM, RANDOM NORMAL → RANDOM_NORMAL
         expr = RANDOM_UNIFORM_PATTERN.matcher(expr).replaceAll("RANDOM_UNIFORM(");
         expr = RANDOM_NORMAL_PATTERN.matcher(expr).replaceAll("RANDOM_NORMAL(");
 
-        // 8c. PULSE TRAIN → PULSE_TRAIN
+        // 8e. PULSE TRAIN → PULSE_TRAIN
         expr = PULSE_TRAIN_PATTERN.matcher(expr).replaceAll("PULSE_TRAIN(");
 
         // 9. ^ → ** (Vensim uses ^ for power, Shrewd uses **)
@@ -190,10 +200,13 @@ public final class VensimExprTranslator {
             expr = TIME_VAR_PATTERN.matcher(expr).replaceAll("TIME");
         }
 
-        // 11. Rewrite lookupName(arg) → LOOKUP(lookupName, arg)
+        // 11. Translate subscript bracket notation: name[label] → name_label
+        expr = translateSubscriptBrackets(expr);
+
+        // 12. Rewrite lookupName(arg) → LOOKUP(lookupName, arg)
         expr = rewriteLookupCalls(expr, lookupNames);
 
-        // 12. Check for unsupported functions
+        // 13. Check for unsupported functions
         checkUnsupportedFunctions(expr, warnings);
 
         return new TranslationResult(expr, lookups, warnings);
@@ -594,6 +607,26 @@ public final class VensimExprTranslator {
         return Optional.of(new double[][]{xValues, yValues});
     }
 
+    private static final Pattern SUBSCRIPT_BRACKET_PATTERN = Pattern.compile(
+            "([a-zA-Z_][a-zA-Z0-9_]*)\\[([^\\]]+)\\]");
+
+    /**
+     * Translates subscript bracket notation to flattened names.
+     * Converts {@code name[label]} to {@code name_label} where the label
+     * is normalized (spaces → underscores, special chars removed).
+     */
+    private static String translateSubscriptBrackets(String expr) {
+        Matcher m = SUBSCRIPT_BRACKET_PATTERN.matcher(expr);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            String varName = m.group(1);
+            String subscript = normalizeName(m.group(2));
+            m.appendReplacement(sb, Matcher.quoteReplacement(varName + "_" + subscript));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
     /**
      * Strips GAME(expr) wrappers, replacing with just the inner expression.
      * In Vensim, GAME() allows interactive override during game mode;
@@ -608,6 +641,46 @@ public final class VensimExprTranslator {
                 String inner = expr.substring(openParen + 1, closeParen).strip();
                 expr = expr.substring(0, m.start()) + inner + expr.substring(closeParen + 1);
                 m = GAME_PATTERN.matcher(expr);
+            } else {
+                break;
+            }
+        }
+        return expr;
+    }
+
+    /**
+     * Strips MESSAGE(args) wrappers, replacing with 0.
+     * In Vensim, MESSAGE() displays an interactive message during simulation;
+     * it has no effect outside the Vensim UI.
+     */
+    private static String translateMessage(String expr) {
+        Matcher m = MESSAGE_PATTERN.matcher(expr);
+        while (m.find()) {
+            int openParen = m.end() - 1;
+            int closeParen = findMatchingParen(expr, openParen);
+            if (closeParen > 0) {
+                expr = expr.substring(0, m.start()) + "0" + expr.substring(closeParen + 1);
+                m = MESSAGE_PATTERN.matcher(expr);
+            } else {
+                break;
+            }
+        }
+        return expr;
+    }
+
+    /**
+     * Strips SIMULTANEOUS(args) wrappers, replacing with 0.
+     * In Vensim, SIMULTANEOUS() is a solver hint for simultaneous equation solving;
+     * Shrewd uses Euler integration which doesn't need this hint.
+     */
+    private static String translateSimultaneous(String expr) {
+        Matcher m = SIMULTANEOUS_PATTERN.matcher(expr);
+        while (m.find()) {
+            int openParen = m.end() - 1;
+            int closeParen = findMatchingParen(expr, openParen);
+            if (closeParen > 0) {
+                expr = expr.substring(0, m.start()) + "0" + expr.substring(closeParen + 1);
+                m = SIMULTANEOUS_PATTERN.matcher(expr);
             } else {
                 break;
             }

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimImporter.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimImporter.java
@@ -53,6 +53,8 @@ public class VensimImporter implements ModelImporter {
             "^[+-]?(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?$");
     private static final Set<String> SYSTEM_VAR_KEYS = Set.of(
             "INITIAL TIME", "FINAL TIME", "TIME STEP", "SAVEPER");
+    private static final Pattern SUBSCRIPT_NAME_PATTERN = Pattern.compile(
+            "^(.+?)\\[(.+?)\\]$");
     private static final Set<String> CONTROL_GROUPS = Set.of(".Control");
     private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
@@ -78,9 +80,13 @@ public class VensimImporter implements ModelImporter {
         List<String> warnings = new ArrayList<>();
         MdlParser.ParsedMdl parsed = MdlParser.parse(content);
 
-        // Pass 1: Collect all variable names
+        // Pass 1: Collect all variable names and subscript dimensions
         Set<String> vensimNames = new HashSet<>();
         Map<String, MdlEquation> controlVars = new LinkedHashMap<>();
+        // Map from normalized dimension name → list of normalized labels
+        Map<String, List<String>> subscriptDimensions = new LinkedHashMap<>();
+        // Map from normalized dimension name → list of original (display) labels
+        Map<String, List<String>> subscriptDisplayLabels = new LinkedHashMap<>();
 
         for (MdlEquation eq : parsed.equations()) {
             String name = eq.name().strip();
@@ -88,9 +94,35 @@ public class VensimImporter implements ModelImporter {
                 continue;
             }
             vensimNames.add(name);
+            // For subscripted names like "growth rate[Region]", also register
+            // the base name "growth rate" so multi-word replacement works
+            // after dimension substitution (e.g., "growth rate[North]")
+            Matcher baseMatcher = SUBSCRIPT_NAME_PATTERN.matcher(name);
+            if (baseMatcher.matches()) {
+                vensimNames.add(baseMatcher.group(1).strip());
+            }
 
             if (isSystemVar(name) || CONTROL_GROUPS.contains(eq.group())) {
                 controlVars.put(normalizeSystemVarKey(name), eq);
+            }
+
+            // Collect subscript dimension definitions
+            if (eq.operator().equals(":")) {
+                String dimName = VensimExprTranslator.normalizeName(name);
+                List<String> normalizedLabels = Arrays.stream(eq.expression().split(","))
+                        .map(String::strip)
+                        .filter(s -> !s.isEmpty())
+                        .map(VensimExprTranslator::normalizeName)
+                        .toList();
+                List<String> displayLabels = Arrays.stream(eq.expression().split(","))
+                        .map(String::strip)
+                        .filter(s -> !s.isEmpty())
+                        .map(VensimExprTranslator::normalizeDisplayName)
+                        .toList();
+                if (!normalizedLabels.isEmpty()) {
+                    subscriptDimensions.put(dimName, normalizedLabels);
+                    subscriptDisplayLabels.put(dimName, displayLabels);
+                }
             }
         }
 
@@ -139,6 +171,45 @@ public class VensimImporter implements ModelImporter {
             if (name.isEmpty() || isSystemVar(name)) {
                 continue;
             }
+
+            // Check for subscripted variable names and register expanded names
+            Matcher subMatcher = SUBSCRIPT_NAME_PATTERN.matcher(name);
+            if (subMatcher.matches()) {
+                String baseName = subMatcher.group(1).strip();
+                String dimNameRaw = subMatcher.group(2).strip();
+                String dimKey = VensimExprTranslator.normalizeName(dimNameRaw);
+                List<String> labels = subscriptDimensions.get(dimKey);
+                if (labels != null) {
+                    String normalizedBase = VensimExprTranslator.normalizeName(baseName);
+                    boolean isInteg = INTEG_PATTERN.matcher(eq.expression()).find();
+                    // Try splitting comma-separated constant values for expanded names
+                    List<String> perLabelValues = splitSubscriptValues(
+                            eq.expression(), labels.size());
+                    for (int li = 0; li < labels.size(); li++) {
+                        String expandedName = normalizedBase + "_" + labels.get(li);
+                        if (isInteg) {
+                            stockNames.add(expandedName);
+                        }
+                        // Register per-label numeric constants under both key forms:
+                        // base_label (expanded name) and normalizeName(base[label]) (what
+                        // parseInitialValue will look up)
+                        if (perLabelValues != null) {
+                            String val = perLabelValues.get(li).strip();
+                            if (isNumericLiteral(val)) {
+                                double numVal = Double.parseDouble(val);
+                                constantValues.put(expandedName, numVal);
+                                // Also register under the key normalizeName produces
+                                // from "base[label]" (strips brackets without separator)
+                                String altKey = VensimExprTranslator.normalizeName(
+                                        baseName + "[" + labels.get(li) + "]");
+                                constantValues.put(altKey, numVal);
+                            }
+                        }
+                    }
+                    continue;
+                }
+            }
+
             String eqName = VensimExprTranslator.normalizeName(name);
 
             if (eq.operator().equals(":")) {
@@ -202,7 +273,8 @@ public class VensimImporter implements ModelImporter {
                 try {
                     classifyAndBuild(eq, displayName, eqName, unit, comment, builder,
                             vensimNames, stockNames, flowNames, lookupNames,
-                            sketchFlowNames, constantValues, timeUnit, warnings);
+                            sketchFlowNames, constantValues, timeUnit,
+                            subscriptDimensions, subscriptDisplayLabels, warnings);
                 } catch (IllegalArgumentException e) {
                     warnings.add("Error processing '" + name + "': " + e.getMessage());
                 }
@@ -237,9 +309,30 @@ public class VensimImporter implements ModelImporter {
                                    Set<String> flowNames, Set<String> lookupNames,
                                    Set<String> sketchFlowNames,
                                    Map<String, Double> constantValues,
-                                   String timeUnit, List<String> warnings) {
+                                   String timeUnit,
+                                   Map<String, List<String>> subscriptDimensions,
+                                   Map<String, List<String>> subscriptDisplayLabels,
+                                   List<String> warnings) {
         String operator = eq.operator();
         String expression = eq.expression();
+
+        // Check if variable name contains subscript notation: name[Dimension]
+        Matcher subscriptMatcher = SUBSCRIPT_NAME_PATTERN.matcher(eq.name().strip());
+        if (subscriptMatcher.matches()) {
+            String baseName = subscriptMatcher.group(1).strip();
+            String dimNameRaw = subscriptMatcher.group(2).strip();
+            String dimName = VensimExprTranslator.normalizeName(dimNameRaw);
+            List<String> normalizedLabels = subscriptDimensions.get(dimName);
+            List<String> displayLabels = subscriptDisplayLabels.get(dimName);
+            if (normalizedLabels != null) {
+                expandSubscriptedVariable(eq, baseName, dimName, dimNameRaw,
+                        normalizedLabels, displayLabels, unit, builder,
+                        vensimNames, stockNames, flowNames, lookupNames,
+                        sketchFlowNames, constantValues, timeUnit, warnings);
+                return;
+            }
+            // If dimension not found, fall through — the brackets will be normalized away
+        }
 
         // Subscript definition (operator ":")
         if (operator.equals(":")) {
@@ -348,6 +441,93 @@ public class VensimImporter implements ModelImporter {
 
         builder.cldVariable(new CldVariableDef(displayName, comment));
         cldVariableNames.add(eqName);
+    }
+
+    /**
+     * Expands a subscripted variable into per-label scalar variables.
+     * For comma-separated values, assigns each value to the corresponding label.
+     * For formulas, creates copies with the dimension reference replaced by each label.
+     */
+    private void expandSubscriptedVariable(MdlEquation eq, String baseName,
+                                            String dimName, String dimNameRaw,
+                                            List<String> normalizedLabels,
+                                            List<String> displayLabels,
+                                            String unit, ModelDefinitionBuilder builder,
+                                            Set<String> vensimNames, Set<String> stockNames,
+                                            Set<String> flowNames, Set<String> lookupNames,
+                                            Set<String> sketchFlowNames,
+                                            Map<String, Double> constantValues,
+                                            String timeUnit, List<String> warnings) {
+        String operator = eq.operator();
+        String expression = eq.expression();
+        String normalizedBase = VensimExprTranslator.normalizeName(baseName);
+        String displayBase = VensimExprTranslator.normalizeDisplayName(baseName);
+
+        // Try to split expression into comma-separated per-label values
+        List<String> perLabelValues = splitSubscriptValues(expression, normalizedLabels.size());
+
+        for (int i = 0; i < normalizedLabels.size(); i++) {
+            String label = normalizedLabels.get(i);
+            String displayLabel = displayLabels.get(i);
+            String expandedEqName = normalizedBase + "_" + label;
+            String expandedDisplayName = displayBase + " " + displayLabel;
+            String comment = eq.comment().isBlank() ? eq.name().strip() : eq.comment();
+
+            String labelExpression;
+            if (perLabelValues != null) {
+                // Comma-separated values: assign per-label
+                labelExpression = perLabelValues.get(i).strip();
+            } else {
+                // Formula: replace [DimensionName] with [specific label] throughout
+                labelExpression = expression.replace("[" + dimNameRaw + "]", "[" + label + "]");
+            }
+
+            // Create a synthetic equation for this label and classify normally
+            MdlEquation labelEq = new MdlEquation(
+                    expandedDisplayName, operator, labelExpression,
+                    eq.units(), comment, eq.group());
+            classifyAndBuild(labelEq, expandedDisplayName, expandedEqName, unit, comment,
+                    builder, vensimNames, stockNames, flowNames, lookupNames,
+                    sketchFlowNames, constantValues, timeUnit,
+                    Map.of(), Map.of(), warnings);
+        }
+    }
+
+    /**
+     * Splits a subscript expression into per-label values if it's comma-separated.
+     * Returns null if the expression is a formula (not comma-separated values).
+     */
+    private static List<String> splitSubscriptValues(String expression, int expectedCount) {
+        if (expression == null || expression.isBlank()) {
+            return null;
+        }
+        // Split on top-level commas only (respect parentheses)
+        List<String> parts = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < expression.length(); i++) {
+            char c = expression.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+            } else if (c == ',' && depth == 0) {
+                parts.add(expression.substring(start, i));
+                start = i + 1;
+            }
+        }
+        parts.add(expression.substring(start));
+
+        // Only treat as per-label values if count matches exactly
+        if (parts.size() == expectedCount) {
+            // Verify all parts are numeric literals (constants)
+            boolean allNumeric = parts.stream()
+                    .allMatch(p -> NUMERIC_PATTERN.matcher(p.strip()).matches());
+            if (allNumeric) {
+                return parts;
+            }
+        }
+        return null;
     }
 
     private void buildStock(MdlEquation eq, String displayName, String eqName,

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimExprTranslatorTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimExprTranslatorTest.java
@@ -544,6 +544,92 @@ class VensimExprTranslatorTest {
     }
 
     @Nested
+    @DisplayName("Subscript bracket translation (#495)")
+    class SubscriptBrackets {
+
+        @Test
+        void shouldTranslateSimpleSubscriptBracket() {
+            var result = VensimExprTranslator.translate(
+                    "Population[North]", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("Population_North");
+        }
+
+        @Test
+        void shouldTranslateMultipleSubscriptBrackets() {
+            var result = VensimExprTranslator.translate(
+                    "inflow[tub] + outflow[tub]", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("inflow_tub + outflow_tub");
+        }
+
+        @Test
+        void shouldTranslateSubscriptWithSpaces() {
+            var result = VensimExprTranslator.translate(
+                    "x[low tub]", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("x_low_tub");
+        }
+
+        @Test
+        void shouldTranslateSubscriptInComplexExpression() {
+            var result = VensimExprTranslator.translate(
+                    "rate[Region] * Population[Region] / total", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo(
+                    "rate_Region * Population_Region / total");
+        }
+
+        @Test
+        void shouldNotAffectArrayIndexInFunctions() {
+            // Built-in functions should pass through; brackets only affect identifiers
+            var result = VensimExprTranslator.translate(
+                    "MAX(x[a], y[b])", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("MAX(x_a, y_b)");
+        }
+    }
+
+    @Nested
+    @DisplayName("MESSAGE and SIMULTANEOUS no-ops (#498)")
+    class MessageAndSimultaneous {
+
+        @Test
+        void shouldStripMessageToZero() {
+            var result = VensimExprTranslator.translate("MESSAGE(text, 1)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("0");
+        }
+
+        @Test
+        void shouldStripMessageInsideExpression() {
+            var result = VensimExprTranslator.translate(
+                    "x + MESSAGE(alert, y)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("x + 0");
+        }
+
+        @Test
+        void shouldStripSimultaneousToZero() {
+            var result = VensimExprTranslator.translate(
+                    "SIMULTANEOUS(0, 2)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("0");
+        }
+
+        @Test
+        void shouldStripSimultaneousInsideExpression() {
+            var result = VensimExprTranslator.translate(
+                    "IF THEN ELSE(SIMULTANEOUS(0, 1) > 0, 1, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).contains("IF(0 > 0, 1, 0)");
+        }
+
+        @Test
+        void shouldBeCaseInsensitiveForMessage() {
+            var result = VensimExprTranslator.translate("message(x, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("0");
+        }
+
+        @Test
+        void shouldBeCaseInsensitiveForSimultaneous() {
+            var result = VensimExprTranslator.translate("simultaneous(1, 3)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("0");
+        }
+    }
+
+    @Nested
     @DisplayName("Edge cases")
     class EdgeCases {
 

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimImporterTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimImporterTest.java
@@ -1525,6 +1525,291 @@ class VensimImporterTest {
     }
 
     @Nested
+    @DisplayName("MESSAGE and SIMULTANEOUS no-op handling (#498)")
+    class MessageAndSimultaneousImport {
+
+        @Test
+        void shouldCompileModelWithMessageFunction() {
+            String mdl = """
+                    msg = IF THEN ELSE(x > 5, MESSAGE(alert, x), 0)
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    x = 10
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // MESSAGE should be stripped, allowing compilation
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+        }
+
+        @Test
+        void shouldCompileModelWithSimultaneousFunction() {
+            String mdl = """
+                    solver_hint = SIMULTANEOUS(0, 2)
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    x = 5
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Subscript expansion (#495)")
+    class SubscriptExpansion {
+
+        @Test
+        void shouldExpandSubscriptedConstant() {
+            // Subscripted variable with comma-separated constant values
+            String mdl = """
+                    Region : North, South
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    Population[Region] = 100, 200
+                    \t~\tPeople
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // Should expand into Population_North = 100 and Population_South = 200
+            assertThat(def.auxiliaries().stream()
+                    .filter(a -> a.name().equals("Population North"))
+                    .findFirst()).isPresent();
+            assertThat(def.auxiliaries().stream()
+                    .filter(a -> a.name().equals("Population South"))
+                    .findFirst()).isPresent();
+        }
+
+        @Test
+        void shouldExpandSubscriptedFormula() {
+            // Subscripted auxiliary with formula referencing the dimension
+            String mdl = """
+                    tub : low tub, high tub
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    capacity[tub] = 100
+                    \t~\tLiters
+                    \t~\t
+                    \t|
+
+                    fill rate[tub] = capacity[tub] * 0.1
+                    \t~\tLiters/Day
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // fill rate[tub] should be expanded into fill_rate_low_tub and fill_rate_high_tub
+            // with capacity[tub] → capacity_low_tub / capacity_high_tub
+            AuxDef lowFill = def.auxiliaries().stream()
+                    .filter(a -> a.name().equals("fill rate low tub"))
+                    .findFirst().orElseThrow();
+            assertThat(lowFill.equation()).isEqualTo("capacity_low_tub * 0.1");
+
+            AuxDef highFill = def.auxiliaries().stream()
+                    .filter(a -> a.name().equals("fill rate high tub"))
+                    .findFirst().orElseThrow();
+            assertThat(highFill.equation()).isEqualTo("capacity_high_tub * 0.1");
+        }
+
+        @Test
+        void shouldCompileExpandedSubscriptModel() {
+            // End-to-end: subscripted model should compile and simulate
+            String mdl = """
+                    Region : North, South
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    initial pop[Region] = 100, 200
+                    \t~\tPeople
+                    \t~\t
+                    \t|
+
+                    growth rate[Region] = 0.05, 0.03
+                    \t~\t1/Year
+                    \t~\t
+                    \t|
+
+                    Population[Region] = INTEG(births[Region], initial pop[Region])
+                    \t~\tPeople
+                    \t~\t
+                    \t|
+
+                    births[Region] = Population[Region] * growth rate[Region]
+                    \t~\tPeople/Year
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tYear
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 50
+                    \t~\tYear
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tYear
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            // Should have 2 stocks (Population_North, Population_South)
+            assertThat(def.stocks()).hasSize(2);
+
+            // Should compile and simulate
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+
+            Simulation sim = compiled.createSimulation();
+            sim.execute();
+
+            // Both populations should have grown
+            for (Stock stock : compiled.getModel().getStocks()) {
+                assertThat(stock.getValue()).isGreaterThan(100.0);
+            }
+        }
+
+        @Test
+        void shouldExpandSubscriptedStockWithPerLabelInit() {
+            String mdl = """
+                    Color : red, blue
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    Level[Color] = INTEG(rate[Color], 10)
+                    \t~\tUnits
+                    \t~\t
+                    \t|
+
+                    rate[Color] = 1
+                    \t~\tUnits/Day
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            assertThat(def.stocks()).hasSize(2);
+            assertThat(def.stocks().stream().map(StockDef::name))
+                    .containsExactlyInAnyOrder("Level red", "Level blue");
+
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+        }
+    }
+
+    @Nested
     @DisplayName("Rate term decomposition")
     class RateTermDecomposition {
 


### PR DESCRIPTION
## Summary
- Expand Vensim subscripted variables into per-label scalar variables during import (e.g., `Population[Region]` → `Population_North`, `Population_South`)
- Translate `name[label]` bracket notation to `name_label` in expressions
- Strip MESSAGE() and SIMULTANEOUS() as no-ops in VensimExprTranslator

## Test plan
- [x] Unit tests for subscript bracket translation in VensimExprTranslatorTest
- [x] Unit tests for MESSAGE/SIMULTANEOUS stripping in VensimExprTranslatorTest
- [x] Integration tests: subscript expansion with constants, formulas, stocks in VensimImporterTest
- [x] Integration tests: MESSAGE/SIMULTANEOUS compile through full pipeline
- [x] Full test suite passes (1766 tests)
- [x] SpotBugs clean