### PR TITLE
Add extreme-condition testing under Simulate menu

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -633,6 +633,9 @@ public class ModelWindow {
         validateItem.setAccelerator(new KeyCodeCombination(KeyCode.B, KeyCombination.SHORTCUT_DOWN));
         validateItem.setOnAction(e -> simulationController.validateModel());
 
+        MenuItem extremeCondItem = new MenuItem("Extreme Conditions...");
+        extremeCondItem.setOnAction(e -> simulationController.runExtremeConditionTest());
+
         MenuItem sweepItem = new MenuItem("Parameter Sweep...");
         sweepItem.setOnAction(e -> simulationController.runParameterSweep());
 
@@ -646,7 +649,7 @@ public class ModelWindow {
         optimizeItem.setOnAction(e -> simulationController.runOptimization());
 
         simulateMenu.getItems().addAll(settingsItem, runItem,
-                new SeparatorMenuItem(), validateItem,
+                new SeparatorMenuItem(), validateItem, extremeCondItem,
                 new SeparatorMenuItem(), sweepItem, multiSweepItem, monteCarloItem, optimizeItem);
         simulateMenu.setDisable(true);
         editorOnlyItems.add(simulateMenu);
@@ -1174,6 +1177,7 @@ public class ModelWindow {
         commands.add(cmd("Run Simulation", "Simulate", simulationController::runSimulation));
         commands.add(cmd("Validate Model", "Simulate", simulationController::validateModel));
         commands.add(cmd("Simulation Settings", "Simulate", simulationController::openSimulationSettings));
+        commands.add(cmd("Extreme Conditions", "Simulate", simulationController::runExtremeConditionTest));
         commands.add(cmd("Parameter Sweep", "Simulate", simulationController::runParameterSweep));
         commands.add(cmd("Multi-Parameter Sweep", "Simulate", simulationController::runMultiParameterSweep));
         commands.add(cmd("Monte Carlo", "Simulate", simulationController::runMonteCarlo));

--- a/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
@@ -14,6 +14,7 @@ import systems.courant.sd.app.canvas.SensitivityPane;
 import systems.courant.sd.app.canvas.SimulationRunner;
 import systems.courant.sd.app.canvas.SimulationSettingsDialog;
 import systems.courant.sd.app.canvas.StatusBar;
+import systems.courant.sd.app.canvas.ExtremeConditionDialog;
 import systems.courant.sd.app.canvas.ValidationDialog;
 import systems.courant.sd.measure.Quantity;
 import systems.courant.sd.measure.TimeUnit;
@@ -21,8 +22,10 @@ import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.ModelValidator;
 import systems.courant.sd.model.def.SimulationSettings;
 import systems.courant.sd.model.def.StockDef;
+import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.graph.FeedbackAnalysis;
 import systems.courant.sd.model.graph.LoopDominanceAnalysis;
+import systems.courant.sd.sweep.ExtremeConditionTest;
 import systems.courant.sd.sweep.MonteCarlo;
 import systems.courant.sd.sweep.Objectives;
 import systems.courant.sd.sweep.ObjectiveFunction;
@@ -366,6 +369,47 @@ final class SimulationController {
                     fireLogEvent.accept(l -> l.onValidation(result.errorCount(), result.warningCount()));
                 },
                 "Validation Error");
+    }
+
+    void runExtremeConditionTest() {
+        SimulationSettings settings = ensureSettings();
+        if (settings == null) {
+            return;
+        }
+
+        ModelDefinition def = canvas.toModelDefinition();
+        List<VariableDef> params = def.parameters();
+
+        if (params.isEmpty()) {
+            showError.accept("Model has no parameters to test.");
+            return;
+        }
+
+        int totalRuns = params.size() * 3;
+        analysisRunner.run(
+                "Running extreme condition tests (" + totalRuns + " runs)...",
+                () -> {
+                    TimeUnit timeStep = ModelDefinitionFactory.resolveTimeStep(settings);
+                    Quantity duration = ModelDefinitionFactory.resolveDuration(settings);
+
+                    ExtremeConditionTest.Builder builder = ExtremeConditionTest.builder()
+                            .compiledModelFactory(
+                                    ModelDefinitionFactory.createFactory(def, settings))
+                            .timeStep(timeStep)
+                            .duration(duration);
+
+                    for (VariableDef param : params) {
+                        builder.parameter(param.name(), param.literalValue());
+                    }
+
+                    return builder.build().execute();
+                },
+                result -> {
+                    ExtremeConditionDialog.showOrUpdate(result);
+                    fireLogEvent.accept(l -> l.onAnalysisRun("Extreme Condition Test",
+                            params.size() + " parameters, " + result.findings().size() + " findings"));
+                },
+                "Extreme Condition Test Error");
     }
 
     private void showMultiSweepSensitivity(

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ExtremeConditionDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ExtremeConditionDialog.java
@@ -1,0 +1,206 @@
+package systems.courant.sd.app.canvas;
+
+import systems.courant.sd.sweep.ExtremeConditionFinding;
+import systems.courant.sd.sweep.ExtremeConditionResult;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+
+/**
+ * A dialog that displays extreme-condition test results in a table.
+ *
+ * <p>Only one instance may be open at a time. Use {@link #showOrUpdate} to
+ * create a new dialog or refresh and bring an existing one to the front.
+ */
+public class ExtremeConditionDialog extends Dialog<Void> {
+
+    private static ExtremeConditionDialog openInstance;
+
+    private final TableView<ExtremeConditionFinding> table;
+    private final Label summaryLabel;
+    private final Button copyButton;
+    private ExtremeConditionResult currentResult;
+
+    /**
+     * Shows an extreme-condition dialog with the given result. If a dialog is already open,
+     * refreshes its contents and brings it to the front instead of creating a new one.
+     *
+     * @param result the extreme-condition test result to display
+     */
+    public static void showOrUpdate(ExtremeConditionResult result) {
+        if (openInstance != null && openInstance.isShowing()) {
+            openInstance.updateResult(result);
+            Stage window = (Stage) openInstance.getDialogPane().getScene().getWindow();
+            window.toFront();
+            window.requestFocus();
+            return;
+        }
+        ExtremeConditionDialog dialog = new ExtremeConditionDialog(result);
+        openInstance = dialog;
+        dialog.show();
+    }
+
+    /**
+     * Returns the currently open dialog, or {@code null} if none is showing.
+     * Visible for testing.
+     */
+    static ExtremeConditionDialog getOpenInstance() {
+        if (openInstance != null && !openInstance.isShowing()) {
+            openInstance = null;
+        }
+        return openInstance;
+    }
+
+    public ExtremeConditionDialog(ExtremeConditionResult result) {
+        initModality(Modality.NONE);
+        setTitle("Extreme Condition Test Results");
+        this.currentResult = result;
+
+        table = new TableView<>();
+        table.setId("extremeConditionTable");
+        table.setPlaceholder(new Label("No issues found. Model is robust under extreme conditions."));
+
+        TableColumn<ExtremeConditionFinding, String> paramCol = new TableColumn<>("Parameter");
+        paramCol.setCellValueFactory(data ->
+                new SimpleStringProperty(data.getValue().parameterName()));
+        paramCol.setPrefWidth(130);
+
+        TableColumn<ExtremeConditionFinding, String> condCol = new TableColumn<>("Condition");
+        condCol.setCellValueFactory(data ->
+                new SimpleStringProperty(data.getValue().condition().label()));
+        condCol.setPrefWidth(80);
+
+        TableColumn<ExtremeConditionFinding, String> valueCol = new TableColumn<>("Applied Value");
+        valueCol.setCellValueFactory(data ->
+                new SimpleStringProperty(formatValue(data.getValue().appliedValue())));
+        valueCol.setPrefWidth(100);
+
+        TableColumn<ExtremeConditionFinding, String> varCol = new TableColumn<>("Affected Variable");
+        varCol.setCellValueFactory(data ->
+                new SimpleStringProperty(data.getValue().affectedVariable()));
+        varCol.setPrefWidth(130);
+
+        TableColumn<ExtremeConditionFinding, String> stepCol = new TableColumn<>("Step");
+        stepCol.setCellValueFactory(data -> {
+            long step = data.getValue().stepNumber();
+            return new SimpleStringProperty(step >= 0 ? Long.toString(step) : "N/A");
+        });
+        stepCol.setPrefWidth(60);
+
+        TableColumn<ExtremeConditionFinding, String> descCol = new TableColumn<>("Description");
+        descCol.setCellValueFactory(data ->
+                new SimpleStringProperty(data.getValue().description()));
+        descCol.setPrefWidth(300);
+
+        table.getColumns().add(paramCol);
+        table.getColumns().add(condCol);
+        table.getColumns().add(valueCol);
+        table.getColumns().add(varCol);
+        table.getColumns().add(stepCol);
+        table.getColumns().add(descCol);
+
+        table.setItems(FXCollections.observableArrayList(result.findings()));
+
+        summaryLabel = new Label();
+        summaryLabel.setId("extremeConditionSummary");
+        summaryLabel.setPadding(new Insets(6, 8, 6, 8));
+        updateSummaryLabel(result);
+
+        copyButton = new Button("Copy to Clipboard");
+        copyButton.setId("extremeConditionCopy");
+        copyButton.setOnAction(e -> {
+            String text = formatAsText(currentResult);
+            ClipboardContent content = new ClipboardContent();
+            content.putString(text);
+            Clipboard.getSystemClipboard().setContent(content);
+            copyButton.setText("Copied!");
+        });
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        HBox bottomBar = new HBox(summaryLabel, spacer, copyButton);
+        bottomBar.setAlignment(Pos.CENTER_LEFT);
+        bottomBar.setPadding(new Insets(4, 8, 4, 0));
+
+        BorderPane root = new BorderPane();
+        root.setCenter(table);
+        root.setBottom(bottomBar);
+
+        getDialogPane().setContent(root);
+        getDialogPane().setPrefWidth(Styles.screenAwareWidth(800));
+        getDialogPane().setPrefHeight(Styles.screenAwareHeight(500));
+        getDialogPane().getButtonTypes().add(ButtonType.CLOSE);
+
+        setResultConverter(button -> null);
+
+        setOnHidden(e -> {
+            if (openInstance == this) {
+                openInstance = null;
+            }
+        });
+    }
+
+    /**
+     * Replaces the displayed result with a new one.
+     *
+     * @param result the new extreme-condition test result
+     */
+    public void updateResult(ExtremeConditionResult result) {
+        this.currentResult = result;
+        table.setItems(FXCollections.observableArrayList(result.findings()));
+        updateSummaryLabel(result);
+        copyButton.setText("Copy to Clipboard");
+    }
+
+    private void updateSummaryLabel(ExtremeConditionResult result) {
+        if (result.findings().isEmpty()) {
+            summaryLabel.setText("No issues found (" + result.runsCompleted() + " runs)");
+        } else {
+            summaryLabel.setText(result.findings().size() + " findings from "
+                    + result.runsCompleted() + " runs");
+        }
+    }
+
+    private static String formatValue(double value) {
+        if (!Double.isInfinite(value) && !Double.isNaN(value)
+                && Double.compare(value, Math.rint(value)) == 0
+                && Math.abs(value) <= Long.MAX_VALUE) {
+            return Long.toString((long) value);
+        }
+        return Double.toString(value);
+    }
+
+    private static String formatAsText(ExtremeConditionResult result) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Extreme Condition Test Results\n");
+        sb.append("==============================\n\n");
+        if (result.findings().isEmpty()) {
+            sb.append("No issues found. Model is robust under extreme conditions.\n");
+        } else {
+            sb.append(result.findings().size()).append(" findings from ")
+                    .append(result.runsCompleted()).append(" runs\n\n");
+            for (ExtremeConditionFinding f : result.findings()) {
+                sb.append("[").append(f.condition().label()).append("] ");
+                sb.append(f.parameterName()).append(" = ").append(formatValue(f.appliedValue()));
+                sb.append(": ").append(f.description()).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ExtremeConditionDialogTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ExtremeConditionDialogTest.java
@@ -1,0 +1,165 @@
+package systems.courant.sd.app.canvas;
+
+import systems.courant.sd.sweep.ExtremeCondition;
+import systems.courant.sd.sweep.ExtremeConditionFinding;
+import systems.courant.sd.sweep.ExtremeConditionResult;
+
+import javafx.application.Platform;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ExtremeConditionDialog")
+@ExtendWith(ApplicationExtension.class)
+class ExtremeConditionDialogTest {
+
+    @Start
+    void start(Stage stage) {
+        // No-op — tests create their own dialog instances
+    }
+
+    private ExtremeConditionResult resultWith(int findingCount) {
+        List<ExtremeConditionFinding> findings = new java.util.ArrayList<>();
+        for (int i = 0; i < findingCount; i++) {
+            findings.add(new ExtremeConditionFinding(
+                    "param" + i, 1.0 + i, ExtremeCondition.ZERO, 0.0,
+                    "Stock" + i, i, "Test finding " + i));
+        }
+        return new ExtremeConditionResult(findings, 6, 6);
+    }
+
+    @Test
+    @DisplayName("showOrUpdate creates a new dialog when none is open")
+    void shouldCreateNewDialogWhenNoneOpen() {
+        assertThat(ExtremeConditionDialog.getOpenInstance()).isNull();
+
+        ExtremeConditionResult result = resultWith(1);
+        Platform.runLater(() -> ExtremeConditionDialog.showOrUpdate(result));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ExtremeConditionDialog instance = ExtremeConditionDialog.getOpenInstance();
+        assertThat(instance).isNotNull();
+        assertThat(instance.isShowing()).isTrue();
+
+        Platform.runLater(() -> instance.close());
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @Test
+    @DisplayName("showOrUpdate reuses existing dialog instead of creating a new one")
+    void shouldReuseExistingDialog() {
+        ExtremeConditionResult result1 = resultWith(1);
+        Platform.runLater(() -> ExtremeConditionDialog.showOrUpdate(result1));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ExtremeConditionDialog firstInstance = ExtremeConditionDialog.getOpenInstance();
+        assertThat(firstInstance).isNotNull();
+
+        ExtremeConditionResult result2 = resultWith(3);
+        Platform.runLater(() -> ExtremeConditionDialog.showOrUpdate(result2));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ExtremeConditionDialog secondInstance = ExtremeConditionDialog.getOpenInstance();
+        assertThat(secondInstance).isSameAs(firstInstance);
+
+        Platform.runLater(() -> firstInstance.close());
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @Test
+    @DisplayName("Closing the dialog clears the open instance")
+    void shouldClearInstanceOnClose() {
+        ExtremeConditionResult result = resultWith(1);
+        Platform.runLater(() -> ExtremeConditionDialog.showOrUpdate(result));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ExtremeConditionDialog instance = ExtremeConditionDialog.getOpenInstance();
+        assertThat(instance).isNotNull();
+
+        Platform.runLater(() -> instance.close());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(ExtremeConditionDialog.getOpenInstance()).isNull();
+    }
+
+    @Test
+    @DisplayName("showOrUpdate creates a new dialog after previous one was closed")
+    void shouldCreateNewDialogAfterPreviousClosed() {
+        ExtremeConditionResult result = resultWith(1);
+
+        Platform.runLater(() -> ExtremeConditionDialog.showOrUpdate(result));
+        WaitForAsyncUtils.waitForFxEvents();
+        ExtremeConditionDialog first = ExtremeConditionDialog.getOpenInstance();
+        Platform.runLater(() -> first.close());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        Platform.runLater(() -> ExtremeConditionDialog.showOrUpdate(result));
+        WaitForAsyncUtils.waitForFxEvents();
+        ExtremeConditionDialog second = ExtremeConditionDialog.getOpenInstance();
+
+        assertThat(second).isNotNull();
+        assertThat(second).isNotSameAs(first);
+
+        Platform.runLater(() -> second.close());
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @Test
+    @DisplayName("updateResult refreshes the displayed content")
+    void shouldUpdateResultContent() {
+        ExtremeConditionResult result1 = resultWith(1);
+        Platform.runLater(() -> ExtremeConditionDialog.showOrUpdate(result1));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ExtremeConditionDialog instance = ExtremeConditionDialog.getOpenInstance();
+        assertThat(instance).isNotNull();
+
+        ExtremeConditionResult result2 = resultWith(5);
+        Platform.runLater(() -> instance.updateResult(result2));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(ExtremeConditionDialog.getOpenInstance()).isSameAs(instance);
+        assertThat(instance.isShowing()).isTrue();
+
+        Platform.runLater(() -> instance.close());
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @Test
+    @DisplayName("Dialog shows empty state when no findings")
+    void shouldShowEmptyState() {
+        ExtremeConditionResult result = new ExtremeConditionResult(List.of(), 6, 6);
+        Platform.runLater(() -> ExtremeConditionDialog.showOrUpdate(result));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ExtremeConditionDialog instance = ExtremeConditionDialog.getOpenInstance();
+        assertThat(instance).isNotNull();
+        assertThat(instance.isShowing()).isTrue();
+
+        Platform.runLater(() -> instance.close());
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @Test
+    @DisplayName("ExtremeConditionDialog extends Dialog")
+    void shouldExtendDialog() {
+        ExtremeConditionResult result = resultWith(1);
+        Platform.runLater(() -> ExtremeConditionDialog.showOrUpdate(result));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ExtremeConditionDialog instance = ExtremeConditionDialog.getOpenInstance();
+        assertThat(instance).isInstanceOf(javafx.scene.control.Dialog.class);
+
+        Platform.runLater(() -> instance.close());
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+}

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/ExtremeCondition.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/ExtremeCondition.java
@@ -1,0 +1,77 @@
+package systems.courant.sd.sweep;
+
+/**
+ * Defines the extreme conditions applied to parameters during extreme-condition testing.
+ * Each condition transforms a baseline parameter value into an extreme value designed
+ * to stress-test the model.
+ */
+public enum ExtremeCondition {
+
+    /**
+     * Sets the parameter to zero.
+     */
+    ZERO {
+        @Override
+        public double apply(double baseline) {
+            return 0.0;
+        }
+
+        @Override
+        public String label() {
+            return "Zero";
+        }
+    },
+
+    /**
+     * Sets the parameter to 10x its baseline value.
+     * If baseline is zero, uses 10.0 instead.
+     */
+    TEN_X {
+        @Override
+        public double apply(double baseline) {
+            if (baseline == 0.0) {
+                return 10.0;
+            }
+            return baseline * 10.0;
+        }
+
+        @Override
+        public String label() {
+            return "10x";
+        }
+    },
+
+    /**
+     * Negates the parameter value. If baseline is positive, returns negative (and vice versa).
+     * If baseline is zero, uses -1.0.
+     */
+    NEGATIVE {
+        @Override
+        public double apply(double baseline) {
+            if (baseline == 0.0) {
+                return -1.0;
+            }
+            return -baseline;
+        }
+
+        @Override
+        public String label() {
+            return "Negative";
+        }
+    };
+
+    /**
+     * Computes the extreme value for the given baseline parameter value.
+     *
+     * @param baseline the original parameter value
+     * @return the extreme test value
+     */
+    public abstract double apply(double baseline);
+
+    /**
+     * Returns a human-readable label for this condition.
+     *
+     * @return the display label
+     */
+    public abstract String label();
+}

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/ExtremeConditionFinding.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/ExtremeConditionFinding.java
@@ -1,0 +1,25 @@
+package systems.courant.sd.sweep;
+
+/**
+ * A single finding from an extreme-condition test run. All findings are informational —
+ * extreme conditions are expected to produce unusual behavior. The goal is awareness,
+ * not enforcement.
+ *
+ * @param parameterName        the parameter that was set to an extreme value
+ * @param baselineValue        the original parameter value
+ * @param condition            the extreme condition applied (ZERO, TEN_X, NEGATIVE)
+ * @param appliedValue         the numeric value used for the test
+ * @param affectedVariable     the stock, flow, or variable where the problem occurred
+ * @param stepNumber           the simulation step where the problem was detected (-1 if N/A)
+ * @param description          a human-readable description of the finding
+ */
+public record ExtremeConditionFinding(
+        String parameterName,
+        double baselineValue,
+        ExtremeCondition condition,
+        double appliedValue,
+        String affectedVariable,
+        long stepNumber,
+        String description
+) {
+}

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/ExtremeConditionResult.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/ExtremeConditionResult.java
@@ -1,0 +1,21 @@
+package systems.courant.sd.sweep;
+
+import java.util.List;
+
+/**
+ * The result of running extreme-condition tests on a model.
+ *
+ * @param findings      the list of findings (anomalies detected)
+ * @param runsCompleted the number of simulation runs completed (includes failed runs)
+ * @param totalRuns     the total number of runs attempted
+ */
+public record ExtremeConditionResult(
+        List<ExtremeConditionFinding> findings,
+        int runsCompleted,
+        int totalRuns
+) {
+
+    public ExtremeConditionResult {
+        findings = List.copyOf(findings);
+    }
+}

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/ExtremeConditionTest.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/ExtremeConditionTest.java
@@ -1,0 +1,310 @@
+package systems.courant.sd.sweep;
+
+import systems.courant.sd.NonFiniteValueException;
+import systems.courant.sd.Simulation;
+import systems.courant.sd.SimulationCancelledException;
+import systems.courant.sd.measure.Quantity;
+import systems.courant.sd.measure.TimeUnit;
+import systems.courant.sd.model.compile.CompiledModel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Runs extreme-condition tests on a model by systematically setting each parameter to
+ * extreme values (zero, 10x baseline, negative) and inspecting the results for anomalies
+ * such as NaN, Infinity, or negative stock values.
+ *
+ * <p>This implements Forrester &amp; Senge's extreme-condition validation test:
+ * "Does the model behave reasonably when inputs are zero? Very large? Negative?"
+ *
+ * <pre>{@code
+ * ExtremeConditionResult result = ExtremeConditionTest.builder()
+ *     .compiledModelFactory(ModelDefinitionFactory.createFactory(def, settings))
+ *     .parameters(def.parameters())
+ *     .timeStep(timeStep)
+ *     .duration(duration)
+ *     .build()
+ *     .execute();
+ * }</pre>
+ */
+public class ExtremeConditionTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ExtremeConditionTest.class);
+
+    /** Default threshold for "unreasonably large" values. */
+    private static final double DEFAULT_BOUND_THRESHOLD = 1e15;
+
+    private static final Pattern STOCK_NAME_PATTERN = Pattern.compile("Stock '([^']+)'");
+    private static final Pattern FLOW_NAME_PATTERN = Pattern.compile("Flow '([^']+)'");
+    private static final Pattern STEP_PATTERN = Pattern.compile("at step (\\d+)");
+
+    private final Function<Map<String, Double>, CompiledModel> compiledModelFactory;
+    private final List<ParameterInfo> parameters;
+    private final TimeUnit timeStep;
+    private final Quantity duration;
+    private final double boundThreshold;
+
+    private ExtremeConditionTest(Builder builder) {
+        this.compiledModelFactory = builder.compiledModelFactory;
+        this.parameters = List.copyOf(builder.parameters);
+        this.timeStep = builder.timeStep;
+        this.duration = builder.duration;
+        this.boundThreshold = builder.boundThreshold;
+    }
+
+    /**
+     * Executes extreme-condition tests for all parameters and conditions.
+     *
+     * @return the test results containing all findings
+     * @throws SimulationCancelledException if the thread is interrupted during execution
+     */
+    public ExtremeConditionResult execute() {
+        List<ExtremeConditionFinding> findings = new ArrayList<>();
+        int totalRuns = parameters.size() * ExtremeCondition.values().length;
+        int completed = 0;
+
+        for (ParameterInfo param : parameters) {
+            for (ExtremeCondition condition : ExtremeCondition.values()) {
+                if (Thread.interrupted()) {
+                    throw new SimulationCancelledException(
+                            "Extreme condition test cancelled at run " + completed + "/" + totalRuns);
+                }
+
+                double extremeValue = condition.apply(param.baselineValue());
+                runSingleTest(param, condition, extremeValue, findings);
+                completed++;
+            }
+        }
+
+        return new ExtremeConditionResult(findings, completed, totalRuns);
+    }
+
+    private void runSingleTest(ParameterInfo param, ExtremeCondition condition,
+                               double extremeValue, List<ExtremeConditionFinding> findings) {
+        try {
+            CompiledModel compiled = compiledModelFactory.apply(
+                    Map.of(param.name(), extremeValue));
+            Simulation simulation = compiled.createSimulation(timeStep, duration);
+            simulation.setStrictMode(true);
+
+            RunResult runResult = new RunResult(Map.of(param.name(), extremeValue));
+            simulation.addEventHandler(runResult);
+            simulation.execute();
+
+            // Post-run inspection: check for negative stocks and extreme values
+            inspectRunResult(param, condition, extremeValue, runResult, findings);
+        } catch (NonFiniteValueException e) {
+            String affectedVar = extractVariableName(e.getMessage());
+            long step = extractStepNumber(e.getMessage());
+            findings.add(new ExtremeConditionFinding(
+                    param.name(), param.baselineValue(), condition, extremeValue,
+                    affectedVar, step, e.getMessage()));
+        } catch (SimulationCancelledException e) {
+            throw e;
+        } catch (Exception e) {
+            log.debug("Extreme condition test failed for {} = {} ({}): {}",
+                    param.name(), extremeValue, condition.label(), e.getMessage());
+            findings.add(new ExtremeConditionFinding(
+                    param.name(), param.baselineValue(), condition, extremeValue,
+                    "", -1, "Simulation failed: " + e.getMessage()));
+        }
+    }
+
+    private void inspectRunResult(ParameterInfo param, ExtremeCondition condition,
+                                  double extremeValue, RunResult runResult,
+                                  List<ExtremeConditionFinding> findings) {
+        List<String> stockNames = runResult.getStockNames();
+        List<String> variableNames = runResult.getVariableNames();
+
+        for (int stepIdx = 0; stepIdx < runResult.getStepCount(); stepIdx++) {
+            long step = runResult.getStep(stepIdx);
+            double[] stockValues = runResult.getStockValuesAtStep(stepIdx);
+            double[] varValues = runResult.getVariableValuesAtStep(stepIdx);
+
+            // Check stocks for negative values and extreme magnitudes
+            for (int s = 0; s < stockNames.size(); s++) {
+                double value = stockValues[s];
+                if (value < 0) {
+                    findings.add(new ExtremeConditionFinding(
+                            param.name(), param.baselineValue(), condition, extremeValue,
+                            stockNames.get(s), step,
+                            "Stock '" + stockNames.get(s) + "' went negative ("
+                                    + value + ") at step " + step));
+                    // Only report first negative occurrence per stock per run
+                    return;
+                }
+                if (Math.abs(value) > boundThreshold) {
+                    findings.add(new ExtremeConditionFinding(
+                            param.name(), param.baselineValue(), condition, extremeValue,
+                            stockNames.get(s), step,
+                            "Stock '" + stockNames.get(s) + "' exceeded bound threshold ("
+                                    + value + ") at step " + step));
+                    return;
+                }
+            }
+
+            // Check variables for extreme magnitudes
+            for (int v = 0; v < variableNames.size(); v++) {
+                double value = varValues[v];
+                if (!Double.isFinite(value)) {
+                    findings.add(new ExtremeConditionFinding(
+                            param.name(), param.baselineValue(), condition, extremeValue,
+                            variableNames.get(v), step,
+                            "Variable '" + variableNames.get(v) + "' became "
+                                    + value + " at step " + step));
+                    return;
+                }
+                if (Math.abs(value) > boundThreshold) {
+                    findings.add(new ExtremeConditionFinding(
+                            param.name(), param.baselineValue(), condition, extremeValue,
+                            variableNames.get(v), step,
+                            "Variable '" + variableNames.get(v) + "' exceeded bound threshold ("
+                                    + value + ") at step " + step));
+                    return;
+                }
+            }
+        }
+    }
+
+    private static String extractVariableName(String message) {
+        if (message == null) {
+            return "";
+        }
+        Matcher stockMatcher = STOCK_NAME_PATTERN.matcher(message);
+        if (stockMatcher.find()) {
+            return stockMatcher.group(1);
+        }
+        Matcher flowMatcher = FLOW_NAME_PATTERN.matcher(message);
+        if (flowMatcher.find()) {
+            return flowMatcher.group(1);
+        }
+        return "";
+    }
+
+    private static long extractStepNumber(String message) {
+        if (message == null) {
+            return -1;
+        }
+        Matcher matcher = STEP_PATTERN.matcher(message);
+        if (matcher.find()) {
+            return Long.parseLong(matcher.group(1));
+        }
+        return -1;
+    }
+
+    /**
+     * Returns a new builder for configuring an extreme-condition test.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Holds name and baseline value for a parameter under test.
+     */
+    record ParameterInfo(String name, double baselineValue) {
+    }
+
+    /**
+     * Builder for {@link ExtremeConditionTest}.
+     */
+    public static class Builder {
+
+        private Function<Map<String, Double>, CompiledModel> compiledModelFactory;
+        private final List<ParameterInfo> parameters = new ArrayList<>();
+        private TimeUnit timeStep;
+        private Quantity duration;
+        private double boundThreshold = DEFAULT_BOUND_THRESHOLD;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the factory function that builds a fresh compiled model with parameter overrides.
+         *
+         * @param compiledModelFactory a function that receives parameter overrides and returns a compiled model
+         * @return this builder
+         */
+        public Builder compiledModelFactory(
+                Function<Map<String, Double>, CompiledModel> compiledModelFactory) {
+            this.compiledModelFactory = compiledModelFactory;
+            return this;
+        }
+
+        /**
+         * Adds a parameter to test with its baseline value.
+         *
+         * @param name          the parameter name
+         * @param baselineValue the original parameter value
+         * @return this builder
+         */
+        public Builder parameter(String name, double baselineValue) {
+            this.parameters.add(new ParameterInfo(name, baselineValue));
+            return this;
+        }
+
+        /**
+         * Sets the simulation time step.
+         *
+         * @param timeStep the time unit for each step
+         * @return this builder
+         */
+        public Builder timeStep(TimeUnit timeStep) {
+            this.timeStep = timeStep;
+            return this;
+        }
+
+        /**
+         * Sets the simulation duration.
+         *
+         * @param duration the total simulation time
+         * @return this builder
+         */
+        public Builder duration(Quantity duration) {
+            this.duration = duration;
+            return this;
+        }
+
+        /**
+         * Sets the threshold for detecting unreasonably large values.
+         * Defaults to 1e15.
+         *
+         * @param boundThreshold the threshold value
+         * @return this builder
+         */
+        public Builder boundThreshold(double boundThreshold) {
+            this.boundThreshold = boundThreshold;
+            return this;
+        }
+
+        /**
+         * Builds the {@link ExtremeConditionTest} instance.
+         *
+         * @return a configured test ready to execute
+         * @throws IllegalStateException if any required field is missing
+         */
+        public ExtremeConditionTest build() {
+            if (compiledModelFactory == null) {
+                throw new IllegalStateException("compiledModelFactory is required");
+            }
+            if (parameters.isEmpty()) {
+                throw new IllegalStateException("At least one parameter is required");
+            }
+            if (timeStep == null) {
+                throw new IllegalStateException("timeStep is required");
+            }
+            if (duration == null) {
+                throw new IllegalStateException("duration is required");
+            }
+            return new ExtremeConditionTest(this);
+        }
+    }
+}

--- a/courant-engine/src/test/java/systems/courant/sd/sweep/ExtremeConditionTestTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/sweep/ExtremeConditionTestTest.java
@@ -1,0 +1,308 @@
+package systems.courant.sd.sweep;
+
+import systems.courant.sd.model.compile.CompiledModel;
+import systems.courant.sd.model.compile.ModelCompiler;
+import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.ModelDefinitionBuilder;
+import systems.courant.sd.model.def.VariableDef;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ExtremeConditionTest")
+class ExtremeConditionTestTest {
+
+    /**
+     * Creates a compiled model factory that applies parameter overrides to the given
+     * base definition, recompiling each time.
+     */
+    private static Function<Map<String, Double>, CompiledModel> factoryFor(ModelDefinition baseDef) {
+        return overrides -> {
+            List<VariableDef> updatedVars = new ArrayList<>();
+            for (VariableDef v : baseDef.variables()) {
+                if (overrides.containsKey(v.name())) {
+                    updatedVars.add(new VariableDef(v.name(), v.comment(),
+                            VariableDef.formatValue(overrides.get(v.name())), v.unit()));
+                } else {
+                    updatedVars.add(v);
+                }
+            }
+            ModelDefinitionBuilder b = baseDef.toBuilder();
+            b.clearVariables();
+            updatedVars.forEach(b::variable);
+            ModelDefinition overridden = b.build();
+            return new ModelCompiler().compile(overridden);
+        };
+    }
+
+    @Nested
+    @DisplayName("NaN/Infinity detection")
+    class NanDetection {
+
+        @Test
+        @DisplayName("should detect NaN from division by zero when parameter is set to zero")
+        void shouldDetectNaNFromDivisionByZero() {
+            // Model: Stock "Population" with inflow "growth" = Population * growth_rate / divisor
+            // When divisor = 0, flow produces NaN/Infinity
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("DivByZero")
+                    .stock("Population", 100, "People")
+                    .flow("growth", "Population * growth_rate / divisor", "Day",
+                            null, "Population")
+                    .variable("growth_rate", "0.1", "1/Day")
+                    .variable("divisor", "10", "Dimensionless")
+                    .defaultSimulation("Day", 10, "Day")
+                    .build();
+
+            ExtremeConditionResult result = ExtremeConditionTest.builder()
+                    .compiledModelFactory(factoryFor(def))
+                    .parameter("divisor", 10.0)
+                    .timeStep(resolveTimeStep(def))
+                    .duration(resolveDuration(def))
+                    .build()
+                    .execute();
+
+            // The ZERO condition should trigger a NaN/Infinity finding
+            assertThat(result.findings()).anySatisfy(f -> {
+                assertThat(f.condition()).isEqualTo(ExtremeCondition.ZERO);
+                assertThat(f.parameterName()).isEqualTo("divisor");
+                assertThat(f.appliedValue()).isEqualTo(0.0);
+            });
+        }
+
+        @Test
+        @DisplayName("should detect Infinity from unbounded growth with 10x parameter")
+        void shouldDetectInfinityFromUnboundedGrowth() {
+            // Model with exponential growth: growth = Population * rate
+            // With rate = 10x, growth is extremely fast and can overflow
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("ExponentialGrowth")
+                    .stock("Population", 1000, "People")
+                    .flow("growth", "Population * rate", "Day",
+                            null, "Population")
+                    .variable("rate", "0.5", "1/Day")
+                    .defaultSimulation("Day", 100, "Day")
+                    .build();
+
+            ExtremeConditionResult result = ExtremeConditionTest.builder()
+                    .compiledModelFactory(factoryFor(def))
+                    .parameter("rate", 0.5)
+                    .timeStep(resolveTimeStep(def))
+                    .duration(resolveDuration(def))
+                    .boundThreshold(1e12)
+                    .build()
+                    .execute();
+
+            // With rate = 5.0 (10x), exponential growth should exceed bounds
+            assertThat(result.findings()).anySatisfy(f -> {
+                assertThat(f.condition()).isEqualTo(ExtremeCondition.TEN_X);
+                assertThat(f.parameterName()).isEqualTo("rate");
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("Negative stock detection")
+    class NegativeStockDetection {
+
+        @Test
+        @DisplayName("should detect negative stock when outflow exceeds stock value")
+        void shouldDetectNegativeStock() {
+            // Model: Stock "Inventory" with outflow "sales" = sales_rate
+            // When sales_rate goes 10x, it drains inventory below zero
+            // Must use ALLOW policy since the default clamps to zero
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Inventory")
+                    .stock("Inventory", null, 100, "Units", "ALLOW")
+                    .flow("sales", "sales_rate", "Day",
+                            "Inventory", null)
+                    .variable("sales_rate", "5", "Units/Day")
+                    .defaultSimulation("Day", 30, "Day")
+                    .build();
+
+            ExtremeConditionResult result = ExtremeConditionTest.builder()
+                    .compiledModelFactory(factoryFor(def))
+                    .parameter("sales_rate", 5.0)
+                    .timeStep(resolveTimeStep(def))
+                    .duration(resolveDuration(def))
+                    .build()
+                    .execute();
+
+            // 10x sales_rate = 50/day for 30 days should drain inventory
+            assertThat(result.findings()).anySatisfy(f -> {
+                assertThat(f.condition()).isEqualTo(ExtremeCondition.TEN_X);
+                assertThat(f.parameterName()).isEqualTo("sales_rate");
+                assertThat(f.affectedVariable()).isEqualTo("Inventory");
+                assertThat(f.description()).contains("negative");
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge cases in extreme value generation")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("should handle zero baseline: 10x becomes 10.0, negative becomes -1.0")
+        void shouldHandleZeroBaseline() {
+            assertThat(ExtremeCondition.TEN_X.apply(0.0)).isEqualTo(10.0);
+            assertThat(ExtremeCondition.NEGATIVE.apply(0.0)).isEqualTo(-1.0);
+            assertThat(ExtremeCondition.ZERO.apply(0.0)).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("should handle negative baseline: negative flips to positive")
+        void shouldHandleNegativeBaseline() {
+            assertThat(ExtremeCondition.NEGATIVE.apply(-5.0)).isEqualTo(5.0);
+            assertThat(ExtremeCondition.TEN_X.apply(-5.0)).isEqualTo(-50.0);
+            assertThat(ExtremeCondition.ZERO.apply(-5.0)).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("should handle positive baseline normally")
+        void shouldHandlePositiveBaseline() {
+            assertThat(ExtremeCondition.ZERO.apply(10.0)).isEqualTo(0.0);
+            assertThat(ExtremeCondition.TEN_X.apply(10.0)).isEqualTo(100.0);
+            assertThat(ExtremeCondition.NEGATIVE.apply(10.0)).isEqualTo(-10.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("Robust model")
+    class RobustModel {
+
+        @Test
+        @DisplayName("should return empty findings for a model that survives all extreme conditions")
+        void shouldReturnEmptyFindingsForRobustModel() {
+            // Simple linear decay: Stock = 100, outflow = MIN(Stock, rate)
+            // Clamped outflow so it never goes negative, bounded, and no division
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Robust")
+                    .stock("Level", 100, "Units")
+                    .flow("drain", "MIN(Level, drain_rate)", "Day",
+                            "Level", null)
+                    .variable("drain_rate", "5", "Units/Day")
+                    .defaultSimulation("Day", 10, "Day")
+                    .build();
+
+            ExtremeConditionResult result = ExtremeConditionTest.builder()
+                    .compiledModelFactory(factoryFor(def))
+                    .parameter("drain_rate", 5.0)
+                    .timeStep(resolveTimeStep(def))
+                    .duration(resolveDuration(def))
+                    .build()
+                    .execute();
+
+            assertThat(result.findings()).isEmpty();
+            assertThat(result.runsCompleted()).isEqualTo(3);
+            assertThat(result.totalRuns()).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("Run counts")
+    class RunCounts {
+
+        @Test
+        @DisplayName("should report correct run counts for multiple parameters")
+        void shouldReportCorrectRunCounts() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("TwoParam")
+                    .stock("X", 50, "Units")
+                    .flow("change", "rate_a + rate_b", "Day", null, "X")
+                    .variable("rate_a", "1", "Units/Day")
+                    .variable("rate_b", "2", "Units/Day")
+                    .defaultSimulation("Day", 5, "Day")
+                    .build();
+
+            ExtremeConditionResult result = ExtremeConditionTest.builder()
+                    .compiledModelFactory(factoryFor(def))
+                    .parameter("rate_a", 1.0)
+                    .parameter("rate_b", 2.0)
+                    .timeStep(resolveTimeStep(def))
+                    .duration(resolveDuration(def))
+                    .build()
+                    .execute();
+
+            // 2 parameters × 3 conditions = 6 runs
+            assertThat(result.runsCompleted()).isEqualTo(6);
+            assertThat(result.totalRuns()).isEqualTo(6);
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder validation")
+    class BuilderValidation {
+
+        @Test
+        @DisplayName("should reject missing compiled model factory")
+        void shouldRejectMissingFactory() {
+            assertThatThrownBy(() -> ExtremeConditionTest.builder()
+                    .parameter("x", 1.0)
+                    .timeStep(systems.courant.sd.measure.Units.DAY)
+                    .duration(systems.courant.sd.measure.units.time.Times.days(10))
+                    .build())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("compiledModelFactory");
+        }
+
+        @Test
+        @DisplayName("should reject empty parameters")
+        void shouldRejectEmptyParameters() {
+            assertThatThrownBy(() -> ExtremeConditionTest.builder()
+                    .compiledModelFactory(params -> null)
+                    .timeStep(systems.courant.sd.measure.Units.DAY)
+                    .duration(systems.courant.sd.measure.units.time.Times.days(10))
+                    .build())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("parameter");
+        }
+
+        @Test
+        @DisplayName("should reject missing time step")
+        void shouldRejectMissingTimeStep() {
+            assertThatThrownBy(() -> ExtremeConditionTest.builder()
+                    .compiledModelFactory(params -> null)
+                    .parameter("x", 1.0)
+                    .duration(systems.courant.sd.measure.units.time.Times.days(10))
+                    .build())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("timeStep");
+        }
+
+        @Test
+        @DisplayName("should reject missing duration")
+        void shouldRejectMissingDuration() {
+            assertThatThrownBy(() -> ExtremeConditionTest.builder()
+                    .compiledModelFactory(params -> null)
+                    .parameter("x", 1.0)
+                    .timeStep(systems.courant.sd.measure.Units.DAY)
+                    .build())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("duration");
+        }
+    }
+
+    // --- Utility methods ---
+
+    private static systems.courant.sd.measure.TimeUnit resolveTimeStep(ModelDefinition def) {
+        return new systems.courant.sd.measure.UnitRegistry()
+                .resolveTimeUnit(def.defaultSimulation().timeStep());
+    }
+
+    private static systems.courant.sd.measure.Quantity resolveDuration(ModelDefinition def) {
+        systems.courant.sd.measure.UnitRegistry registry = new systems.courant.sd.measure.UnitRegistry();
+        systems.courant.sd.measure.TimeUnit durUnit = registry.resolveTimeUnit(
+                def.defaultSimulation().durationUnit());
+        return new systems.courant.sd.measure.Quantity(def.defaultSimulation().duration(), durUnit);
+    }
+}


### PR DESCRIPTION
Closes #400

## Summary
- Implement Forrester & Senge's extreme-condition validation test
- For each parameter, runs the model with zero, 10x, and negative values
- Detects NaN/Infinity (via strict mode), negative stocks, and values exceeding bound threshold
- Results shown in a singleton table dialog following ValidationDialog pattern

## Test plan
- [x] 11 engine unit tests (NaN detection, negative stocks, edge cases, builder validation)
- [x] 6 TestFX dialog tests (singleton behavior, content update, empty state)
- [x] Full test suite passes
- [x] SpotBugs clean