### PR TITLE
Extract shared JsonNodeHelper, remove dead refColorIdx

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/SimulationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/SimulationResultPane.java
@@ -357,7 +357,6 @@ public class SimulationResultPane extends BorderPane {
         // --- Reference data overlay ---
         List<XYChart.Series<Number, Number>> allRefSeries = new ArrayList<>();
         if (!referenceDatasets.isEmpty()) {
-            int refColorIdx = 0;
             for (ReferenceDataset refData : referenceDatasets) {
                 for (String varName : refData.variableNames()) {
                     XYChart.Series<Number, Number> refSeries = new XYChart.Series<>();
@@ -370,7 +369,6 @@ public class SimulationResultPane extends BorderPane {
                         }
                     }
                     allRefSeries.add(refSeries);
-                    refColorIdx++;
                 }
             }
             chart.getData().addAll(allRefSeries);

--- a/courant-engine/src/main/java/systems/courant/sd/io/json/JsonNodeHelper.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/JsonNodeHelper.java
@@ -1,0 +1,32 @@
+package systems.courant.sd.io.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Shared helper methods for reading fields from Jackson {@link JsonNode} trees.
+ */
+public final class JsonNodeHelper {
+
+    private JsonNodeHelper() {
+    }
+
+    /**
+     * Returns the text value of the named field, or {@code null} if the field
+     * is absent or explicitly {@code null}.
+     */
+    public static String textOrNull(JsonNode node, String field) {
+        JsonNode child = node.get(field);
+        return (child != null && !child.isNull()) ? child.asText() : null;
+    }
+
+    /**
+     * Returns the text value of the named field, throwing if absent or null.
+     */
+    public static String requiredText(JsonNode node, String field) {
+        JsonNode child = node.get(field);
+        if (child == null || child.isNull()) {
+            throw new IllegalArgumentException("Missing required field: " + field);
+        }
+        return child.asText();
+    }
+}

--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -1,5 +1,8 @@
 package systems.courant.sd.io.json;
 
+import static systems.courant.sd.io.json.JsonNodeHelper.requiredText;
+import static systems.courant.sd.io.json.JsonNodeHelper.textOrNull;
+
 import systems.courant.sd.model.ModelMetadata;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.CausalLinkDef;
@@ -882,17 +885,6 @@ public class ModelDefinitionSerializer {
         return result;
     }
 
-    private String textOrNull(JsonNode node, String field) {
-        return node.has(field) && !node.get(field).isNull() ? node.get(field).asText() : null;
-    }
-
-    private String requiredText(JsonNode node, String field) {
-        JsonNode child = node.get(field);
-        if (child == null || child.isNull()) {
-            throw new IllegalArgumentException("Missing required field: " + field);
-        }
-        return child.asText();
-    }
 
     private double requiredDouble(JsonNode node, String field) {
         JsonNode child = node.get(field);

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
@@ -1,5 +1,8 @@
 package systems.courant.sd.tools.importer;
 
+import static systems.courant.sd.io.json.JsonNodeHelper.requiredText;
+import static systems.courant.sd.io.json.JsonNodeHelper.textOrNull;
+
 import systems.courant.sd.model.ModelMetadata;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -309,18 +312,6 @@ public class BatchImportCli {
                 """);
     }
 
-    private static String requiredText(JsonNode node, String field) {
-        JsonNode child = node.get(field);
-        if (child == null || child.isNull()) {
-            throw new IllegalArgumentException("Missing required field: " + field);
-        }
-        return child.asText();
-    }
-
-    private static String textOrNull(JsonNode node, String field) {
-        JsonNode child = node.get(field);
-        return (child != null && !child.isNull()) ? child.asText() : null;
-    }
 
     static class CliArgs {
         String manifestFile;

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
@@ -1,5 +1,7 @@
 package systems.courant.sd.tools.importer;
 
+import static systems.courant.sd.io.json.JsonNodeHelper.textOrNull;
+
 import systems.courant.sd.model.ModelMetadata;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -121,10 +123,6 @@ public class ImportPipelineCli {
                 .build();
     }
 
-    private static String textOrNull(JsonNode node, String field) {
-        JsonNode child = node.get(field);
-        return (child != null && !child.isNull()) ? child.asText() : null;
-    }
 
     /** Lazily initialized Scanner for reading from System.in when System.console() is null. */
     private Scanner stdinScanner;


### PR DESCRIPTION
## Summary
- Extract `textOrNull` and `requiredText` into shared `JsonNodeHelper` utility in courant-engine
- Remove duplicate private copies from `ModelDefinitionSerializer`, `ImportPipelineCli`, `BatchImportCli`
- Remove unused `refColorIdx` counter from `SimulationResultPane`

## Test plan
- [x] Full reactor clean build passes
- [x] All tests pass
- [x] SpotBugs clean

Closes #583, closes #584