### PR TITLE
Add GitHub Packages to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to Maven Central
+name: Publish
 
 on:
   release:
@@ -10,6 +10,7 @@ jobs:
 
     permissions:
       contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +39,11 @@ jobs:
                 <username>${env.CENTRAL_USERNAME}</username>
                 <password>${env.CENTRAL_PASSWORD}</password>
               </server>
+              <server>
+                <id>github</id>
+                <username>${env.GITHUB_ACTOR}</username>
+                <password>${env.GITHUB_TOKEN}</password>
+              </server>
             </servers>
           </settings>
           SETTINGS
@@ -50,3 +56,8 @@ jobs:
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+
+      - name: Publish to GitHub Packages
+        run: mvn deploy -B -q -DskipTests -Pgithub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds GitHub Packages as a second publish target alongside Maven Central
- Adds `packages: write` permission
- Adds GitHub server credentials to Maven settings
- Adds a deploy step using the existing `github` Maven profile

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Next release triggers both Maven Central and GitHub Packages deployment