### PR TITLE
Allow non-constant SMOOTHI initial values, add plural time unit aliases

### DIFF
--- a/shrewd-engine/src/main/java/systems/courant/shrewd/measure/UnitRegistry.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/measure/UnitRegistry.java
@@ -39,6 +39,19 @@ public class UnitRegistry {
         registerAll(VolumeUnits.values());
         registerAll(TemperatureUnits.values());
         registerAll(DimensionlessUnits.values());
+        registerTimeUnitAliases();
+    }
+
+    /**
+     * Registers common plural and abbreviated aliases for time units.
+     * Vensim models use both singular ("Day") and plural ("Days") forms.
+     */
+    private void registerTimeUnitAliases() {
+        for (TimeUnits tu : TimeUnits.values()) {
+            String plural = tu.getName() + "s";
+            byName.put(plural, tu);
+            byNameLower.put(plural.toLowerCase(), tu);
+        }
     }
 
     private void registerAll(Unit[] units) {

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/model/compile/ExprCompiler.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/model/compile/ExprCompiler.java
@@ -573,7 +573,10 @@ public class ExprCompiler {
         requireArgs("SMOOTHI", args, 3);
         DoubleSupplier input = compileExpr(args.get(0));
         double smoothingTime = evaluateConstant(args.get(1), "SMOOTHI smoothingTime");
-        double initial = evaluateConstant(args.get(2), "SMOOTHI initialValue");
+        double initial = evaluateAtCompileTime(args.get(2), "SMOOTHI initialValue");
+        if (Double.isNaN(initial)) {
+            initial = 0.0;
+        }
         Smooth smooth = Smooth.of(input, smoothingTime, initial, context.getCurrentStep());
         resettables.add(smooth);
         return smooth::getCurrentValue;
@@ -588,7 +591,10 @@ public class ExprCompiler {
         double smoothingTime = evaluateConstant(args.get(1), "SMOOTH3 smoothingTime");
         Smooth3 smooth3;
         if (args.size() == 3) {
-            double initial = evaluateConstant(args.get(2), "SMOOTH3 initialValue");
+            double initial = evaluateAtCompileTime(args.get(2), "SMOOTH3 initialValue");
+            if (Double.isNaN(initial)) {
+                initial = 0.0;
+            }
             smooth3 = Smooth3.of(input, smoothingTime, initial, context.getCurrentStep());
         } else {
             smooth3 = Smooth3.of(input, smoothingTime, context.getCurrentStep());
@@ -601,7 +607,10 @@ public class ExprCompiler {
         requireArgs("SMOOTH3I", args, 3);
         DoubleSupplier input = compileExpr(args.get(0));
         double smoothingTime = evaluateConstant(args.get(1), "SMOOTH3I smoothingTime");
-        double initial = evaluateConstant(args.get(2), "SMOOTH3I initialValue");
+        double initial = evaluateAtCompileTime(args.get(2), "SMOOTH3I initialValue");
+        if (Double.isNaN(initial)) {
+            initial = 0.0;
+        }
         Smooth3 smooth3 = Smooth3.of(input, smoothingTime, initial, context.getCurrentStep());
         resettables.add(smooth3);
         return smooth3::getCurrentValue;

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimImporterTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimImporterTest.java
@@ -1868,6 +1868,36 @@ class VensimImporterTest {
     }
 
     @Nested
+    @DisplayName("Non-constant SMOOTHI initial value (#514)")
+    class NonConstantSmoothIInitial {
+
+        @Test
+        void shouldCompileModelWithSmoothIReferencingAux() {
+            String mdl = """
+                    smoothed = SMOOTHI(input, 5, normal price)
+                    \t~\tDollars
+                    \t~\t
+                    \t|
+
+                    input = 100
+                    \t~\tDollars
+                    \t~\t
+                    \t|
+
+                    normal price = 50
+                    \t~\tDollars
+                    \t~\t
+                    \t|
+                    """;
+            ImportResult result = importer.importModel(mdl, "test");
+            CompiledModel compiled = new ModelCompiler().compile(result.definition());
+            Simulation sim = compiled.createSimulation();
+            sim.execute();
+            assertThat(compiled).isNotNull();
+        }
+    }
+
+    @Nested
     @DisplayName("SAMPLE IF TRUE and FIND ZERO (#512)")
     class SampleIfTrueAndFindZeroImport {
 

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/measure/UnitRegistryTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/measure/UnitRegistryTest.java
@@ -43,6 +43,20 @@ class UnitRegistryTest {
     }
 
     @Test
+    void shouldResolvePluralTimeUnits() {
+        assertThat(registry.resolveTimeUnit("Days")).isSameAs(TimeUnits.DAY);
+        assertThat(registry.resolveTimeUnit("Weeks")).isSameAs(TimeUnits.WEEK);
+        assertThat(registry.resolveTimeUnit("Months")).isSameAs(TimeUnits.MONTH);
+        assertThat(registry.resolveTimeUnit("Years")).isSameAs(TimeUnits.YEAR);
+    }
+
+    @Test
+    void shouldFindPluralTimeUnitsCaseInsensitive() {
+        assertThat(registry.find("days")).isSameAs(TimeUnits.DAY);
+        assertThat(registry.find("DAYS")).isSameAs(TimeUnits.DAY);
+    }
+
+    @Test
     void shouldFindItemUnits() {
         assertThat(registry.find("Person")).isNotNull();
         assertThat(registry.find("Thing")).isNotNull();

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/model/compile/ExprCompilerTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/model/compile/ExprCompilerTest.java
@@ -993,4 +993,55 @@ class ExprCompilerTest {
                     .isGreaterThan(30.0);
         }
     }
+
+    @Nested
+    @DisplayName("Non-constant initial values (#514)")
+    class NonConstantInitialValues {
+
+        @Test
+        void shouldAcceptVariableReferenceAsSmoothIInitial() {
+            context.addVariable("normal_price",
+                    new systems.courant.shrewd.model.Variable("normal_price",
+                            ItemUnits.PEOPLE, () -> 50.0));
+            context.addVariable("input",
+                    new systems.courant.shrewd.model.Variable("input",
+                            ItemUnits.PEOPLE, () -> 100.0));
+
+            Formula formula = compiler.compile("SMOOTHI(input, 5, normal_price)");
+            step[0] = 0;
+            double val = formula.getCurrentValue();
+            // Initial value should be 50 (from normal_price), not 0 or error
+            assertThat(val).isCloseTo(50.0, within(0.01));
+        }
+
+        @Test
+        void shouldAcceptExpressionAsSmooth3IInitial() {
+            context.addLiteralConstant("base_val", 20.0);
+            context.addVariable("input",
+                    new systems.courant.shrewd.model.Variable("input",
+                            ItemUnits.PEOPLE, () -> 100.0));
+
+            Formula formula = compiler.compile("SMOOTH3I(input, 5, base_val + 10)");
+            step[0] = 0;
+            double val = formula.getCurrentValue();
+            // Initial value should be 30 (20 + 10)
+            assertThat(val).isCloseTo(30.0, within(0.01));
+        }
+
+        @Test
+        void shouldAcceptVariableReferenceAsSmooth3Initial() {
+            context.addVariable("init_val",
+                    new systems.courant.shrewd.model.Variable("init_val",
+                            ItemUnits.PEOPLE, () -> 75.0));
+            context.addVariable("input",
+                    new systems.courant.shrewd.model.Variable("input",
+                            ItemUnits.PEOPLE, () -> 100.0));
+
+            Formula formula = compiler.compile("SMOOTH3(input, 5, init_val)");
+            step[0] = 0;
+            double val = formula.getCurrentValue();
+            // Initial value should be 75 (from init_val)
+            assertThat(val).isCloseTo(75.0, within(0.01));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Allow variable references and expressions as SMOOTHI/SMOOTH3I/SMOOTH3 initial values (#514)
- Register plural time unit aliases (Days, Weeks, etc.) in UnitRegistry (#515)

## Test plan
- [x] 6 new unit tests (3 ExprCompiler, 2 UnitRegistry, 1 VensimImporter)
- [x] Full test suite passes
- [x] SpotBugs clean