### PR TITLE
Fix null guard, warning reset, start event safety, dead code

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/Simulation.java
+++ b/courant-engine/src/main/java/systems/courant/sd/Simulation.java
@@ -104,6 +104,7 @@ public class Simulation {
     }
 
     public void addEventHandler(EventHandler handler) {
+        Preconditions.checkNotNull(handler, "handler must not be null");
         eventHandlers.add(handler);
     }
 
@@ -162,8 +163,6 @@ public class Simulation {
         elapsedTime = Duration.ZERO;
         clearHistory();
 
-        fireStartEvent(new SimulationStartEvent(this));
-
         long nanos = Math.round(timeStep.ratioToBaseUnit() * 1_000_000_000L);
         if (nanos <= 0) {
             throw new IllegalArgumentException(
@@ -196,9 +195,14 @@ public class Simulation {
         long deadlineMs = timeoutMs > 0 ? System.currentTimeMillis() + timeoutMs : Long.MAX_VALUE;
         Map<Flow, Quantity> flowMap = new IdentityHashMap<>();
         List<Stock> allStocks = collectAllStocks();
+        for (Stock stock : allStocks) {
+            stock.resetWarnings();
+        }
         Map<Stock, Double> deltas = new IdentityHashMap<>();
 
         try {
+            fireStartEvent(new SimulationStartEvent(this));
+
             while (currentStep <= totalSteps) {
                 if (Thread.interrupted()) {
                     log.info("Simulation cancelled at step {}/{}", currentStep, totalSteps);

--- a/courant-engine/src/main/java/systems/courant/sd/model/Stock.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Stock.java
@@ -135,6 +135,14 @@ public class Stock extends Element {
     }
 
     /**
+     * Resets the non-finite warning flag so that warnings will fire again
+     * on the next simulation re-run.
+     */
+    public void resetWarnings() {
+        warnedNonFinite = false;
+    }
+
+    /**
      * Returns the policy that governs how this stock handles negative values.
      */
     public NegativeValuePolicy getNegativeValuePolicy() {

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -826,7 +826,7 @@ public class ExprCompiler {
         DoubleSupplier input = compileExpr(args.get(0));
         double delayTime = evaluateConstant(args.get(1), "DELAY_FIXED delayTime");
         int delaySteps = (int) Math.round(delayTime);
-        if (delaySteps <= 0 || Double.isNaN(delayTime)) {
+        if (Double.isNaN(delayTime) || delaySteps <= 0) {
             String msg = "DELAY_FIXED delayTime evaluated to " + delayTime
                     + " (rounded to " + delaySteps
                     + ") at compile time; using default of 1 step"

--- a/courant-engine/src/test/java/systems/courant/sd/SimulationTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/SimulationTest.java
@@ -933,4 +933,81 @@ public class SimulationTest {
             assertThat(stock.getValue()).isEqualTo(45.0);
         }
     }
+
+    @Nested
+    @DisplayName("Null handler guard (#597)")
+    class NullHandlerGuard {
+
+        @Test
+        void shouldRejectNullEventHandler() {
+            Simulation sim = new Simulation(new Model("Null Test"), MINUTE, MINUTE, 1);
+            assertThatThrownBy(() -> sim.addEventHandler(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Start event inside try block (#599)")
+    class StartEventInsideTry {
+
+        @Test
+        void shouldFireEndEventEvenWhenStartHandlerThrows() {
+            Model model = new Model("Start Throws");
+            Simulation sim = new Simulation(model, MINUTE, MINUTE, 3);
+            boolean[] endFired = {false};
+
+            sim.addEventHandler(new systems.courant.sd.event.EventHandler() {
+                @Override
+                public void handleSimulationStartEvent(
+                        systems.courant.sd.event.SimulationStartEvent e) {
+                    throw new RuntimeException("start handler error");
+                }
+                @Override
+                public void handleTimeStepEvent(
+                        systems.courant.sd.event.TimeStepEvent e) { }
+                @Override
+                public void handleSimulationEndEvent(
+                        systems.courant.sd.event.SimulationEndEvent e) {
+                    endFired[0] = true;
+                }
+            });
+
+            assertThatThrownBy(sim::execute)
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("start handler error");
+
+            assertThat(endFired[0])
+                    .as("End event should fire even when start handler throws")
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Warning reset on re-run (#598)")
+    class WarningResetOnRerun {
+
+        @Test
+        void shouldResetNonFiniteWarningsBetweenRuns() {
+            Model model = new Model("Warn Reset");
+            Stock stock = new Stock("S", 100, THING);
+            boolean[] produceNaN = {true};
+
+            Flow flow = Flow.create("MaybeNaN", MINUTE, () ->
+                    new Quantity(produceNaN[0] ? Double.NaN : 5, THING));
+            stock.addInflow(flow);
+            model.addStock(stock);
+
+            Simulation sim = new Simulation(model, MINUTE, MINUTE, 2);
+
+            // First run: produces NaN warnings
+            sim.execute();
+            assertThat(stock.getValue()).isEqualTo(100.0);
+
+            // Second run: still produces NaN but warnings should fire again (not suppressed)
+            // We verify indirectly: stock value should still be preserved
+            stock.setValue(200);
+            sim.execute();
+            assertThat(stock.getValue()).isEqualTo(200.0);
+        }
+    }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/model/StockTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/StockTest.java
@@ -133,6 +133,19 @@ public class StockTest {
                 () -> new Stock("Water", Double.POSITIVE_INFINITY, GALLON_US));
     }
 
+    @Test
+    public void shouldResetNonFiniteWarningFlag() {
+        Stock stock = new Stock("Water", 100, GALLON_US);
+        // Trigger the warning
+        stock.setValue(Double.NaN);
+        assertEquals(100, stock.getValue(), 0.0);
+
+        // Reset and verify a new warning can fire (no NPE or suppression)
+        stock.resetWarnings();
+        stock.setValue(Double.NaN);
+        assertEquals(100, stock.getValue(), 0.0);
+    }
+
     private static Flow createConstantFlow(String name, double value, Unit unit) {
         return Flow.create(name, MINUTE, () -> new Quantity(value, unit));
     }


### PR DESCRIPTION
## Summary
- Add null check to Simulation.addEventHandler (#597)
- Move fireStartEvent inside try block so end handlers fire even when start handlers throw (#599)
- Add Stock.resetWarnings() and call it on re-run so non-finite warnings are not suppressed (#598)
- Reorder DELAY_FIXED NaN check to put the meaningful guard first (#601)

## Test plan
- [x] All tests pass (0 failures)
- [x] SpotBugs clean
- [x] New tests: null handler rejection, end event fires on start handler error, warning reset between runs, Stock.resetWarnings