### PR TITLE
Sort non-monotonic lookups, implement SAMPLE IF TRUE/FIND ZERO, handle ACTIVE INITIAL

### DIFF
--- a/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimExprTranslator.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimExprTranslator.java
@@ -62,15 +62,21 @@ public final class VensimExprTranslator {
             "(?i)MESSAGE\\s*\\(");
     private static final Pattern SIMULTANEOUS_PATTERN = Pattern.compile(
             "(?i)SIMULTANEOUS\\s*\\(");
+    private static final Pattern ACTIVE_INITIAL_PATTERN = Pattern.compile(
+            "(?i)ACTIVE\\s+INITIAL\\s*\\(");
+    private static final Pattern SAMPLE_IF_TRUE_PATTERN = Pattern.compile(
+            "(?i)SAMPLE\\s+IF\\s+TRUE\\s*\\(");
+    private static final Pattern FIND_ZERO_PATTERN = Pattern.compile(
+            "(?i)FIND\\s+ZERO\\s*\\(");
     private static final Pattern CARET_PATTERN = Pattern.compile("\\^");
     private static final Pattern TIME_VAR_PATTERN = Pattern.compile(
             "(?i)\\bTime\\b");
     private static final Set<String> UNSUPPORTED_FUNCTIONS = Set.of(
             "DELAY N",
             "GET XLS DATA", "GET DIRECT DATA",
-            "GET DIRECT CONSTANTS", "TABBED ARRAY", "SAMPLE IF TRUE",
+            "GET DIRECT CONSTANTS", "TABBED ARRAY",
             "VECTOR SELECT", "VECTOR ELM MAP", "VECTOR SORT ORDER",
-            "ALLOCATE AVAILABLE", "FIND ZERO");
+            "ALLOCATE AVAILABLE");
 
     /**
      * Result of translating a Vensim expression.
@@ -185,11 +191,20 @@ public final class VensimExprTranslator {
         // 8c. SIMULTANEOUS(args) → 0 (solver hint, no-op for Euler integration)
         expr = translateSimultaneous(expr);
 
-        // 8d. RANDOM UNIFORM → RANDOM_UNIFORM, RANDOM NORMAL → RANDOM_NORMAL
+        // 8d. ACTIVE INITIAL(expr, initial) → expr (pass-through first arg)
+        expr = translateActiveInitial(expr);
+
+        // 8e. RANDOM UNIFORM → RANDOM_UNIFORM, RANDOM NORMAL → RANDOM_NORMAL
         expr = RANDOM_UNIFORM_PATTERN.matcher(expr).replaceAll("RANDOM_UNIFORM(");
         expr = RANDOM_NORMAL_PATTERN.matcher(expr).replaceAll("RANDOM_NORMAL(");
 
-        // 8e. PULSE TRAIN → PULSE_TRAIN
+        // 8f. SAMPLE IF TRUE → SAMPLE_IF_TRUE
+        expr = SAMPLE_IF_TRUE_PATTERN.matcher(expr).replaceAll("SAMPLE_IF_TRUE(");
+
+        // 8g. FIND ZERO → FIND_ZERO
+        expr = FIND_ZERO_PATTERN.matcher(expr).replaceAll("FIND_ZERO(");
+
+        // 8h. PULSE TRAIN → PULSE_TRAIN
         expr = PULSE_TRAIN_PATTERN.matcher(expr).replaceAll("PULSE_TRAIN(");
 
         // 9. ^ → ** (Vensim uses ^ for power, Shrewd uses **)
@@ -641,6 +656,31 @@ public final class VensimExprTranslator {
                 String inner = expr.substring(openParen + 1, closeParen).strip();
                 expr = expr.substring(0, m.start()) + inner + expr.substring(closeParen + 1);
                 m = GAME_PATTERN.matcher(expr);
+            } else {
+                break;
+            }
+        }
+        return expr;
+    }
+
+    /**
+     * Strips ACTIVE INITIAL(expr, initial) wrappers, returning the first argument.
+     * In Vensim, ACTIVE INITIAL returns the first argument during normal simulation
+     * and uses the second argument only during game-mode initialization.
+     * Since Shrewd doesn't support game mode, we pass through the first argument.
+     */
+    private static String translateActiveInitial(String expr) {
+        Matcher m = ACTIVE_INITIAL_PATTERN.matcher(expr);
+        while (m.find()) {
+            int openParen = m.end() - 1;
+            int closeParen = findMatchingParen(expr, openParen);
+            if (closeParen > 0) {
+                String argsContent = expr.substring(openParen + 1, closeParen);
+                List<String> args = splitTopLevelArgs(argsContent);
+                // First argument is the active expression
+                String firstArg = args.get(0).strip();
+                expr = expr.substring(0, m.start()) + firstArg + expr.substring(closeParen + 1);
+                m = ACTIVE_INITIAL_PATTERN.matcher(expr);
             } else {
                 break;
             }

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimImporter.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimImporter.java
@@ -638,38 +638,75 @@ public class VensimImporter implements ModelImporter {
     }
 
     /**
-     * Removes consecutive duplicate x-values from lookup table data,
-     * keeping the last y-value for each x.
+     * Sorts and deduplicates lookup table x-values so they are strictly increasing.
+     * Non-monotonic x-values are sorted; duplicate x-values keep the last y-value.
      */
     private static double[][] deduplicateLookupPoints(double[][] points,
                                                        String name,
                                                        List<String> warnings) {
         double[] xs = points[0];
         double[] ys = points[1];
-        List<Double> newXs = new ArrayList<>();
-        List<Double> newYs = new ArrayList<>();
-        newXs.add(xs[0]);
-        newYs.add(ys[0]);
-        int dupes = 0;
+
+        // Check if x-values are already strictly increasing
+        boolean sorted = true;
         for (int i = 1; i < xs.length; i++) {
-            if (xs[i] == xs[i - 1]) {
-                // Replace last y with this one (keep last value for duplicate x)
-                newYs.set(newYs.size() - 1, ys[i]);
-                dupes++;
-            } else {
-                newXs.add(xs[i]);
-                newYs.add(ys[i]);
+            if (xs[i] <= xs[i - 1]) {
+                sorted = false;
+                break;
             }
         }
-        if (dupes > 0) {
+        if (sorted) {
+            return points;
+        }
+
+        // Build index array and sort by x-value (stable sort preserves original order for ties)
+        Integer[] indices = new Integer[xs.length];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = i;
+        }
+        Arrays.sort(indices, (a, b) -> {
+            int cmp = Double.compare(xs[a], xs[b]);
+            return cmp != 0 ? cmp : Integer.compare(a, b);
+        });
+
+        double[] sortedXs = new double[xs.length];
+        double[] sortedYs = new double[ys.length];
+        for (int i = 0; i < indices.length; i++) {
+            sortedXs[i] = xs[indices[i]];
+            sortedYs[i] = ys[indices[i]];
+        }
+
+        boolean wasUnsorted = !sorted;
+
+        // Deduplicate consecutive x-values (keep last y-value)
+        List<Double> newXs = new ArrayList<>();
+        List<Double> newYs = new ArrayList<>();
+        newXs.add(sortedXs[0]);
+        newYs.add(sortedYs[0]);
+        int dupes = 0;
+        for (int i = 1; i < sortedXs.length; i++) {
+            if (sortedXs[i] == sortedXs[i - 1]) {
+                newYs.set(newYs.size() - 1, sortedYs[i]);
+                dupes++;
+            } else {
+                newXs.add(sortedXs[i]);
+                newYs.add(sortedYs[i]);
+            }
+        }
+
+        if (wasUnsorted && dupes > 0) {
+            warnings.add("Lookup '" + name + "': sorted non-monotonic x-values and removed "
+                    + dupes + " duplicate(s)");
+        } else if (wasUnsorted) {
+            warnings.add("Lookup '" + name + "': sorted non-monotonic x-values");
+        } else {
             warnings.add("Lookup '" + name + "': removed " + dupes
                     + " duplicate x-value(s)");
-            return new double[][]{
-                    newXs.stream().mapToDouble(Double::doubleValue).toArray(),
-                    newYs.stream().mapToDouble(Double::doubleValue).toArray()
-            };
         }
-        return points;
+        return new double[][]{
+                newXs.stream().mapToDouble(Double::doubleValue).toArray(),
+                newYs.stream().mapToDouble(Double::doubleValue).toArray()
+        };
     }
 
     private void addExtractedLookups(VensimExprTranslator.TranslationResult tr,

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/model/FindZero.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/model/FindZero.java
@@ -1,0 +1,103 @@
+package systems.courant.shrewd.model;
+
+import com.google.common.base.Preconditions;
+
+import systems.courant.shrewd.model.compile.CompilationContext;
+
+import java.util.function.DoubleSupplier;
+
+/**
+ * Implements the Vensim FIND ZERO function using bisection.
+ *
+ * <p>{@code FIND ZERO(expression, variable, lo, hi)} finds the value of {@code variable}
+ * in the range {@code [lo, hi]} that makes {@code expression} evaluate to zero.
+ *
+ * <p>At runtime, temporarily overrides the loop variable in the compilation context
+ * and uses the bisection method to converge on the root.
+ */
+public class FindZero implements Formula {
+
+    private static final int MAX_ITERATIONS = 50;
+    private static final double TOLERANCE = 1e-10;
+
+    private final DoubleSupplier expression;
+    private final String variableName;
+    private final DoubleSupplier loBound;
+    private final DoubleSupplier hiBound;
+    private final CompilationContext context;
+
+    private FindZero(DoubleSupplier expression, String variableName,
+                     DoubleSupplier loBound, DoubleSupplier hiBound,
+                     CompilationContext context) {
+        Preconditions.checkNotNull(expression, "expression supplier must not be null");
+        Preconditions.checkNotNull(variableName, "variableName must not be null");
+        Preconditions.checkNotNull(loBound, "loBound supplier must not be null");
+        Preconditions.checkNotNull(hiBound, "hiBound supplier must not be null");
+        Preconditions.checkNotNull(context, "context must not be null");
+        this.expression = expression;
+        this.variableName = variableName;
+        this.loBound = loBound;
+        this.hiBound = hiBound;
+        this.context = context;
+    }
+
+    /**
+     * Creates a FIND ZERO formula.
+     *
+     * @param expression   the compiled expression to find the zero of
+     * @param variableName the name of the loop variable to vary
+     * @param loBound      supplies the lower bound of the search range
+     * @param hiBound      supplies the upper bound of the search range
+     * @param context      the compilation context (for overriding the loop variable)
+     * @return a new FindZero formula
+     */
+    public static FindZero of(DoubleSupplier expression, String variableName,
+                               DoubleSupplier loBound, DoubleSupplier hiBound,
+                               CompilationContext context) {
+        return new FindZero(expression, variableName, loBound, hiBound, context);
+    }
+
+    @Override
+    public double getCurrentValue() {
+        double lo = loBound.getAsDouble();
+        double hi = hiBound.getAsDouble();
+
+        // Evaluate expression at lo
+        context.addLiteralConstant(variableName, lo);
+        double fLo = expression.getAsDouble();
+
+        // Evaluate expression at hi
+        context.addLiteralConstant(variableName, hi);
+        double fHi = expression.getAsDouble();
+
+        // If signs are the same, return the endpoint closer to zero
+        if (fLo * fHi > 0) {
+            double result = Math.abs(fLo) < Math.abs(fHi) ? lo : hi;
+            context.addLiteralConstant(variableName, result);
+            return result;
+        }
+
+        // Bisection
+        for (int i = 0; i < MAX_ITERATIONS; i++) {
+            double mid = (lo + hi) / 2.0;
+            context.addLiteralConstant(variableName, mid);
+            double fMid = expression.getAsDouble();
+
+            if (Math.abs(fMid) < TOLERANCE || (hi - lo) / 2.0 < TOLERANCE) {
+                return mid;
+            }
+
+            if (fLo * fMid < 0) {
+                hi = mid;
+            } else {
+                lo = mid;
+                fLo = fMid;
+            }
+        }
+
+        // Return best estimate
+        double mid = (lo + hi) / 2.0;
+        context.addLiteralConstant(variableName, mid);
+        return mid;
+    }
+}

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/model/SampleIfTrue.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/model/SampleIfTrue.java
@@ -1,0 +1,78 @@
+package systems.courant.shrewd.model;
+
+import com.google.common.base.Preconditions;
+
+import systems.courant.shrewd.model.compile.Resettable;
+
+import java.util.function.DoubleSupplier;
+import java.util.function.IntSupplier;
+
+/**
+ * Implements the Vensim SAMPLE IF TRUE function.
+ *
+ * <p>{@code SAMPLE IF TRUE(condition, input, initial)} samples {@code input} whenever
+ * {@code condition} is non-zero (true), and holds the last sampled value when condition
+ * is false. The initial value before the first true condition is {@code initial}.
+ *
+ * <p>This is a zero-order hold triggered by a boolean condition.
+ */
+public class SampleIfTrue implements Formula, Resettable {
+
+    private final DoubleSupplier condition;
+    private final DoubleSupplier input;
+    private final double initialValue;
+    private final IntSupplier currentStep;
+
+    private double heldValue;
+    private boolean initialized;
+    private int lastStep = -1;
+
+    private SampleIfTrue(DoubleSupplier condition, DoubleSupplier input,
+                          double initialValue, IntSupplier currentStep) {
+        Preconditions.checkNotNull(condition, "condition supplier must not be null");
+        Preconditions.checkNotNull(input, "input supplier must not be null");
+        Preconditions.checkNotNull(currentStep, "currentStep supplier must not be null");
+        this.condition = condition;
+        this.input = input;
+        this.initialValue = initialValue;
+        this.currentStep = currentStep;
+    }
+
+    /**
+     * Creates a SAMPLE IF TRUE formula.
+     *
+     * @param condition    supplies the boolean condition (non-zero = true)
+     * @param input        supplies the value to sample when condition is true
+     * @param initialValue the value to return before the first true condition
+     * @param currentStep  supplies the current simulation timestep
+     * @return a new SampleIfTrue formula
+     */
+    public static SampleIfTrue of(DoubleSupplier condition, DoubleSupplier input,
+                                   double initialValue, IntSupplier currentStep) {
+        return new SampleIfTrue(condition, input, initialValue, currentStep);
+    }
+
+    @Override
+    public void reset() {
+        heldValue = 0;
+        initialized = false;
+        lastStep = -1;
+    }
+
+    @Override
+    public double getCurrentValue() {
+        int step = currentStep.getAsInt();
+        if (!initialized) {
+            heldValue = initialValue;
+            initialized = true;
+            lastStep = step;
+        }
+        if (step > lastStep) {
+            if (condition.getAsDouble() != 0.0) {
+                heldValue = input.getAsDouble();
+            }
+            lastStep = step;
+        }
+        return heldValue;
+    }
+}

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/model/compile/ExprCompiler.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/model/compile/ExprCompiler.java
@@ -3,12 +3,14 @@ package systems.courant.shrewd.model.compile;
 import systems.courant.shrewd.model.Delay1;
 import systems.courant.shrewd.model.Delay3;
 import systems.courant.shrewd.model.DelayFixed;
+import systems.courant.shrewd.model.FindZero;
 import systems.courant.shrewd.model.Forecast;
 import systems.courant.shrewd.model.Formula;
 import systems.courant.shrewd.model.LookupTable;
 import systems.courant.shrewd.model.Npv;
 import systems.courant.shrewd.model.Pulse;
 import systems.courant.shrewd.model.Ramp;
+import systems.courant.shrewd.model.SampleIfTrue;
 import systems.courant.shrewd.model.Smooth;
 import systems.courant.shrewd.model.Smooth3;
 import systems.courant.shrewd.model.Step;
@@ -533,6 +535,8 @@ public class ExprCompiler {
             case "NPV" -> compileNpv(args);
             case "RANDOM_NORMAL" -> compileRandomNormal(args);
             case "RANDOM_UNIFORM" -> compileRandomUniform(args);
+            case "SAMPLE_IF_TRUE" -> compileSampleIfTrue(args);
+            case "FIND_ZERO" -> compileFindZero(args);
             case "LOOKUP" -> compileLookup(args);
             default -> {
                 // Check if the function name is a lookup table (Vensim allows table(input) syntax)
@@ -815,6 +819,38 @@ public class ExprCompiler {
             double hi = maxVal.getAsDouble();
             return lo + (hi - lo) * rng.nextDouble();
         };
+    }
+
+    private DoubleSupplier compileSampleIfTrue(List<Expr> args) {
+        requireArgs("SAMPLE_IF_TRUE", args, 3);
+        DoubleSupplier condition = compileExpr(args.get(0));
+        DoubleSupplier input = compileExpr(args.get(1));
+        double initial = evaluateAtCompileTime(args.get(2), "SAMPLE_IF_TRUE initialValue");
+        if (Double.isNaN(initial)) {
+            initial = 0.0;
+        }
+        SampleIfTrue sampler = SampleIfTrue.of(condition, input, initial,
+                context.getCurrentStep());
+        resettables.add(sampler);
+        return sampler::getCurrentValue;
+    }
+
+    private DoubleSupplier compileFindZero(List<Expr> args) {
+        requireArgs("FIND_ZERO", args, 4);
+        // First arg: expression to find the zero of
+        // Second arg: loop variable (must be a Ref)
+        if (!(args.get(1) instanceof Expr.Ref ref)) {
+            throw new CompilationException(
+                    "FIND_ZERO second argument must be a variable reference", "FIND_ZERO");
+        }
+        String varName = ref.name();
+        // Register the loop variable as a literal constant so the expression can resolve it
+        context.addLiteralConstant(varName, 0.0);
+        DoubleSupplier expression = compileExpr(args.get(0));
+        DoubleSupplier lo = compileExpr(args.get(2));
+        DoubleSupplier hi = compileExpr(args.get(3));
+        FindZero findZero = FindZero.of(expression, varName, lo, hi, context);
+        return findZero::getCurrentValue;
     }
 
     private DoubleSupplier compileLookup(List<Expr> args) {

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/model/expr/ExprDependencies.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/model/expr/ExprDependencies.java
@@ -25,6 +25,7 @@ public final class ExprDependencies {
             "TREND", "FORECAST", "NPV",
             "RANDOM_NORMAL", "RANDOM_UNIFORM",
             "XIDZ", "ZIDZ",
+            "SAMPLE_IF_TRUE", "FIND_ZERO",
             "LOOKUP", "IF", "TIME", "DT", "PI"
     );
 

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimExprTranslatorTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimExprTranslatorTest.java
@@ -630,6 +630,98 @@ class VensimExprTranslatorTest {
     }
 
     @Nested
+    @DisplayName("SAMPLE IF TRUE and FIND ZERO translation (#512)")
+    class SampleIfTrueAndFindZero {
+
+        @Test
+        void shouldTranslateSampleIfTrue() {
+            var result = VensimExprTranslator.translate(
+                    "SAMPLE IF TRUE(x > 0, input, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("SAMPLE_IF_TRUE(x > 0, input, 0)");
+            assertThat(result.warnings()).noneMatch(w -> w.contains("SAMPLE IF TRUE"));
+        }
+
+        @Test
+        void shouldTranslateSampleIfTrueCaseInsensitive() {
+            var result = VensimExprTranslator.translate(
+                    "sample if true(cond, val, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("SAMPLE_IF_TRUE(cond, val, 0)");
+        }
+
+        @Test
+        void shouldTranslateFindZero() {
+            var result = VensimExprTranslator.translate(
+                    "FIND ZERO(expr, x, 0, 100)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("FIND_ZERO(expr, x, 0, 100)");
+            assertThat(result.warnings()).noneMatch(w -> w.contains("FIND ZERO"));
+        }
+
+        @Test
+        void shouldTranslateFindZeroCaseInsensitive() {
+            var result = VensimExprTranslator.translate(
+                    "find zero(f, y, -10, 10)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("FIND_ZERO(f, y, -10, 10)");
+        }
+
+        @Test
+        void shouldNoLongerWarnForSampleIfTrue() {
+            var result = VensimExprTranslator.translate(
+                    "SAMPLE IF TRUE(x > 0, y, 0)", "var", EMPTY_NAMES);
+            assertThat(result.warnings()).noneMatch(w -> w.contains("Unsupported"));
+        }
+
+        @Test
+        void shouldNoLongerWarnForFindZero() {
+            var result = VensimExprTranslator.translate(
+                    "FIND ZERO(x - 5, x, 0, 10)", "var", EMPTY_NAMES);
+            assertThat(result.warnings()).noneMatch(w -> w.contains("Unsupported"));
+        }
+    }
+
+    @Nested
+    @DisplayName("ACTIVE INITIAL translation (#513)")
+    class ActiveInitial {
+
+        @Test
+        void shouldExtractFirstArgument() {
+            var result = VensimExprTranslator.translate(
+                    "ACTIVE INITIAL(x + y, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("x + y");
+        }
+
+        @Test
+        void shouldBeCaseInsensitive() {
+            var result = VensimExprTranslator.translate(
+                    "active initial(x, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("x");
+        }
+
+        @Test
+        void shouldHandleNestedFunctions() {
+            Set<String> names = Set.of("Potential Customers", "Waiting Customers");
+            var result = VensimExprTranslator.translate(
+                    "ACTIVE INITIAL(Potential Customers + Waiting Customers, Potential Customers)",
+                    "var", names);
+            assertThat(result.expression())
+                    .isEqualTo("Potential_Customers + Waiting_Customers");
+        }
+
+        @Test
+        void shouldHandleActiveInitialWithIfThenElse() {
+            var result = VensimExprTranslator.translate(
+                    "ACTIVE INITIAL(IF THEN ELSE(x > 0, x, 0), 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("IF(x > 0, x, 0)");
+        }
+
+        @Test
+        void shouldHandleActiveInitialInLargerExpression() {
+            var result = VensimExprTranslator.translate(
+                    "ACTIVE INITIAL(a * b, 0) + c", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("a * b + c");
+        }
+    }
+
+    @Nested
     @DisplayName("Edge cases")
     class EdgeCases {
 

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimImporterTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimImporterTest.java
@@ -1866,4 +1866,205 @@ class VensimImporterTest {
             assertThat(terms.get(1).expr()).isEqualTo("c");
         }
     }
+
+    @Nested
+    @DisplayName("SAMPLE IF TRUE and FIND ZERO (#512)")
+    class SampleIfTrueAndFindZeroImport {
+
+        @Test
+        void shouldCompileModelWithSampleIfTrue() {
+            String mdl = """
+                    sensor = SAMPLE IF TRUE(switch > 0, input, 0)
+                    \t~\tUnits
+                    \t~\t
+                    \t|
+
+                    switch = 1
+                    \t~\tDimensionless
+                    \t~\t
+                    \t|
+
+                    input = 42
+                    \t~\tUnits
+                    \t~\t
+                    \t|
+                    """;
+            ImportResult result = importer.importModel(mdl, "test");
+            assertThat(result.warnings()).noneMatch(w -> w.contains("Unsupported"));
+
+            CompiledModel compiled = new ModelCompiler().compile(result.definition());
+            Simulation sim = compiled.createSimulation();
+            sim.execute();
+            assertThat(compiled).isNotNull();
+        }
+
+        @Test
+        void shouldCompileModelWithFindZero() {
+            String mdl = """
+                    root = FIND ZERO(x - 5, x, 0, 10)
+                    \t~\tUnits
+                    \t~\t
+                    \t|
+
+                    x = 0
+                    \t~\tUnits
+                    \t~\t
+                    \t|
+                    """;
+            ImportResult result = importer.importModel(mdl, "test");
+            assertThat(result.warnings()).noneMatch(w -> w.contains("Unsupported"));
+
+            CompiledModel compiled = new ModelCompiler().compile(result.definition());
+            Simulation sim = compiled.createSimulation();
+            sim.execute();
+
+            // FIND ZERO should find x=5 where x-5=0
+            var rootVar = compiled.getModel().getVariables().stream()
+                    .filter(v -> v.getName().contains("root"))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(rootVar.getValue()).isCloseTo(5.0, org.assertj.core.data.Offset.offset(0.01));
+        }
+    }
+
+    @Nested
+    @DisplayName("ACTIVE INITIAL handling (#513)")
+    class ActiveInitialImport {
+
+        @Test
+        void shouldCompileModelWithActiveInitial() {
+            String mdl = """
+                    total market= ACTIVE INITIAL(
+                    Potential Customers + Customers, Potential Customers)
+                    \t~\tPeople
+                    \t~\t
+                    \t|
+
+                    Potential Customers = 1000
+                    \t~\tPeople
+                    \t~\t
+                    \t|
+
+                    Customers = 500
+                    \t~\tPeople
+                    \t~\t
+                    \t|
+                    """;
+            ImportResult result = importer.importModel(mdl, "test");
+            ModelDefinition def = result.definition();
+
+            // ACTIVE INITIAL should resolve to first arg: Potential Customers + Customers
+            var aux = def.auxiliaries().stream()
+                    .filter(a -> a.name().contains("total market"))
+                    .findFirst();
+            assertThat(aux).isPresent();
+            assertThat(aux.get().equation()).isEqualTo("Potential_Customers + Customers");
+
+            // Should compile without errors
+            CompiledModel compiled = new ModelCompiler().compile(def);
+            assertThat(compiled).isNotNull();
+        }
+
+        @Test
+        void shouldCompileModelWithActiveInitialAndIfThenElse() {
+            String mdl = """
+                    proactive replacements = ACTIVE INITIAL(IF THEN ELSE(avail > 0, avail, 0), 0)
+                    \t~\tUnits
+                    \t~\t
+                    \t|
+
+                    avail = 50
+                    \t~\tUnits
+                    \t~\t
+                    \t|
+                    """;
+            ImportResult result = importer.importModel(mdl, "test");
+            ModelDefinition def = result.definition();
+
+            var aux = def.auxiliaries().stream()
+                    .filter(a -> a.name().contains("proactive"))
+                    .findFirst();
+            assertThat(aux).isPresent();
+            assertThat(aux.get().equation()).isEqualTo("IF(avail > 0, avail, 0)");
+        }
+    }
+
+    @Nested
+    @DisplayName("Non-monotonic lookup table handling (#511)")
+    class NonMonotonicLookup {
+
+        @Test
+        void shouldSortNonMonotonicLookupXValues() {
+            String mdl = """
+                    my table(
+                    [(0,0)-(10,10)],(0,1),(3,5),(2,3),(5,8),(4,6))
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    result = my table(Time)
+                    \t~\t
+                    \t~\t
+                    \t|
+                    """;
+            ImportResult result = importer.importModel(mdl, "test");
+            ModelDefinition def = result.definition();
+
+            assertThat(def.lookupTables()).hasSize(1);
+            LookupTableDef lookup = def.lookupTables().get(0);
+            // x-values should be sorted: 0, 2, 3, 4, 5
+            assertThat(lookup.xValues()).containsExactly(0, 2, 3, 4, 5);
+            assertThat(lookup.yValues()).containsExactly(1, 3, 5, 6, 8);
+            assertThat(result.warnings()).anyMatch(w -> w.contains("sorted non-monotonic"));
+        }
+
+        @Test
+        void shouldSortAndDeduplicateLookupXValues() {
+            String mdl = """
+                    my table(
+                    [(0,0)-(10,10)],(0,1),(5.5,7),(3,5),(5.0,6),(5.5,8))
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    result = my table(Time)
+                    \t~\t
+                    \t~\t
+                    \t|
+                    """;
+            ImportResult result = importer.importModel(mdl, "test");
+            ModelDefinition def = result.definition();
+
+            assertThat(def.lookupTables()).hasSize(1);
+            LookupTableDef lookup = def.lookupTables().get(0);
+            // Sorted: 0, 3, 5.0, 5.5, 5.5 → deduplicated: 0, 3, 5.0, 5.5
+            assertThat(lookup.xValues()).containsExactly(0, 3, 5.0, 5.5);
+            // Last y for x=5.5 is 8 (from the second 5.5 entry)
+            assertThat(lookup.yValues()).containsExactly(1, 5, 6, 8);
+            assertThat(result.warnings()).anyMatch(w -> w.contains("sorted non-monotonic")
+                    && w.contains("duplicate"));
+        }
+
+        @Test
+        void shouldCompileModelWithNonMonotonicLookup() {
+            String mdl = """
+                    my table(
+                    [(0,0)-(10,10)],(0,0),(5,10),(3,6),(10,20))
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    output = my table(Time)
+                    \t~\t
+                    \t~\t
+                    \t|
+                    """;
+            ImportResult result = importer.importModel(mdl, "test");
+            CompiledModel compiled = new ModelCompiler().compile(result.definition());
+            Simulation sim = compiled.createSimulation();
+            sim.execute();
+            // Model should compile and run without errors
+            assertThat(compiled).isNotNull();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Sort and deduplicate non-monotonic lookup table x-values during import (#511)
- Implement SAMPLE IF TRUE and FIND ZERO Vensim functions in expression compiler (#512)
- Translate ACTIVE INITIAL to first argument for multi-word name resolution (#513)

## Test plan
- [x] 18 new unit tests covering all three fixes
- [x] Full test suite passes (1787 tests)
- [x] SpotBugs clean