### PR TITLE
Fix simulation re-run, module stock reset, XMILE export crash, undo ordering

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
@@ -576,6 +576,12 @@ public class ModelCanvas extends Canvas {
         }
     }
 
+    private void pushUndoSnapshot(UndoManager.Snapshot snapshot, String label) {
+        if (undoManager != null) {
+            undoManager.pushUndo(snapshot, label);
+        }
+    }
+
     /**
      * Returns a short description of the current selection for undo labels.
      * Single element: its name. Multiple: "N elements". Empty: "elements".
@@ -808,10 +814,11 @@ public class ModelCanvas extends Canvas {
         if (editor == null) {
             return;
         }
+        var snapshot = captureSnapshot();
         FlowCreationController.FlowResult result = flowCreation.handleClick(
                 worldX, worldY, canvasState, editor);
         if (result.isCreated()) {
-            saveUndoState("Add flow");
+            pushUndoSnapshot(snapshot, "Add flow");
             regenerateConnectors();
             canvasState.clearSelection();
             canvasState.select(result.flowName());
@@ -824,10 +831,11 @@ public class ModelCanvas extends Canvas {
         if (editor == null) {
             return;
         }
+        var snapshot = captureSnapshot();
         CausalLinkCreationController.LinkResult result = causalLinkCreation.handleClick(
                 worldX, worldY, canvasState, editor);
         if (result.isCreated()) {
-            saveUndoState("Add causal link");
+            pushUndoSnapshot(snapshot, "Add causal link");
             regenerateConnectors();
         }
         redraw();
@@ -838,10 +846,11 @@ public class ModelCanvas extends Canvas {
         if (editor == null) {
             return;
         }
+        var snapshot = captureSnapshot();
         InfoLinkCreationController.LinkResult result = infoLinkCreation.handleClick(
                 worldX, worldY, canvasState, editor);
         if (result.isCreated()) {
-            saveUndoState("Bind module port");
+            pushUndoSnapshot(snapshot, "Bind module port");
             regenerateConnectors();
         }
         redraw();

--- a/courant-engine/src/main/java/systems/courant/sd/Simulation.java
+++ b/courant-engine/src/main/java/systems/courant/sd/Simulation.java
@@ -6,11 +6,13 @@ import systems.courant.sd.event.SimulationStartEvent;
 import systems.courant.sd.event.TimeStepEvent;
 import systems.courant.sd.measure.Quantity;
 import systems.courant.sd.measure.TimeUnit;
+import systems.courant.sd.model.Formula;
 import systems.courant.sd.model.Model;
 import systems.courant.sd.model.Module;
 import systems.courant.sd.model.Stock;
 import systems.courant.sd.model.Flow;
 import systems.courant.sd.model.Variable;
+import systems.courant.sd.model.compile.Resettable;
 import systems.courant.sd.measure.Dimension;
 import com.google.common.base.Preconditions;
 
@@ -162,6 +164,7 @@ public class Simulation {
         currentDateTime = startTime;
         elapsedTime = Duration.ZERO;
         clearHistory();
+        resetStatefulFormulas();
 
         long nanos = Math.round(timeStep.ratioToBaseUnit() * 1_000_000_000L);
         if (nanos <= 0) {
@@ -406,6 +409,39 @@ public class Simulation {
         }
         for (Module module : model.getModules()) {
             clearModuleHistory(module, seenFlows, seenVars);
+        }
+    }
+
+    /**
+     * Resets any stateful formulas (Smooth, Delay, Trend, etc.) found in variables
+     * throughout the model and its modules. This ensures re-running the simulation
+     * produces correct results without requiring an external reset call.
+     */
+    private void resetStatefulFormulas() {
+        Set<Variable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (Variable variable : model.getVariables()) {
+            seen.add(variable);
+            resetIfStateful(variable.getFormula());
+        }
+        for (Module module : model.getModules()) {
+            resetModuleFormulas(module, seen);
+        }
+    }
+
+    private static void resetModuleFormulas(Module module, Set<Variable> seen) {
+        for (Variable variable : module.getVariables()) {
+            if (seen.add(variable)) {
+                resetIfStateful(variable.getFormula());
+            }
+        }
+        for (Module child : module.getSubModules().values()) {
+            resetModuleFormulas(child, seen);
+        }
+    }
+
+    private static void resetIfStateful(Formula formula) {
+        if (formula instanceof Resettable resettable) {
+            resettable.reset();
         }
     }
 

--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
@@ -381,6 +381,11 @@ public final class XmileExporter {
         double[] xVals = lookup.xValues();
         double[] yVals = lookup.yValues();
 
+        if (xVals.length == 0) {
+            parent.appendChild(gf);
+            return;
+        }
+
         // <xscale>
         Element xscale = doc.createElementNS(
                 XmileConstants.NAMESPACE_URI, XmileConstants.XSCALE);

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/CompiledModel.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/CompiledModel.java
@@ -82,6 +82,9 @@ public class CompiledModel {
         for (Stock stock : model.getStocks()) {
             initialStockValues.put(stock, stock.getValue());
         }
+        for (Module module : model.getModules()) {
+            collectModuleStockValues(module);
+        }
     }
 
     /**
@@ -214,6 +217,15 @@ public class CompiledModel {
         }
         for (Module child : module.getSubModules().values()) {
             clearModuleHistory(child, seenFlows, seenVars);
+        }
+    }
+
+    private void collectModuleStockValues(Module module) {
+        for (Stock stock : module.getStocks()) {
+            initialStockValues.putIfAbsent(stock, stock.getValue());
+        }
+        for (Module child : module.getSubModules().values()) {
+            collectModuleStockValues(child);
         }
     }
 


### PR DESCRIPTION
## Summary
- **#619** Simulation.execute() now resets stateful formulas on re-run
- **#620** CompiledModel records and restores module stock initial values
- **#621** XmileExporter.writeGf() guards against empty lookup tables
- **#639** ModelCanvas captures undo snapshot before mutation, pushes only on success

## Test plan
- [x] Clean compile (full reactor)
- [x] SpotBugs clean
- [x] 1999 engine tests pass (0 failures)
- [x] Quality audit on all 4 touched files — no issues

Closes #619, closes #620, closes #621, closes #639