### PR TITLE
Refactor large methods, fix bugs, harden utilities, add CI matrix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120
+
+[*.{xml,yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -21,15 +25,18 @@ jobs:
           cache: maven
 
       - name: Build and test
-        run: mvn verify -B -q
+        run: mvn verify -B
+
+      - name: Checkstyle
+        run: mvn checkstyle:check -B
 
       - name: SpotBugs analysis
-        run: mvn compile spotbugs:check -B -q
+        run: mvn compile spotbugs:check -B
 
       - name: Upload coverage reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-reports
+          name: coverage-reports-${{ matrix.os }}
           path: '**/target/site/jacoco/'
           retention-days: 14

--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -176,6 +176,59 @@ public class ModelWindow {
             simulationController.runSimulation();
         });
 
+        configureToolBarAndNavigation();
+        configureCanvasCallbacks();
+        createRightPanel();
+
+        MenuBar menuBar = createMenuBar();
+        topContainer = new VBox(menuBar, toolBar, loopNavigatorBar, breadcrumbBar);
+
+        root = new BorderPane();
+        root.setId("modelWindowRoot");
+
+        configureStartScreen();
+
+        Scene scene = new Scene(root, 1200, 800);
+        stage.setScene(scene);
+        stage.setOnCloseRequest(event -> {
+            if (!fileController.confirmDiscardChanges()) {
+                event.consume();
+                return;
+            }
+            close();
+        });
+
+        commandPalette = new CommandPalette(this::buildCommands);
+        scene.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.isShortcutDown() && event.getCode() == KeyCode.K) {
+                commandPalette.show(stage);
+                event.consume();
+            }
+            if (event.getCode() == KeyCode.F1) {
+                showContextHelp();
+                event.consume();
+            }
+        });
+
+        updateTitle();
+
+        // When the window gains focus (e.g. switching from another window),
+        // give focus to the canvas so keyboard shortcuts (Ctrl+V, etc.) work
+        // immediately without requiring a click first.
+        stage.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
+            if (isFocused) {
+                Node focused = scene.getFocusOwner();
+                if (focused == null || focused == root
+                        || !(focused instanceof javafx.scene.control.TextInputControl)) {
+                    canvas.requestFocus();
+                }
+            }
+        });
+
+        canvas.requestFocus();
+    }
+
+    private void configureToolBarAndNavigation() {
         toolBar = new CanvasToolBar();
         toolBar.setOnToolChanged(tool -> {
             canvas.setActiveTool(tool);
@@ -216,6 +269,9 @@ public class ModelWindow {
         });
         toolBar.setOnValidateClicked(simulationController::validateModel);
         toolBar.setOnSearchClicked(() -> commandPalette.show(stage));
+    }
+
+    private void configureCanvasCallbacks() {
         canvas.setToolBar(toolBar);
         canvas.setOnStatusChanged(() -> {
             updateStatusBar();
@@ -247,7 +303,9 @@ public class ModelWindow {
             canvas.requestFocus();
         });
         canvas.setOnNavigationChanged(this::updateBreadcrumb);
+    }
 
+    private void createRightPanel() {
         Pane canvasPane = new Pane(canvas);
         canvas.widthProperty().bind(canvasPane.widthProperty());
         canvas.heightProperty().bind(canvasPane.heightProperty());
@@ -282,14 +340,9 @@ public class ModelWindow {
         editorSplitPane = new SplitPane(canvasPane, rightTabPane);
         editorSplitPane.setDividerPositions(0.75);
         SplitPane.setResizableWithParent(rightTabPane, false);
+    }
 
-        MenuBar menuBar = createMenuBar();
-        topContainer = new VBox(menuBar, toolBar, loopNavigatorBar, breadcrumbBar);
-
-        root = new BorderPane();
-        root.setId("modelWindowRoot");
-
-        // Show start screen instead of blank editor
+    private void configureStartScreen() {
         StartScreen startScreen = new StartScreen();
         startScreen.setOnNewModel(() -> {
             showEditor();
@@ -332,45 +385,6 @@ public class ModelWindow {
         root.setTop(topContainer);
         root.setCenter(startScreen);
         root.setBottom(statusBar);
-
-        Scene scene = new Scene(root, 1200, 800);
-        stage.setScene(scene);
-        stage.setOnCloseRequest(event -> {
-            if (!fileController.confirmDiscardChanges()) {
-                event.consume();
-                return;
-            }
-            close();
-        });
-
-        commandPalette = new CommandPalette(this::buildCommands);
-        scene.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            if (event.isShortcutDown() && event.getCode() == KeyCode.K) {
-                commandPalette.show(stage);
-                event.consume();
-            }
-            if (event.getCode() == KeyCode.F1) {
-                showContextHelp();
-                event.consume();
-            }
-        });
-
-        updateTitle();
-
-        // When the window gains focus (e.g. switching from another window),
-        // give focus to the canvas so keyboard shortcuts (Ctrl+V, etc.) work
-        // immediately without requiring a click first.
-        stage.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
-            if (isFocused) {
-                Node focused = scene.getFocusOwner();
-                if (focused == null || focused == root
-                        || !(focused instanceof javafx.scene.control.TextInputControl)) {
-                    canvas.requestFocus();
-                }
-            }
-        });
-
-        canvas.requestFocus();
     }
 
     /**
@@ -391,6 +405,16 @@ public class ModelWindow {
     }
 
     private MenuBar createMenuBar() {
+        Menu fileMenu = createFileMenu();
+        Menu editMenu = createEditMenu();
+        Menu viewMenu = createViewMenu();
+        Menu simulateMenu = createSimulateMenu();
+        Menu helpMenu = createHelpMenu();
+
+        return new MenuBar(fileMenu, editMenu, viewMenu, simulateMenu, helpMenu);
+    }
+
+    private Menu createFileMenu() {
         Menu fileMenu = new Menu("File");
 
         MenuItem newWindowItem = new MenuItem("New Window");
@@ -476,6 +500,10 @@ public class ModelWindow {
                 new SeparatorMenuItem(), saveItem, saveAsItem, exportItem, exportReportItem,
                 new SeparatorMenuItem(), closeItem, exitItem);
 
+        return fileMenu;
+    }
+
+    private Menu createEditMenu() {
         Menu editMenu = new Menu("Edit");
 
         undoItem = new MenuItem("Undo");
@@ -535,7 +563,10 @@ public class ModelWindow {
         editMenu.setDisable(true);
         editorOnlyItems.add(editMenu);
 
-        // View menu
+        return editMenu;
+    }
+
+    private Menu createViewMenu() {
         Menu viewMenu = new Menu("View");
 
         CheckMenuItem activityLogItem = new CheckMenuItem("Activity Log");
@@ -618,7 +649,10 @@ public class ModelWindow {
         viewMenu.setDisable(true);
         editorOnlyItems.add(viewMenu);
 
-        // Simulate menu
+        return viewMenu;
+    }
+
+    private Menu createSimulateMenu() {
         Menu simulateMenu = new Menu("Simulate");
 
         MenuItem settingsItem = new MenuItem("Simulation Settings...");
@@ -651,6 +685,10 @@ public class ModelWindow {
         simulateMenu.setDisable(true);
         editorOnlyItems.add(simulateMenu);
 
+        return simulateMenu;
+    }
+
+    private Menu createHelpMenu() {
         Menu helpMenu = new Menu("Help");
 
         MenuItem contextHelpItem = new MenuItem("Context Help");
@@ -705,7 +743,7 @@ public class ModelWindow {
                 new SeparatorMenuItem(), shortcutsItem,
                 new SeparatorMenuItem(), aboutItem);
 
-        return new MenuBar(fileMenu, editMenu, viewMenu, simulateMenu, helpMenu);
+        return helpMenu;
     }
 
     void loadDefinition(ModelDefinition def, String displayName) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/BehaviorModeClassifier.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/BehaviorModeClassifier.java
@@ -197,16 +197,6 @@ final class BehaviorModeClassifier {
         return rise > 0 && fall > rise * 0.3;
     }
 
-    private static double min(double[] values) {
-        double min = values[0];
-        for (double v : values) {
-            if (v < min) {
-                min = v;
-            }
-        }
-        return min;
-    }
-
     private static double range(double[] values) {
         double min = values[0];
         double max = values[0];

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasRenderer.java
@@ -71,9 +71,6 @@ public class CanvasRenderer {
     }
 
     /**
-     * Groups the per-frame interactive state passed to {@link #render}.
-     */
-    /**
      * Pre-extracted sparkline data for stock elements.
      *
      * @param stockSeries map of stock name to time-series values
@@ -130,18 +127,9 @@ public class CanvasRenderer {
 
         ModelEditor editor = ctx.editor();
         List<ConnectorRoute> connectors = ctx.connectors();
-        FlowCreationController.State flowState = ctx.flowState();
-        CausalLinkCreationController.State causalLinkState = ctx.causalLinkState();
-        InfoLinkCreationController.State infoLinkState = ctx.infoLinkState();
-        ReattachState reattachState = ctx.reattachState();
-        RerouteState rerouteState = ctx.rerouteState();
-        MarqueeState marqueeState = ctx.marqueeState();
         FeedbackAnalysis loopAnalysis = ctx.loopAnalysis();
         CausalTraceAnalysis traceAnalysis = ctx.traceAnalysis();
-        Map<String, ValidationIssue.Severity> elementIssues = ctx.elementIssues();
         String hoveredElement = ctx.hoveredElement();
-        ConnectionId hoveredConnection = ctx.hoveredConnection();
-        ConnectionId selectedConnection = ctx.selectedConnection();
         boolean hideAux = ctx.hideVariables();
         boolean showDelay = ctx.showDelayBadges();
 
@@ -172,6 +160,16 @@ public class CanvasRenderer {
         }
 
         // 2. Draw elements on top
+        renderElements(gc, editor, hideAux, showDelay);
+
+        // 3. Draw overlays: sparklines, validation, loops, highlights, rubber bands, marquee
+        renderOverlays(gc, ctx, connectors, editor.getCausalLinks(), hideAux);
+
+        gc.restore();
+    }
+
+    private void renderElements(GraphicsContext gc, ModelEditor editor,
+                                boolean hideAux, boolean showDelay) {
         for (String name : canvasState.getDrawOrder()) {
             ElementType type = canvasState.getType(name).orElse(null);
             double cx = canvasState.getX(name);
@@ -265,6 +263,23 @@ public class CanvasRenderer {
                 default -> { }
             }
         }
+    }
+
+    private void renderOverlays(GraphicsContext gc, RenderContext ctx,
+                                List<ConnectorRoute> connectors,
+                                List<CausalLinkDef> allCausalLinks, boolean hideAux) {
+        FeedbackAnalysis loopAnalysis = ctx.loopAnalysis();
+        CausalTraceAnalysis traceAnalysis = ctx.traceAnalysis();
+        Map<String, ValidationIssue.Severity> elementIssues = ctx.elementIssues();
+        String hoveredElement = ctx.hoveredElement();
+        ConnectionId hoveredConnection = ctx.hoveredConnection();
+        ConnectionId selectedConnection = ctx.selectedConnection();
+        FlowCreationController.State flowState = ctx.flowState();
+        CausalLinkCreationController.State causalLinkState = ctx.causalLinkState();
+        InfoLinkCreationController.State infoLinkState = ctx.infoLinkState();
+        ReattachState reattachState = ctx.reattachState();
+        RerouteState rerouteState = ctx.rerouteState();
+        MarqueeState marqueeState = ctx.marqueeState();
 
         // 2-spark. Draw sparklines inside stock elements (above fill, below overlays)
         if (ctx.sparklineData() != null) {
@@ -312,7 +327,6 @@ public class CanvasRenderer {
         }
 
         // 2c. Draw connection highlights (above loops, below element hover)
-        List<CausalLinkDef> allCausalLinks = editor.getCausalLinks();
         if (selectedConnection != null) {
             drawConnectionHighlight(gc, connectors, allCausalLinks, selectedConnection, false);
         }
@@ -368,8 +382,6 @@ public class CanvasRenderer {
         if (marqueeState.active()) {
             drawMarquee(gc, marqueeState);
         }
-
-        gc.restore();
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/Styles.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/Styles.java
@@ -62,7 +62,7 @@ public final class Styles {
 
     // --- Validation ---
     public static final String VALIDATION_ERROR =
-            "-fx-text-fill: #E74C3C; -fx-font-size: 11;";
+            "-fx-text-fill: #E74C3C; -fx-font-size: 11px;";
     public static final String VALIDATION_WARNING =
             "-fx-text-fill: #cc7700; -fx-font-weight: bold;";
 

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowFileOperationsFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowFileOperationsFxTest.java
@@ -141,7 +141,7 @@ class WorkflowFileOperationsFxTest {
     void shouldBeDirtyAfterEquationChange(FxRobot robot) {
         loadExample("Bathtub", "introductory/bathtub.json");
 
-        Platform.runLater(() -> window.getEditor().setAuxEquation("Outflow Rate", "10"));
+        Platform.runLater(() -> window.getEditor().setVariableEquation("Outflow Rate", "10"));
         WaitForAsyncUtils.waitForFxEvents();
 
         assertThat(window.isDirty()).isTrue();

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowSimulationFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowSimulationFxTest.java
@@ -195,7 +195,7 @@ class WorkflowSimulationFxTest {
         var banner = robot.lookup("#staleBanner").queryAs(javafx.scene.layout.HBox.class);
         assertThat(banner.isVisible()).isFalse();
 
-        Platform.runLater(() -> window.getEditor().setAuxEquation("Outflow Rate", "10"));
+        Platform.runLater(() -> window.getEditor().setVariableEquation("Outflow Rate", "10"));
         WaitForAsyncUtils.waitForFxEvents();
 
         banner = robot.lookup("#staleBanner").queryAs(javafx.scene.layout.HBox.class);
@@ -210,7 +210,7 @@ class WorkflowSimulationFxTest {
         triggerSimulation(robot);
         waitForDashboardResults(robot);
 
-        Platform.runLater(() -> window.getEditor().setAuxEquation("Outflow Rate", "10"));
+        Platform.runLater(() -> window.getEditor().setVariableEquation("Outflow Rate", "10"));
         WaitForAsyncUtils.waitForFxEvents();
 
         triggerSimulation(robot);
@@ -228,7 +228,7 @@ class WorkflowSimulationFxTest {
         triggerSimulation(robot);
         waitForDashboardResults(robot);
 
-        Platform.runLater(() -> window.getEditor().setAuxEquation("Outflow Rate", "10"));
+        Platform.runLater(() -> window.getEditor().setVariableEquation("Outflow Rate", "10"));
         WaitForAsyncUtils.waitForFxEvents();
 
         robot.clickOn("#staleRerunLink");

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowSweepAnalysisFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowSweepAnalysisFxTest.java
@@ -59,9 +59,9 @@ class WorkflowSweepAnalysisFxTest {
         Platform.runLater(() -> {
             editor.addStock();
             editor.setStockInitialValue("Stock 1", 100);
-            editor.addAux();
-            editor.renameElement("Aux 1", "Drain Rate");
-            editor.setAuxEquation("Drain Rate", "5");
+            editor.addVariable();
+            editor.renameElement("Variable 1", "Drain Rate");
+            editor.setVariableEquation("Drain Rate", "5");
             editor.addFlow("Stock 1", null);
             editor.setFlowEquation("Flow 1", "Drain_Rate");
             editor.setSimulationSettings(new SimulationSettings("Day", 20, "Day"));
@@ -78,12 +78,12 @@ class WorkflowSweepAnalysisFxTest {
         Platform.runLater(() -> {
             editor.addStock();
             editor.setStockInitialValue("Stock 1", 100);
-            editor.addAux();
-            editor.renameElement("Aux 1", "Drain Rate");
-            editor.setAuxEquation("Drain Rate", "5");
-            editor.addAux();
-            editor.renameElement("Aux 2", "Fill Rate");
-            editor.setAuxEquation("Fill Rate", "3");
+            editor.addVariable();
+            editor.renameElement("Variable 1", "Drain Rate");
+            editor.setVariableEquation("Drain Rate", "5");
+            editor.addVariable();
+            editor.renameElement("Variable 2", "Fill Rate");
+            editor.setVariableEquation("Fill Rate", "3");
             editor.addFlow("Stock 1", null);
             editor.setFlowEquation("Flow 1", "Drain_Rate");
             editor.addFlow(null, "Stock 1");
@@ -359,7 +359,7 @@ class WorkflowSweepAnalysisFxTest {
         waitForDashboardResults(robot);
 
         // Modify parameter
-        Platform.runLater(() -> window.getEditor().setAuxEquation("Drain Rate", "8"));
+        Platform.runLater(() -> window.getEditor().setVariableEquation("Drain Rate", "8"));
         WaitForAsyncUtils.waitForFxEvents();
 
         // Re-simulate

--- a/courant-engine/src/main/java/systems/courant/sd/Simulation.java
+++ b/courant-engine/src/main/java/systems/courant/sd/Simulation.java
@@ -225,19 +225,19 @@ public class Simulation {
     }
 
     private void fireStartEvent(SimulationStartEvent event) {
-        for (EventHandler handler : eventHandlers) {
+        for (EventHandler handler : List.copyOf(eventHandlers)) {
             handler.handleSimulationStartEvent(event);
         }
     }
 
     private void fireTimeStepEvent(TimeStepEvent event) {
-        for (EventHandler handler : eventHandlers) {
+        for (EventHandler handler : List.copyOf(eventHandlers)) {
             handler.handleTimeStepEvent(event);
         }
     }
 
     private void fireEndEvent(SimulationEndEvent event) {
-        for (EventHandler handler : eventHandlers) {
+        for (EventHandler handler : List.copyOf(eventHandlers)) {
             handler.handleSimulationEndEvent(event);
         }
     }

--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -502,6 +502,49 @@ public class ModelDefinitionSerializer {
             moduleInterface = deserializeModuleInterface(root.get("moduleInterface"));
         }
 
+        List<StockDef> stocks = deserializeStocks(root);
+        List<FlowDef> flows = deserializeFlows(root);
+        List<VariableDef> variables = deserializeVariables(root);
+        List<VariableDef> migratedConstants = deserializeLegacyConstants(root);
+        List<LookupTableDef> lookupTables = deserializeLookupTables(root);
+        List<ModuleInstanceDef> modules = deserializeModules(root, depth);
+        List<SubscriptDef> subscripts = deserializeSubscripts(root);
+        List<CldVariableDef> cldVariables = deserializeCldVariables(root);
+        List<CausalLinkDef> causalLinks = deserializeCausalLinks(root);
+        List<CommentDef> comments = deserializeComments(root);
+
+        List<ViewDef> views = new ArrayList<>();
+        if (root.has("views")) {
+            for (JsonNode n : root.get("views")) {
+                views.add(deserializeView(n));
+            }
+        }
+
+        SimulationSettings defaultSimulation = deserializeSimulationSettings(root);
+        ModelMetadata metadata = deserializeMetadata(root);
+        List<ReferenceDataset> referenceDatasets = deserializeReferenceDatasets(root);
+
+        if (!migratedConstants.isEmpty()) {
+            ModelDefinition migrated = ModelDefinition.withMigratedConstants(
+                    name, comment, moduleInterface,
+                    stocks, flows, variables, migratedConstants, lookupTables,
+                    modules, subscripts, cldVariables, causalLinks, comments,
+                    views, defaultSimulation, metadata);
+            if (referenceDatasets.isEmpty()) {
+                return migrated;
+            }
+            return migrated.toBuilder()
+                    .clearReferenceDatasets()
+                    .referenceDatasets(referenceDatasets)
+                    .build();
+        }
+        return new ModelDefinition(name, comment, moduleInterface,
+                stocks, flows, variables, lookupTables,
+                modules, subscripts, cldVariables, causalLinks,
+                comments, views, defaultSimulation, metadata, referenceDatasets);
+    }
+
+    private List<StockDef> deserializeStocks(JsonNode root) {
         List<StockDef> stocks = new ArrayList<>();
         if (root.has("stocks")) {
             for (JsonNode n : root.get("stocks")) {
@@ -515,7 +558,10 @@ public class ModelDefinitionSerializer {
                         readStringList(n, "subscripts")));
             }
         }
+        return stocks;
+    }
 
+    private List<FlowDef> deserializeFlows(JsonNode root) {
         List<FlowDef> flows = new ArrayList<>();
         if (root.has("flows")) {
             for (JsonNode n : root.get("flows")) {
@@ -530,7 +576,10 @@ public class ModelDefinitionSerializer {
                         readStringList(n, "subscripts")));
             }
         }
+        return flows;
+    }
 
+    private List<VariableDef> deserializeVariables(JsonNode root) {
         List<VariableDef> variables = new ArrayList<>();
         if (root.has("variables")) {
             for (JsonNode n : root.get("variables")) {
@@ -543,8 +592,11 @@ public class ModelDefinitionSerializer {
                         readStringList(n, "subscripts")));
             }
         }
+        return variables;
+    }
 
-        // Backward compatibility: migrate legacy constants into variables
+    // Backward compatibility: migrate legacy constants into variables
+    private List<VariableDef> deserializeLegacyConstants(JsonNode root) {
         List<VariableDef> migratedConstants = new ArrayList<>();
         if (root.has("constants")) {
             for (JsonNode n : root.get("constants")) {
@@ -556,7 +608,10 @@ public class ModelDefinitionSerializer {
                         requiredText(n, "unit")));
             }
         }
+        return migratedConstants;
+    }
 
+    private List<LookupTableDef> deserializeLookupTables(JsonNode root) {
         List<LookupTableDef> lookupTables = new ArrayList<>();
         if (root.has("lookupTables")) {
             for (JsonNode n : root.get("lookupTables")) {
@@ -568,7 +623,10 @@ public class ModelDefinitionSerializer {
                         requiredText(n, "interpolation")));
             }
         }
+        return lookupTables;
+    }
 
+    private List<ModuleInstanceDef> deserializeModules(JsonNode root, int depth) {
         List<ModuleInstanceDef> modules = new ArrayList<>();
         if (root.has("modules")) {
             for (JsonNode n : root.get("modules")) {
@@ -581,7 +639,10 @@ public class ModelDefinitionSerializer {
                         outputBindings));
             }
         }
+        return modules;
+    }
 
+    private List<SubscriptDef> deserializeSubscripts(JsonNode root) {
         List<SubscriptDef> subscripts = new ArrayList<>();
         if (root.has("subscripts")) {
             for (JsonNode n : root.get("subscripts")) {
@@ -593,7 +654,10 @@ public class ModelDefinitionSerializer {
                 subscripts.add(new SubscriptDef(requiredText(n, "name"), labels));
             }
         }
+        return subscripts;
+    }
 
+    private List<CldVariableDef> deserializeCldVariables(JsonNode root) {
         List<CldVariableDef> cldVariables = new ArrayList<>();
         if (root.has("cldVariables")) {
             for (JsonNode n : root.get("cldVariables")) {
@@ -602,7 +666,10 @@ public class ModelDefinitionSerializer {
                         textOrNull(n, "comment")));
             }
         }
+        return cldVariables;
+    }
 
+    private List<CausalLinkDef> deserializeCausalLinks(JsonNode root) {
         List<CausalLinkDef> causalLinks = new ArrayList<>();
         if (root.has("causalLinks")) {
             for (JsonNode n : root.get("causalLinks")) {
@@ -625,7 +692,10 @@ public class ModelDefinitionSerializer {
                         textOrNull(n, "comment")));
             }
         }
+        return causalLinks;
+    }
 
+    private List<CommentDef> deserializeComments(JsonNode root) {
         List<CommentDef> comments = new ArrayList<>();
         if (root.has("comments")) {
             for (JsonNode n : root.get("comments")) {
@@ -635,40 +705,40 @@ public class ModelDefinitionSerializer {
                         text != null ? text : ""));
             }
         }
+        return comments;
+    }
 
-        List<ViewDef> views = new ArrayList<>();
-        if (root.has("views")) {
-            for (JsonNode n : root.get("views")) {
-                views.add(deserializeView(n));
-            }
+    private SimulationSettings deserializeSimulationSettings(JsonNode root) {
+        if (!root.has("defaultSimulation")) {
+            return null;
         }
+        JsonNode s = root.get("defaultSimulation");
+        double dt = s.has("dt") ? s.get("dt").asDouble() : 1.0;
+        boolean strict = s.has("strictMode") && s.get("strictMode").asBoolean();
+        long savePerVal = s.has("savePer") ? s.get("savePer").asLong() : 1;
+        return new SimulationSettings(
+                requiredText(s, "timeStep"),
+                requiredDouble(s, "duration"),
+                requiredText(s, "durationUnit"),
+                dt,
+                strict,
+                savePerVal);
+    }
 
-        SimulationSettings defaultSimulation = null;
-        if (root.has("defaultSimulation")) {
-            JsonNode s = root.get("defaultSimulation");
-            double dt = s.has("dt") ? s.get("dt").asDouble() : 1.0;
-            boolean strict = s.has("strictMode") && s.get("strictMode").asBoolean();
-            long savePerVal = s.has("savePer") ? s.get("savePer").asLong() : 1;
-            defaultSimulation = new SimulationSettings(
-                    requiredText(s, "timeStep"),
-                    requiredDouble(s, "duration"),
-                    requiredText(s, "durationUnit"),
-                    dt,
-                    strict,
-                    savePerVal);
+    private ModelMetadata deserializeMetadata(JsonNode root) {
+        if (!root.has("metadata")) {
+            return null;
         }
+        JsonNode m = root.get("metadata");
+        return ModelMetadata.builder()
+                .author(textOrNull(m, "author"))
+                .source(textOrNull(m, "source"))
+                .license(textOrNull(m, "license"))
+                .url(textOrNull(m, "url"))
+                .build();
+    }
 
-        ModelMetadata metadata = null;
-        if (root.has("metadata")) {
-            JsonNode m = root.get("metadata");
-            metadata = ModelMetadata.builder()
-                    .author(textOrNull(m, "author"))
-                    .source(textOrNull(m, "source"))
-                    .license(textOrNull(m, "license"))
-                    .url(textOrNull(m, "url"))
-                    .build();
-        }
-
+    private List<ReferenceDataset> deserializeReferenceDatasets(JsonNode root) {
         List<ReferenceDataset> referenceDatasets = new ArrayList<>();
         if (root.has("referenceDatasets")) {
             for (JsonNode n : root.get("referenceDatasets")) {
@@ -684,26 +754,7 @@ public class ModelDefinitionSerializer {
                 referenceDatasets.add(new ReferenceDataset(dsName, timeValues, columns));
             }
         }
-
-        if (!migratedConstants.isEmpty()) {
-            ModelDefinition migrated = ModelDefinition.withMigratedConstants(
-                    name, comment, moduleInterface,
-                    stocks, flows, variables, migratedConstants, lookupTables,
-                    modules, subscripts, cldVariables, causalLinks, comments,
-                    views, defaultSimulation, metadata);
-            if (referenceDatasets.isEmpty()) {
-                return migrated;
-            }
-            // Re-wrap with reference datasets
-            return migrated.toBuilder()
-                    .clearReferenceDatasets()
-                    .referenceDatasets(referenceDatasets)
-                    .build();
-        }
-        return new ModelDefinition(name, comment, moduleInterface,
-                stocks, flows, variables, lookupTables,
-                modules, subscripts, cldVariables, causalLinks,
-                comments, views, defaultSimulation, metadata, referenceDatasets);
+        return referenceDatasets;
     }
 
     private ViewDef deserializeView(JsonNode n) {

--- a/courant-engine/src/main/java/systems/courant/sd/measure/units/length/Lengths.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/units/length/Lengths.java
@@ -8,6 +8,9 @@ import systems.courant.sd.measure.Unit;
  */
 public final class Lengths {
 
+    private Lengths() {
+    }
+
     /**
      * Creates a quantity of the given value in feet.
      */

--- a/courant-engine/src/main/java/systems/courant/sd/measure/units/time/Times.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/units/time/Times.java
@@ -6,7 +6,10 @@ import systems.courant.sd.measure.TimeUnit;
 /**
  * Factory methods for creating time {@link Quantity} instances in various time units.
  */
-public class Times {
+public final class Times {
+
+    private Times() {
+    }
 
     /**
      * Creates a quantity of the given value in milliseconds.

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -169,6 +169,69 @@ public class ExprCompiler {
         List<Expr> args = call.arguments();
 
         return switch (name) {
+            case "TIME", "DT" -> compileSpecialVariable(name, args);
+            case "ABS", "SQRT", "LN", "EXP", "LOG", "SIN", "COS", "TAN",
+                    "ARCSIN", "ARCCOS", "ARCTAN", "SIGN", "PI", "INT", "ROUND",
+                    "MODULO", "QUANTUM", "POWER", "MIN", "MAX" ->
+                compileMathFunction(name, args);
+            case "SUM", "MEAN", "VMIN", "VMAX", "PROD" ->
+                compileAggregateFunction(name, args);
+            case "XIDZ", "ZIDZ" -> compileSafeDivision(name, args);
+            case "NOT", "OR", "AND", "TRUE", "FALSE" ->
+                compileLogicFunction(name, args);
+            case "INITIAL" -> {
+                requireArgs(name, args, 1);
+                DoubleSupplier a = compileExpr(args.get(0));
+                double[] cached = {Double.NaN};
+                boolean[] initialized = {false};
+                Resettable reset = () -> {
+                    cached[0] = Double.NaN;
+                    initialized[0] = false;
+                };
+                resettables.add(reset);
+                yield () -> {
+                    if (!initialized[0]) {
+                        cached[0] = a.getAsDouble();
+                        initialized[0] = true;
+                    }
+                    return cached[0];
+                };
+            }
+            case "SMOOTH" -> compileSmooth(args);
+            case "SMOOTHI" -> compileSmoothI(args);
+            case "SMOOTH3" -> compileSmooth3(args);
+            case "SMOOTH3I" -> compileSmooth3I(args);
+            case "DELAY1", "DELAY1I" -> compileDelay1(args);
+            case "DELAY3", "DELAY3I" -> compileDelay3(args);
+            case "STEP" -> compileStep(args);
+            case "RAMP" -> compileRamp(args);
+            case "PULSE" -> compilePulse(args);
+            case "PULSE_TRAIN" -> compilePulseTrain(args);
+            case "DELAY_FIXED" -> compileDelayFixed(args);
+            case "TREND" -> compileTrend(args);
+            case "FORECAST" -> compileForecast(args);
+            case "NPV" -> compileNpv(args);
+            case "RANDOM_NORMAL" -> compileRandomNormal(args);
+            case "RANDOM_UNIFORM" -> compileRandomUniform(args);
+            case "SAMPLE_IF_TRUE" -> compileSampleIfTrue(args);
+            case "FIND_ZERO" -> compileFindZero(args);
+            case "LOOKUP_AREA" -> compileLookupArea(args);
+            case "LOOKUP" -> compileLookup(args);
+            default -> {
+                // Check if the function name is a lookup table (Vensim allows table(input) syntax)
+                String originalName = call.name();
+                if (args.size() == 1 && context.resolveLookupTable(originalName).isPresent()) {
+                    List<Expr> lookupArgs = List.of(new Expr.Ref(originalName), args.get(0));
+                    yield compileLookup(lookupArgs);
+                }
+                throw new CompilationException(
+                        "Unknown function: " + name, name);
+            }
+        };
+    }
+
+    private DoubleSupplier compileSpecialVariable(String name, List<Expr> args) {
+        return switch (name) {
             case "TIME" -> {
                 requireArgs(name, args, 0);
                 yield () -> context.getCurrentStep().getAsLong();
@@ -177,6 +240,13 @@ public class ExprCompiler {
                 requireArgs(name, args, 0);
                 yield () -> context.getDt();
             }
+            default -> throw new CompilationException(
+                    "Unknown special variable: " + name, name);
+        };
+    }
+
+    private DoubleSupplier compileMathFunction(String name, List<Expr> args) {
+        return switch (name) {
             case "ABS" -> {
                 requireArgs(name, args, 1);
                 DoubleSupplier a = compileExpr(args.get(0));
@@ -400,6 +470,13 @@ public class ExprCompiler {
                 DoubleSupplier b = compileExpr(args.get(1));
                 yield () -> Math.max(a.getAsDouble(), b.getAsDouble());
             }
+            default -> throw new CompilationException(
+                    "Unknown math function: " + name, name);
+        };
+    }
+
+    private DoubleSupplier compileAggregateFunction(String name, List<Expr> args) {
+        return switch (name) {
             case "SUM" -> {
                 List<DoubleSupplier> compiled = new ArrayList<>();
                 for (Expr arg : args) {
@@ -482,6 +559,13 @@ public class ExprCompiler {
                     return result;
                 };
             }
+            default -> throw new CompilationException(
+                    "Unknown aggregate function: " + name, name);
+        };
+    }
+
+    private DoubleSupplier compileSafeDivision(String name, List<Expr> args) {
+        return switch (name) {
             case "XIDZ" -> {
                 requireArgs(name, args, 3);
                 DoubleSupplier a = compileExpr(args.get(0));
@@ -501,42 +585,13 @@ public class ExprCompiler {
                     return divisor == 0 ? 0.0 : a.getAsDouble() / divisor;
                 };
             }
-            case "INITIAL" -> {
-                requireArgs(name, args, 1);
-                DoubleSupplier a = compileExpr(args.get(0));
-                double[] cached = {Double.NaN};
-                boolean[] initialized = {false};
-                Resettable reset = () -> {
-                    cached[0] = Double.NaN;
-                    initialized[0] = false;
-                };
-                resettables.add(reset);
-                yield () -> {
-                    if (!initialized[0]) {
-                        cached[0] = a.getAsDouble();
-                        initialized[0] = true;
-                    }
-                    return cached[0];
-                };
-            }
-            case "SMOOTH" -> compileSmooth(args);
-            case "SMOOTHI" -> compileSmoothI(args);
-            case "SMOOTH3" -> compileSmooth3(args);
-            case "SMOOTH3I" -> compileSmooth3I(args);
-            case "DELAY1", "DELAY1I" -> compileDelay1(args);
-            case "DELAY3", "DELAY3I" -> compileDelay3(args);
-            case "STEP" -> compileStep(args);
-            case "RAMP" -> compileRamp(args);
-            case "PULSE" -> compilePulse(args);
-            case "PULSE_TRAIN" -> compilePulseTrain(args);
-            case "DELAY_FIXED" -> compileDelayFixed(args);
-            case "TREND" -> compileTrend(args);
-            case "FORECAST" -> compileForecast(args);
-            case "NPV" -> compileNpv(args);
-            case "RANDOM_NORMAL" -> compileRandomNormal(args);
-            case "RANDOM_UNIFORM" -> compileRandomUniform(args);
-            case "SAMPLE_IF_TRUE" -> compileSampleIfTrue(args);
-            case "FIND_ZERO" -> compileFindZero(args);
+            default -> throw new CompilationException(
+                    "Unknown safe division function: " + name, name);
+        };
+    }
+
+    private DoubleSupplier compileLogicFunction(String name, List<Expr> args) {
+        return switch (name) {
             case "NOT" -> {
                 requireArgs(name, args, 1);
                 DoubleSupplier a = compileExpr(args.get(0));
@@ -562,18 +617,8 @@ public class ExprCompiler {
                 requireArgs(name, args, 0);
                 yield () -> 0.0;
             }
-            case "LOOKUP_AREA" -> compileLookupArea(args);
-            case "LOOKUP" -> compileLookup(args);
-            default -> {
-                // Check if the function name is a lookup table (Vensim allows table(input) syntax)
-                String originalName = call.name();
-                if (args.size() == 1 && context.resolveLookupTable(originalName).isPresent()) {
-                    List<Expr> lookupArgs = List.of(new Expr.Ref(originalName), args.get(0));
-                    yield compileLookup(lookupArgs);
-                }
-                throw new CompilationException(
-                        "Unknown function: " + name, name);
-            }
+            default -> throw new CompilationException(
+                    "Unknown logic function: " + name, name);
         };
     }
 

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/FunctionDocRegistry.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/FunctionDocRegistry.java
@@ -413,13 +413,14 @@ public final class FunctionDocRegistry {
                 "LOOKUP(Effect_of_Density, Population / Area)",
                 List.of());
 
-        add(m, "RANDOM_NORMAL", "RANDOM_NORMAL(min, max, mean, std_dev)",
+        add(m, "RANDOM_NORMAL", "RANDOM_NORMAL(min, max, mean, std_dev [, seed])",
                 "Bounded normal random number",
                 "SD",
                 List.of(p("min", "minimum allowed value"),
                         p("max", "maximum allowed value"),
                         p("mean", "mean of the normal distribution"),
-                        p("std_dev", "standard deviation")),
+                        p("std_dev", "standard deviation"),
+                        p("seed", "(optional) random seed (currently ignored; uses system time)")),
                 "Generates a random number from a normal distribution with the given mean "
                         + "and standard deviation, clamped to [min, max].",
                 "RANDOM_NORMAL(0, 100, 50, 10) → ~50 with std dev 10, clamped to 0-100",

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/ModelDefinitionBuilder.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/ModelDefinitionBuilder.java
@@ -452,6 +452,24 @@ public class ModelDefinitionBuilder {
     /** Clears all view definitions. */
     public ModelDefinitionBuilder clearViews() { views.clear(); return this; }
 
+    /** Clears all lookup table definitions. */
+    public ModelDefinitionBuilder clearLookupTables() { lookupTables.clear(); return this; }
+
+    /** Clears all module instance definitions. */
+    public ModelDefinitionBuilder clearModules() { modules.clear(); return this; }
+
+    /** Clears all subscript definitions. */
+    public ModelDefinitionBuilder clearSubscripts() { subscripts.clear(); return this; }
+
+    /** Clears all CLD variable definitions. */
+    public ModelDefinitionBuilder clearCldVariables() { cldVariables.clear(); return this; }
+
+    /** Clears all causal link definitions. */
+    public ModelDefinitionBuilder clearCausalLinks() { causalLinks.clear(); return this; }
+
+    /** Clears all comment definitions. */
+    public ModelDefinitionBuilder clearComments() { comments.clear(); return this; }
+
     /** Adds all stock definitions from the given list. */
     public ModelDefinitionBuilder stocks(List<StockDef> defs) { stocks.addAll(defs); return this; }
 

--- a/courant-engine/src/test/java/systems/courant/sd/SimulationTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/SimulationTest.java
@@ -777,4 +777,73 @@ public class SimulationTest {
             assertThat(sim.getSavePer()).isEqualTo(1);
         }
     }
+
+    @Nested
+    @DisplayName("Event handler safety (#451)")
+    class EventHandlerSafety {
+
+        @Test
+        void shouldNotThrowWhenHandlerRemovesItselfDuringDispatch() {
+            Model model = new Model("Self-Remove");
+            Simulation sim = new Simulation(model, MINUTE, MINUTE, 3);
+
+            systems.courant.sd.event.EventHandler selfRemovingHandler =
+                    new systems.courant.sd.event.EventHandler() {
+                @Override
+                public void handleSimulationStartEvent(
+                        systems.courant.sd.event.SimulationStartEvent e) {
+                    e.getSimulation().removeEventHandler(this);
+                }
+                @Override
+                public void handleTimeStepEvent(
+                        systems.courant.sd.event.TimeStepEvent e) { }
+                @Override
+                public void handleSimulationEndEvent(
+                        systems.courant.sd.event.SimulationEndEvent e) { }
+            };
+
+            sim.addEventHandler(selfRemovingHandler);
+            sim.execute();
+
+            assertThat(sim.getCurrentStep()).isEqualTo(4);
+        }
+
+        @Test
+        void shouldNotThrowWhenHandlerAddsAnotherDuringDispatch() {
+            Model model = new Model("Add Handler");
+            int[] count = {0};
+            Simulation sim = new Simulation(model, MINUTE, MINUTE, 2);
+
+            systems.courant.sd.event.EventHandler addingHandler =
+                    new systems.courant.sd.event.EventHandler() {
+                @Override
+                public void handleSimulationStartEvent(
+                        systems.courant.sd.event.SimulationStartEvent e) {
+                    e.getSimulation().addEventHandler(
+                            new systems.courant.sd.event.EventHandler() {
+                        @Override
+                        public void handleSimulationStartEvent(
+                                systems.courant.sd.event.SimulationStartEvent ev) { }
+                        @Override
+                        public void handleTimeStepEvent(
+                                systems.courant.sd.event.TimeStepEvent ev) { count[0]++; }
+                        @Override
+                        public void handleSimulationEndEvent(
+                                systems.courant.sd.event.SimulationEndEvent ev) { }
+                    });
+                }
+                @Override
+                public void handleTimeStepEvent(
+                        systems.courant.sd.event.TimeStepEvent e) { }
+                @Override
+                public void handleSimulationEndEvent(
+                        systems.courant.sd.event.SimulationEndEvent e) { }
+            };
+
+            sim.addEventHandler(addingHandler);
+            sim.execute();
+
+            assertThat(sim.getCurrentStep()).isEqualTo(3);
+        }
+    }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/measure/units/length/LengthsTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/units/length/LengthsTest.java
@@ -1,0 +1,49 @@
+package systems.courant.sd.measure.units.length;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Lengths")
+class LengthsTest {
+
+    @Test
+    void shouldBeFinalClass() {
+        assertThat(Modifier.isFinal(Lengths.class.getModifiers())).isTrue();
+    }
+
+    @Test
+    void shouldHavePrivateConstructor() throws NoSuchMethodException {
+        Constructor<Lengths> ctor = Lengths.class.getDeclaredConstructor();
+        assertThat(Modifier.isPrivate(ctor.getModifiers())).isTrue();
+    }
+
+    @Test
+    void shouldCreateFeetQuantity() {
+        assertThat(Lengths.feet(10).getValue()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldCreateInchesQuantity() {
+        assertThat(Lengths.inches(24).getValue()).isEqualTo(24);
+    }
+
+    @Test
+    void shouldCreateMetersQuantity() {
+        assertThat(Lengths.meters(100).getValue()).isEqualTo(100);
+    }
+
+    @Test
+    void shouldCreateMilesQuantity() {
+        assertThat(Lengths.miles(5).getValue()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldCreateNauticalMilesQuantity() {
+        assertThat(Lengths.nauticalMiles(3).getValue()).isEqualTo(3);
+    }
+}

--- a/courant-engine/src/test/java/systems/courant/sd/measure/units/time/TimesTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/units/time/TimesTest.java
@@ -1,0 +1,65 @@
+package systems.courant.sd.measure.units.time;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Times")
+class TimesTest {
+
+    @Test
+    void shouldBeFinalClass() {
+        assertThat(Modifier.isFinal(Times.class.getModifiers())).isTrue();
+    }
+
+    @Test
+    void shouldHavePrivateConstructor() throws NoSuchMethodException {
+        Constructor<Times> ctor = Times.class.getDeclaredConstructor();
+        assertThat(Modifier.isPrivate(ctor.getModifiers())).isTrue();
+    }
+
+    @Test
+    void shouldCreateMillisecondQuantity() {
+        assertThat(Times.milliseconds(500).getValue()).isEqualTo(500);
+    }
+
+    @Test
+    void shouldCreateSecondQuantity() {
+        assertThat(Times.seconds(30).getValue()).isEqualTo(30);
+    }
+
+    @Test
+    void shouldCreateMinuteQuantity() {
+        assertThat(Times.minutes(5).getValue()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldCreateHourQuantity() {
+        assertThat(Times.hours(2).getValue()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldCreateDayQuantity() {
+        assertThat(Times.days(7).getValue()).isEqualTo(7);
+    }
+
+    @Test
+    void shouldCreateWeekQuantity() {
+        assertThat(Times.weeks(4).getValue()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldCreateMonthQuantity() {
+        assertThat(Times.months(12).getValue()).isEqualTo(12);
+    }
+
+    @Test
+    void shouldCreateYearQuantity() {
+        assertThat(Times.years(1).getValue()).isEqualTo(1);
+    }
+}

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/FunctionDocRegistryTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/FunctionDocRegistryTest.java
@@ -74,4 +74,16 @@ class FunctionDocRegistryTest {
         assertThat(step.parameters().get(0).name()).isEqualTo("height");
         assertThat(step.parameters().get(1).name()).isEqualTo("step_time");
     }
+
+    @Test
+    void shouldDocumentRandomNormalWith5Parameters() {
+        FunctionDoc doc = FunctionDocRegistry.get("RANDOM_NORMAL").orElseThrow();
+        assertThat(doc.parameters()).hasSize(5);
+        assertThat(doc.parameters().get(0).name()).isEqualTo("min");
+        assertThat(doc.parameters().get(1).name()).isEqualTo("max");
+        assertThat(doc.parameters().get(2).name()).isEqualTo("mean");
+        assertThat(doc.parameters().get(3).name()).isEqualTo("std_dev");
+        assertThat(doc.parameters().get(4).name()).isEqualTo("seed");
+        assertThat(doc.signature()).contains("[, seed]");
+    }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/model/def/ModelDefinitionBuilderTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/def/ModelDefinitionBuilderTest.java
@@ -104,4 +104,67 @@ class ModelDefinitionBuilderTest {
         List<String> errors = DefinitionValidator.validate(sir);
         assertThat(errors.isEmpty()).as("SIR model should validate: " + errors).isTrue();
     }
+
+    @Test
+    void shouldClearLookupTables() {
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("Clear Test")
+                .lookupTable("T1", new double[]{0, 1}, new double[]{0, 1}, "LINEAR")
+                .clearLookupTables()
+                .build();
+        assertThat(def.lookupTables()).isEmpty();
+    }
+
+    @Test
+    void shouldClearModules() {
+        ModelDefinition inner = new ModelDefinitionBuilder().name("Inner").build();
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("Clear Modules Test")
+                .module("m1", inner, java.util.Map.of(), java.util.Map.of())
+                .clearModules()
+                .build();
+        assertThat(def.modules()).isEmpty();
+    }
+
+    @Test
+    void shouldClearSubscripts() {
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("Clear Subscripts")
+                .subscript("Region", List.of("North", "South"))
+                .clearSubscripts()
+                .build();
+        assertThat(def.subscripts()).isEmpty();
+    }
+
+    @Test
+    void shouldClearCldVariables() {
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("Clear CLD")
+                .cldVariable("Population")
+                .clearCldVariables()
+                .build();
+        assertThat(def.cldVariables()).isEmpty();
+    }
+
+    @Test
+    void shouldClearCausalLinks() {
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("Clear Links")
+                .cldVariable("A")
+                .cldVariable("B")
+                .causalLink("A", "B", CausalLinkDef.Polarity.POSITIVE)
+                .clearCausalLinks()
+                .build();
+        assertThat(def.causalLinks()).isEmpty();
+    }
+
+    @Test
+    void shouldClearComments() {
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("Clear Comments")
+                .comment("note1", "Some text")
+                .clearComments()
+                .build();
+        assertThat(def.comments()).isEmpty();
+    }
 }

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
@@ -9,6 +9,7 @@ import systems.courant.sd.model.def.ModuleInstanceDef;
 import systems.courant.sd.model.def.SimulationSettings;
 import systems.courant.sd.model.def.StockDef;
 
+import java.time.Year;
 import java.util.List;
 import java.util.Map;
 
@@ -64,7 +65,7 @@ public class DemoClassGenerator {
             sb.append(" */\n");
         } else {
             sb.append("/*\n");
-            sb.append(" * Copyright (c) 2026 Courant Systems\n");
+            sb.append(" * Copyright (c) ").append(Year.now().getValue()).append(" Courant Systems\n");
             sb.append(" * Licensed under CC-BY-SA-4.0. See LICENSE in this module for details.\n");
             sb.append(" */\n");
         }

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/JavaSourceEscaper.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/JavaSourceEscaper.java
@@ -105,11 +105,4 @@ public final class JavaSourceEscaper {
         return base;
     }
 
-    /**
-     * Returns "null" if the value is null, otherwise the escaped string literal.
-     * Convenience for generating nullable constructor arguments.
-     */
-    public static String nullableString(String value) {
-        return escapeString(value);
-    }
 }

--- a/courant-ui/src/main/java/systems/courant/sd/ui/StockLevelChartViewer.java
+++ b/courant-ui/src/main/java/systems/courant/sd/ui/StockLevelChartViewer.java
@@ -16,7 +16,6 @@ public class StockLevelChartViewer implements EventHandler {
         ChartViewerApplication.addValues(
                 event.getModel().getStockValues(),
                 event.getModel().getVariableValues(),
-                //event.getCurrentTime(),
                 event.getStep());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -307,6 +307,10 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Summary
- Decompose monolithic methods in ExprCompiler, ModelDefinitionSerializer, ModelWindow, and CanvasRenderer into focused private methods
- Fix ConcurrentModificationException in Simulation event dispatch via List.copyOf()
- Fix CSS unit, test API renames (addAux→addVariable), dynamic copyright year
- Remove dead code: BehaviorModeClassifier.min(), JavaSourceEscaper.nullableString(), stale comments
- Harden utility classes (final, private ctors), add builder clear*() methods
- CI: Windows matrix, Checkstyle step, verbose output
- Add tests for Simulation, FunctionDocRegistry, ModelDefinitionBuilder, Lengths, Times

## Test plan
- [x] Full reactor clean build passes
- [x] All tests pass (engine, ui, demos, app, tools)
- [x] SpotBugs clean

Partially addresses #583, #584