### PR TITLE
Fix duplicate non-finite warning, dominanceTab close handler, and UndoManager failure path

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/DashboardPanel.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/DashboardPanel.java
@@ -317,6 +317,8 @@ public class DashboardPanel extends VBox {
                 multiSweepTab = null;
             } else if (tab == sensitivityTab) {
                 sensitivityTab = null;
+            } else if (tab == dominanceTab) {
+                dominanceTab = null;
             } else if (tab == phasePlotTab) {
                 phasePlotTab = null;
             }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/UndoManager.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/UndoManager.java
@@ -218,6 +218,17 @@ public class UndoManager implements AutoCloseable {
     }
 
     /**
+     * Pushes a raw entry onto the undo stack. Package-private for testing.
+     */
+    void pushEntry(UndoEntry entry) {
+        undoStack.push(entry);
+        redoStack.clear();
+        if (undoStack.size() > MAX_UNDO) {
+            undoStack.removeLast();
+        }
+    }
+
+    /**
      * Clears both undo and redo stacks.
      */
     public void clear() {
@@ -264,7 +275,12 @@ public class UndoManager implements AutoCloseable {
         // Prefer non-blocking getNow() to avoid stalling the FX thread.
         // Fall back to a bounded get() with a 5-second timeout to prevent
         // indefinite blocking if something goes wrong.
-        CompressedData data = entry.future().getNow(null);
+        CompressedData data;
+        try {
+            data = entry.future().getNow(null);
+        } catch (java.util.concurrent.CompletionException e) {
+            throw new IllegalStateException("Undo compression failed", e.getCause());
+        }
         if (data == null) {
             try {
                 data = entry.future().get(5, TimeUnit.SECONDS);

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/UndoManagerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/UndoManagerTest.java
@@ -379,18 +379,17 @@ class UndoManagerTest {
 
         @Test
         void shouldThrowOnCompressionFailure() {
-            // Create an entry with a future that completes exceptionally
+            // Inject an entry whose compression future completed exceptionally
+            // and whose rawSnapshot is null (simulating a lost snapshot)
             CompletableFuture<UndoManager.CompressedData> failedFuture = new CompletableFuture<>();
             failedFuture.completeExceptionally(new RuntimeException("compression failed"));
             UndoManager.UndoEntry entry = new UndoManager.UndoEntry(
                     failedFuture, "Bad", null);
+            manager.pushEntry(entry);
 
-            // Accessing via reflection-free path: push a known-broken entry
-            // We test the decompress behavior through the public API indirectly
-            // by verifying that a normal round-trip works correctly
-            manager.pushUndo(snapshot("S1"), "Normal");
-            UndoManager.Snapshot result = manager.undo(snapshot("Current")).orElseThrow();
-            assertSnapshotName(result, "S1");
+            assertThatThrownBy(() -> manager.undo(snapshot("Current")))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("compression failed");
         }
 
         @Test

--- a/courant-engine/src/main/java/systems/courant/sd/Simulation.java
+++ b/courant-engine/src/main/java/systems/courant/sd/Simulation.java
@@ -78,7 +78,6 @@ public class Simulation {
 
     private final List<EventHandler> eventHandlers = new ArrayList<>();
 
-    private final Set<String> warnedNonFiniteStocks = new java.util.HashSet<>();
 
     public Simulation(Model model, TimeUnit timeStep, Quantity duration) {
         this(model, timeStep, duration, LocalDateTime.now());
@@ -161,7 +160,6 @@ public class Simulation {
         currentStep = 0;
         currentDateTime = startTime;
         elapsedTime = Duration.ZERO;
-        warnedNonFiniteStocks.clear();
         clearHistory();
 
         fireStartEvent(new SimulationStartEvent(this));
@@ -285,24 +283,18 @@ public class Simulation {
         }
 
         // Phase 2: Apply all deltas simultaneously.
+        // In strict mode, non-finite values throw immediately. Otherwise,
+        // Stock.setValue() handles non-finite values by retaining the previous
+        // value and logging a warning, so no additional guard is needed.
         for (Stock stock : stocks) {
             double oldValue = stock.getQuantity().getValue();
             double newValue = oldValue + deltas.get(stock);
-            if (!Double.isFinite(newValue)) {
-                if (strictMode) {
-                    throw new NonFiniteValueException(
-                            "Stock '" + stock.getName() + "' became " + newValue
-                                    + " at step " + currentStep
-                                    + " (previous value: " + oldValue
-                                    + ", delta: " + deltas.get(stock) + ")");
-                }
-                if (warnedNonFiniteStocks.add(stock.getName())) {
-                    log.warn("Stock '{}' became {} at step {} (previous value: {}, delta: {})"
-                                    + " — keeping previous value",
-                            stock.getName(), newValue, currentStep, oldValue, deltas.get(stock));
-                }
-                // Keep the previous value instead of crashing
-                continue;
+            if (strictMode && !Double.isFinite(newValue)) {
+                throw new NonFiniteValueException(
+                        "Stock '" + stock.getName() + "' became " + newValue
+                                + " at step " + currentStep
+                                + " (previous value: " + oldValue
+                                + ", delta: " + deltas.get(stock) + ")");
             }
             stock.setValue(newValue);
         }


### PR DESCRIPTION
## Summary
- **#588**: Remove `warnedNonFiniteStocks` from Simulation — `Stock.setValue()` owns non-finite handling. Simulation only guards in `strictMode`.
- **#378**: Add missing `dominanceTab = null` in `DashboardPanel.ensureTab` close handler.
- **#589**: Fix `UndoManager.decompress()` to catch `CompletionException` from `getNow()` on failed futures. Add `pushEntry()` test hook, rewrite test to exercise failure path.

## Test plan
- [x] All tests pass (full reactor)
- [x] SpotBugs clean
- [x] `shouldThrowOnCompressionFailure` now actually tests the failure path
- [x] Existing non-finite detection tests still pass end-to-end

Closes #588, closes #378, closes #589