### PR TITLE
Fix broken test compilation from package split

### DIFF
--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/ReattachControllerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/ReattachControllerTest.java
@@ -1,5 +1,8 @@
-package systems.courant.sd.app.canvas;
+package systems.courant.sd.app.canvas.controllers;
 
+import systems.courant.sd.app.canvas.CanvasState;
+import systems.courant.sd.app.canvas.FlowEndpointCalculator;
+import systems.courant.sd.app.canvas.ModelEditor;
 import systems.courant.sd.model.def.ElementType;
 import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.ModelDefinitionBuilder;

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/ExtremeConditionDialogTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/ExtremeConditionDialogTest.java
@@ -1,4 +1,4 @@
-package systems.courant.sd.app.canvas;
+package systems.courant.sd.app.canvas.dialogs;
 
 import systems.courant.sd.sweep.ExtremeCondition;
 import systems.courant.sd.sweep.ExtremeConditionFinding;


### PR DESCRIPTION
## Summary
- Moves `ExtremeConditionDialogTest` to `canvas.dialogs` package
- Moves `ReattachControllerTest` to `canvas.controllers` package
- These tests were left in the root `canvas` package after the sub-package split, causing compilation failures due to package-private visibility

## Test plan
- [x] `mvn clean verify` passes