### PR TITLE
Implement remaining Vensim functions: NOT, OR, AND, TRUE, FALSE, LOOKUP_AREA

### DIFF
--- a/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimExprTranslator.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/io/vensim/VensimExprTranslator.java
@@ -68,6 +68,8 @@ public final class VensimExprTranslator {
             "(?i)SAMPLE\\s+IF\\s+TRUE\\s*\\(");
     private static final Pattern FIND_ZERO_PATTERN = Pattern.compile(
             "(?i)FIND\\s+ZERO\\s*\\(");
+    private static final Pattern LOOKUP_AREA_PATTERN = Pattern.compile(
+            "(?i)LOOKUP\\s+AREA\\s*\\(");
     private static final Pattern CARET_PATTERN = Pattern.compile("\\^");
     private static final Pattern TIME_VAR_PATTERN = Pattern.compile(
             "(?i)\\bTime\\b");
@@ -206,6 +208,9 @@ public final class VensimExprTranslator {
 
         // 8h. PULSE TRAIN → PULSE_TRAIN
         expr = PULSE_TRAIN_PATTERN.matcher(expr).replaceAll("PULSE_TRAIN(");
+
+        // 8i. LOOKUP AREA → LOOKUP_AREA
+        expr = LOOKUP_AREA_PATTERN.matcher(expr).replaceAll("LOOKUP_AREA(");
 
         // 9. ^ → ** (Vensim uses ^ for power, Shrewd uses **)
         expr = CARET_PATTERN.matcher(expr).replaceAll("**");

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/model/compile/ExprCompiler.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/model/compile/ExprCompiler.java
@@ -537,6 +537,32 @@ public class ExprCompiler {
             case "RANDOM_UNIFORM" -> compileRandomUniform(args);
             case "SAMPLE_IF_TRUE" -> compileSampleIfTrue(args);
             case "FIND_ZERO" -> compileFindZero(args);
+            case "NOT" -> {
+                requireArgs(name, args, 1);
+                DoubleSupplier a = compileExpr(args.get(0));
+                yield () -> a.getAsDouble() == 0 ? 1.0 : 0.0;
+            }
+            case "OR" -> {
+                requireArgs(name, args, 2);
+                DoubleSupplier a = compileExpr(args.get(0));
+                DoubleSupplier b = compileExpr(args.get(1));
+                yield () -> (a.getAsDouble() != 0 || b.getAsDouble() != 0) ? 1.0 : 0.0;
+            }
+            case "AND" -> {
+                requireArgs(name, args, 2);
+                DoubleSupplier a = compileExpr(args.get(0));
+                DoubleSupplier b = compileExpr(args.get(1));
+                yield () -> (a.getAsDouble() != 0 && b.getAsDouble() != 0) ? 1.0 : 0.0;
+            }
+            case "TRUE" -> {
+                requireArgs(name, args, 0);
+                yield () -> 1.0;
+            }
+            case "FALSE" -> {
+                requireArgs(name, args, 0);
+                yield () -> 0.0;
+            }
+            case "LOOKUP_AREA" -> compileLookupArea(args);
             case "LOOKUP" -> compileLookup(args);
             default -> {
                 // Check if the function name is a lookup table (Vensim allows table(input) syntax)
@@ -892,6 +918,70 @@ public class ExprCompiler {
         // when multiple formulas reference the same lookup table (tables registered without a def)
         LookupTable isolatedTable = existing.get().withInput(input);
         return isolatedTable::getCurrentValue;
+    }
+
+    private DoubleSupplier compileLookupArea(List<Expr> args) {
+        requireArgs("LOOKUP_AREA", args, 3);
+        if (!(args.get(0) instanceof Expr.Ref ref)) {
+            throw new CompilationException(
+                    "LOOKUP_AREA first argument must be a table name reference", "LOOKUP_AREA");
+        }
+        String tableName = ref.name();
+        String resolvedName = tableName;
+        Optional<systems.courant.shrewd.model.def.LookupTableDef> defOpt =
+                context.resolveLookupTableDef(tableName);
+        if (defOpt.isEmpty() && tableName.contains("_")) {
+            resolvedName = tableName.replace('_', ' ');
+            defOpt = context.resolveLookupTableDef(resolvedName);
+        }
+        if (defOpt.isEmpty()) {
+            throw new CompilationException(
+                    "Lookup table not found: " + tableName, tableName);
+        }
+        double[] xValues = defOpt.get().xValues();
+        DoubleSupplier fromX = compileExpr(args.get(1));
+        DoubleSupplier toX = compileExpr(args.get(2));
+
+        // Use the lookup table's interpolation to compute area via trapezoidal rule
+        Optional<LookupTable> tableOpt = context.createFreshLookupTable(resolvedName, () -> 0);
+        if (tableOpt.isEmpty()) {
+            tableOpt = context.resolveLookupTable(resolvedName);
+        }
+        if (tableOpt.isEmpty()) {
+            throw new CompilationException(
+                    "Lookup table not found: " + tableName, tableName);
+        }
+        LookupTable table = tableOpt.get();
+        return () -> {
+            double x1 = fromX.getAsDouble();
+            double x2 = toX.getAsDouble();
+            if (x1 == x2) {
+                return 0.0;
+            }
+            boolean negate = x1 > x2;
+            double lo = negate ? x2 : x1;
+            double hi = negate ? x1 : x2;
+            // Trapezoidal integration using the lookup table's data points
+            double area = 0.0;
+            double prevX = lo;
+            double prevY = table.withInput(() -> lo).getCurrentValue();
+            for (double xVal : xValues) {
+                if (xVal <= lo) {
+                    continue;
+                }
+                if (xVal >= hi) {
+                    break;
+                }
+                double curY = table.withInput(() -> xVal).getCurrentValue();
+                area += (xVal - prevX) * (prevY + curY) / 2.0;
+                prevX = xVal;
+                prevY = curY;
+            }
+            // Final segment to hi
+            double hiY = table.withInput(() -> hi).getCurrentValue();
+            area += (hi - prevX) * (prevY + hiY) / 2.0;
+            return negate ? -area : area;
+        };
     }
 
     private DoubleSupplier compileConditional(Expr.Conditional cond) {

--- a/shrewd-engine/src/main/java/systems/courant/shrewd/model/expr/ExprDependencies.java
+++ b/shrewd-engine/src/main/java/systems/courant/shrewd/model/expr/ExprDependencies.java
@@ -26,6 +26,8 @@ public final class ExprDependencies {
             "RANDOM_NORMAL", "RANDOM_UNIFORM",
             "XIDZ", "ZIDZ",
             "SAMPLE_IF_TRUE", "FIND_ZERO",
+            "NOT", "OR", "AND", "TRUE", "FALSE",
+            "LOOKUP_AREA",
             "LOOKUP", "IF", "TIME", "DT", "PI"
     );
 

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimExprTranslatorTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/io/vensim/VensimExprTranslatorTest.java
@@ -750,4 +750,30 @@ class VensimExprTranslatorTest {
             assertThat(result.expression()).contains("and");
         }
     }
+
+    @Nested
+    @DisplayName("LOOKUP AREA translation")
+    class LookupAreaTranslation {
+
+        @Test
+        void shouldTranslateLookupArea() {
+            var result = VensimExprTranslator.translate(
+                    "LOOKUP AREA(my_table, 0, 10)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("LOOKUP_AREA(my_table, 0, 10)");
+        }
+
+        @Test
+        void shouldTranslateLookupAreaCaseInsensitive() {
+            var result = VensimExprTranslator.translate(
+                    "lookup area(my_table, x1, x2)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("LOOKUP_AREA(my_table, x1, x2)");
+        }
+
+        @Test
+        void shouldTranslateLookupAreaWithExtraSpaces() {
+            var result = VensimExprTranslator.translate(
+                    "LOOKUP   AREA  (tbl, 0, 5)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("LOOKUP_AREA(tbl, 0, 5)");
+        }
+    }
 }

--- a/shrewd-engine/src/test/java/systems/courant/shrewd/model/compile/ExprCompilerTest.java
+++ b/shrewd-engine/src/test/java/systems/courant/shrewd/model/compile/ExprCompilerTest.java
@@ -1044,4 +1044,131 @@ class ExprCompilerTest {
             assertThat(val).isCloseTo(75.0, within(0.01));
         }
     }
+
+    @Nested
+    @DisplayName("Logical function forms (NOT, OR, AND, TRUE, FALSE)")
+    class LogicalFunctionForms {
+
+        @Test
+        void shouldCompileNotFunctionWithZero() {
+            Formula formula = compiler.compile("NOT(0)");
+            assertThat(formula.getCurrentValue()).isEqualTo(1.0);
+        }
+
+        @Test
+        void shouldCompileNotFunctionWithNonZero() {
+            Formula formula = compiler.compile("NOT(5)");
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+        }
+
+        @Test
+        void shouldCompileOrFunctionBothFalse() {
+            Formula formula = compiler.compile("OR(0, 0)");
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+        }
+
+        @Test
+        void shouldCompileOrFunctionOneTrueOneFalse() {
+            Formula formula = compiler.compile("OR(0, 1)");
+            assertThat(formula.getCurrentValue()).isEqualTo(1.0);
+        }
+
+        @Test
+        void shouldCompileAndFunctionBothTrue() {
+            Formula formula = compiler.compile("AND(1, 1)");
+            assertThat(formula.getCurrentValue()).isEqualTo(1.0);
+        }
+
+        @Test
+        void shouldCompileAndFunctionOneFalse() {
+            Formula formula = compiler.compile("AND(1, 0)");
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+        }
+
+        @Test
+        void shouldCompileTrueFunction() {
+            Formula formula = compiler.compile("TRUE()");
+            assertThat(formula.getCurrentValue()).isEqualTo(1.0);
+        }
+
+        @Test
+        void shouldCompileFalseFunction() {
+            Formula formula = compiler.compile("FALSE()");
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("LOOKUP_AREA")
+    class LookupAreaCompilation {
+
+        @Test
+        void shouldComputeAreaUnderConstantLookup() {
+            // Lookup: y = 2.0 for all x (flat line from 0 to 10)
+            // Area from 0 to 10 = 2.0 * 10 = 20.0
+            var def = new systems.courant.shrewd.model.def.LookupTableDef(
+                    "flat_table",
+                    new double[]{0.0, 10.0},
+                    new double[]{2.0, 2.0},
+                    "LINEAR");
+            context.addLookupTableDef("flat_table", def);
+            context.addLookupTable("flat_table",
+                    LookupTable.linear(def.xValues(), def.yValues(), () -> 0),
+                    new double[1]);
+
+            Formula formula = compiler.compile("LOOKUP_AREA(flat_table, 0, 10)");
+            assertThat(formula.getCurrentValue()).isCloseTo(20.0, within(0.001));
+        }
+
+        @Test
+        void shouldComputeAreaUnderLinearRamp() {
+            // Lookup: y = x (linear from 0,0 to 10,10)
+            // Area from 0 to 10 = 0.5 * 10 * 10 = 50.0 (triangle)
+            var def = new systems.courant.shrewd.model.def.LookupTableDef(
+                    "ramp_table",
+                    new double[]{0.0, 10.0},
+                    new double[]{0.0, 10.0},
+                    "LINEAR");
+            context.addLookupTableDef("ramp_table", def);
+            context.addLookupTable("ramp_table",
+                    LookupTable.linear(def.xValues(), def.yValues(), () -> 0),
+                    new double[1]);
+
+            Formula formula = compiler.compile("LOOKUP_AREA(ramp_table, 0, 10)");
+            assertThat(formula.getCurrentValue()).isCloseTo(50.0, within(0.001));
+        }
+
+        @Test
+        void shouldReturnNegativeAreaWhenReversed() {
+            var def = new systems.courant.shrewd.model.def.LookupTableDef(
+                    "flat2",
+                    new double[]{0.0, 10.0},
+                    new double[]{2.0, 2.0},
+                    "LINEAR");
+            context.addLookupTableDef("flat2", def);
+            context.addLookupTable("flat2",
+                    LookupTable.linear(def.xValues(), def.yValues(), () -> 0),
+                    new double[1]);
+
+            Formula formula = compiler.compile("LOOKUP_AREA(flat2, 10, 0)");
+            assertThat(formula.getCurrentValue()).isCloseTo(-20.0, within(0.001));
+        }
+
+        @Test
+        void shouldComputePartialArea() {
+            // Lookup: y = x from 0 to 10. Area from 2 to 6 = trapezoid: (2+6)/2 * 4 = 16
+            var def = new systems.courant.shrewd.model.def.LookupTableDef(
+                    "ramp2",
+                    new double[]{0.0, 10.0},
+                    new double[]{0.0, 10.0},
+                    "LINEAR");
+            context.addLookupTableDef("ramp2", def);
+            context.addLookupTable("ramp2",
+                    LookupTable.linear(def.xValues(), def.yValues(), () -> 0),
+                    new double[1]);
+
+            Formula formula = compiler.compile("LOOKUP_AREA(ramp2, 2, 6)");
+            assertThat(formula.getCurrentValue()).isCloseTo(16.0, within(0.001));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add function-call forms for logical operators (NOT, OR, AND) and boolean constants (TRUE, FALSE) in ExprCompiler
- Add LOOKUP AREA multi-word translation in VensimExprTranslator and trapezoidal area-under-curve computation
- Update ExprDependencies builtin set
- 15 new unit tests

Closes #523