### PR TITLE
Add Calibrate dialog to Simulate menu

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -686,9 +686,13 @@ public class ModelWindow {
         MenuItem optimizeItem = new MenuItem("Optimize...");
         optimizeItem.setOnAction(e -> simulationController.runOptimization());
 
+        MenuItem calibrateItem = new MenuItem("Calibrate...");
+        calibrateItem.setOnAction(e -> simulationController.runCalibration());
+
         simulateMenu.getItems().addAll(settingsItem, runItem,
                 new SeparatorMenuItem(), validateItem, extremeCondItem,
-                new SeparatorMenuItem(), sweepItem, multiSweepItem, monteCarloItem, optimizeItem);
+                new SeparatorMenuItem(), sweepItem, multiSweepItem, monteCarloItem, optimizeItem,
+                calibrateItem);
         simulateMenu.setDisable(true);
         editorOnlyItems.add(simulateMenu);
 
@@ -1224,6 +1228,7 @@ public class ModelWindow {
         commands.add(cmd("Multi-Parameter Sweep", "Simulate", simulationController::runMultiParameterSweep));
         commands.add(cmd("Monte Carlo", "Simulate", simulationController::runMonteCarlo));
         commands.add(cmd("Optimize", "Simulate", simulationController::runOptimization));
+        commands.add(cmd("Calibrate", "Simulate", simulationController::runCalibration));
 
         // View
         commands.add(cmd("Validation Issues", "View", this::showValidationDialog));

--- a/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
@@ -8,6 +8,7 @@ import systems.courant.sd.app.canvas.ModelEditListener;
 import systems.courant.sd.app.canvas.ModelEditor;
 import systems.courant.sd.app.canvas.dialogs.MonteCarloDialog;
 import systems.courant.sd.app.canvas.dialogs.MultiParameterSweepDialog;
+import systems.courant.sd.app.canvas.dialogs.CalibrateDialog;
 import systems.courant.sd.app.canvas.dialogs.OptimizerDialog;
 import systems.courant.sd.app.canvas.dialogs.ParameterSweepDialog;
 import systems.courant.sd.app.canvas.charts.SensitivityPane;
@@ -356,6 +357,90 @@ final class SimulationController {
                             config.algorithm() + ", " + config.parameters().size() + " params"));
                 },
                 "Optimization Error");
+    }
+
+    void runCalibration() {
+        SimulationSettings settings = ensureSettings();
+        if (settings == null) {
+            return;
+        }
+
+        ModelEditor activeEditor = canvas.getEditor();
+        List<String> parameterNames = activeEditor.getParameterNames();
+        List<String> stockNames = activeEditor.getStocks().stream()
+                .map(StockDef::name).toList();
+
+        if (parameterNames.isEmpty()) {
+            showError.accept("Model has no parameters to calibrate.");
+            return;
+        }
+        if (stockNames.isEmpty()) {
+            showError.accept("Model has no stocks to fit against observed data.");
+            return;
+        }
+
+        CalibrateDialog dialog = new CalibrateDialog(parameterNames, stockNames);
+        Optional<CalibrateDialog.Config> configOpt = dialog.showAndWait();
+        if (configOpt.isEmpty()) {
+            return;
+        }
+
+        CalibrateDialog.Config config = configOpt.get();
+        ModelDefinition def = canvas.toModelDefinition();
+        SimulationSettings finalSettings = settings;
+
+        analysisRunner.run(
+                "Calibrating (" + config.maxEvaluations() + " max evals)...",
+                () -> {
+                    TimeUnit timeStep = ModelDefinitionFactory.resolveTimeStep(finalSettings);
+                    Quantity duration = ModelDefinitionFactory.resolveDuration(finalSettings);
+
+                    // Build composite objective: sum SSE across all fit targets
+                    List<CalibrateDialog.FitTarget> targets = config.fitTargets();
+                    List<ObjectiveFunction> perTarget = targets.stream()
+                            .map(t -> Objectives.fitToTimeSeries(t.stockName(), t.observedData()))
+                            .toList();
+                    ObjectiveFunction objective = runResult -> {
+                        double totalSse = 0.0;
+                        for (ObjectiveFunction fn : perTarget) {
+                            totalSse += fn.evaluate(runResult);
+                        }
+                        return totalSse;
+                    };
+
+                    OptimizationAlgorithm algorithm = switch (config.algorithm()) {
+                        case "BOBYQA" -> OptimizationAlgorithm.BOBYQA;
+                        case "CMAES" -> OptimizationAlgorithm.CMAES;
+                        default -> OptimizationAlgorithm.NELDER_MEAD;
+                    };
+
+                    Optimizer.Builder builder = Optimizer.builder()
+                            .compiledModelFactory(
+                                    ModelDefinitionFactory.createFactory(def, finalSettings))
+                            .objective(objective)
+                            .algorithm(algorithm)
+                            .maxEvaluations(config.maxEvaluations())
+                            .timeStep(timeStep)
+                            .duration(duration);
+
+                    for (CalibrateDialog.ParamConfig p : config.parameters()) {
+                        if (Double.isNaN(p.initialGuess())) {
+                            builder.parameter(p.name(), p.lower(), p.upper());
+                        } else {
+                            builder.parameter(p.name(), p.lower(), p.upper(), p.initialGuess());
+                        }
+                    }
+
+                    return builder.build().execute();
+                },
+                result -> {
+                    dashboardPanel.showCalibrationResult(result, config.fitTargets());
+                    switchToDashboard.run();
+                    fireLogEvent.accept(l -> l.onAnalysisRun("Calibration",
+                            config.algorithm() + ", " + config.parameters().size() + " params, "
+                                    + config.fitTargets().size() + " targets"));
+                },
+                "Calibration Error");
     }
 
     void validateModel() {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ClipboardExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ClipboardExporter.java
@@ -52,6 +52,10 @@ public final class ClipboardExporter {
         copyToClipboard(formatOptimizationBestRun(result));
     }
 
+    public static void copyCalibrationBestRun(OptimizationResult result) {
+        copyToClipboard(formatOptimizationBestRun(result));
+    }
+
     // ── Format methods (pure functions, testable) ──────────────────────
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/DashboardPanel.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/DashboardPanel.java
@@ -30,11 +30,13 @@ import java.util.function.Consumer;
 import systems.courant.sd.app.canvas.charts.LoopDominancePane;
 import systems.courant.sd.app.canvas.charts.MonteCarloResultPane;
 import systems.courant.sd.app.canvas.charts.MultiSweepResultPane;
+import systems.courant.sd.app.canvas.charts.CalibrationResultPane;
 import systems.courant.sd.app.canvas.charts.OptimizationResultPane;
 import systems.courant.sd.app.canvas.charts.PhasePlotPane;
 import systems.courant.sd.app.canvas.charts.SensitivityPane;
 import systems.courant.sd.app.canvas.charts.SimulationResultPane;
 import systems.courant.sd.app.canvas.charts.SweepResultPane;
+import systems.courant.sd.app.canvas.dialogs.CalibrateDialog;
 
 /**
  * Dashboard panel that displays results from simulation, parameter sweep,
@@ -60,6 +62,7 @@ public class DashboardPanel extends VBox {
     private Tab sweepTab;
     private Tab monteCarloTab;
     private Tab optimizationTab;
+    private Tab calibrationTab;
     private Tab multiSweepTab;
     private Tab sensitivityTab;
     private Tab dominanceTab;
@@ -233,6 +236,14 @@ public class DashboardPanel extends VBox {
         resultTabs.getSelectionModel().select(optimizationTab);
     }
 
+    public void showCalibrationResult(OptimizationResult result,
+                                      List<CalibrateDialog.FitTarget> fitTargets) {
+        clearStale();
+        CalibrationResultPane pane = new CalibrationResultPane(result, fitTargets);
+        calibrationTab = ensureTab(calibrationTab, "Calibration", pane);
+        resultTabs.getSelectionModel().select(calibrationTab);
+    }
+
     public void showMultiSweepResult(MultiSweepResult result) {
         clearStale();
         MultiSweepResultPane pane = new MultiSweepResultPane(result);
@@ -321,6 +332,8 @@ public class DashboardPanel extends VBox {
                 monteCarloTab = null;
             } else if (tab == optimizationTab) {
                 optimizationTab = null;
+            } else if (tab == calibrationTab) {
+                calibrationTab = null;
             } else if (tab == multiSweepTab) {
                 multiSweepTab = null;
             } else if (tab == sensitivityTab) {
@@ -372,6 +385,7 @@ public class DashboardPanel extends VBox {
         sweepTab = null;
         monteCarloTab = null;
         optimizationTab = null;
+        calibrationTab = null;
         multiSweepTab = null;
         sensitivityTab = null;
         phasePlotTab = null;

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContent.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContent.java
@@ -38,6 +38,7 @@ public final class HelpContent {
             case PARAMETER_SWEEP -> parameterSweepContent();
             case MONTE_CARLO -> monteCarloContent();
             case OPTIMIZATION -> optimizationContent();
+            case CALIBRATION -> calibrationContent();
             case MULTI_SWEEP -> multiSweepContent();
             case FEEDBACK_LOOPS -> feedbackLoopsContent();
             case CAUSAL_LOOPS -> causalLoopsContent();
@@ -336,6 +337,41 @@ public final class HelpContent {
                 bold("Results"),
                 plain(" show the best parameter values found, the objective value, "
                         + "and a convergence plot.")
+        );
+    }
+
+    private static TextFlow calibrationContent() {
+        return new TextFlow(
+                bold("Calibration"),
+                plain(" fits model parameters to observed data by minimizing the sum of squared "
+                        + "errors (SSE) between simulated and observed time series.\n\n"),
+                bold("Setup:\n"),
+                plain("  1. "), bold("Import CSV"),
+                plain(" \u2014 load a CSV file containing observed data. The first column must be "
+                        + "the time axis; remaining columns are data series\n"),
+                plain("  2. "), bold("Map columns"),
+                plain(" \u2014 map each CSV column to a model stock. Columns that don't correspond "
+                        + "to a stock can be skipped\n"),
+                plain("  3. "), bold("Set parameter bounds"),
+                plain(" \u2014 select which parameters to calibrate and specify lower/upper bounds "
+                        + "and an optional initial guess\n"),
+                plain("  4. "), bold("Pick algorithm"),
+                plain(" \u2014 choose the optimization algorithm and maximum evaluations\n\n"),
+                bold("How SSE works:\n\n"),
+                mono("  SSE = \u03a3 (simulated[t] \u2212 observed[t])\u00b2\n\n"),
+                plain("Lower SSE means a better fit. When multiple stocks are mapped, the total SSE "
+                        + "is the sum across all fit targets.\n\n"),
+                bold("Algorithms:\n"),
+                plain("  \u2022 "), bold("Nelder-Mead"),
+                plain(" \u2014 derivative-free simplex method, good for smooth objectives\n"),
+                plain("  \u2022 "), bold("BOBYQA"),
+                plain(" \u2014 bounded optimization by quadratic approximation, good for bounded parameters\n"),
+                plain("  \u2022 "), bold("CMA-ES"),
+                plain(" \u2014 evolutionary strategy, good for noisy or multimodal landscapes\n\n"),
+                bold("Results"),
+                plain(" show the recovered parameter values, total SSE, and a chart overlaying "
+                        + "simulated and observed data for each fit target. Observed data is shown "
+                        + "with a dashed line.")
         );
     }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContextResolver.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContextResolver.java
@@ -145,6 +145,7 @@ public final class HelpContextResolver {
             case "SimulationSettingsDialog" -> HelpTopic.SIMULATION_SETTINGS;
             case "MonteCarloDialog" -> HelpTopic.MONTE_CARLO;
             case "OptimizerDialog" -> HelpTopic.OPTIMIZATION;
+            case "CalibrateDialog" -> HelpTopic.CALIBRATION;
             case "ParameterSweepDialog" -> HelpTopic.PARAMETER_SWEEP;
             case "MultiParameterSweepDialog" -> HelpTopic.MULTI_SWEEP;
             case "DefinePortsDialog" -> HelpTopic.MODULE_PORTS;

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpTopic.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpTopic.java
@@ -29,6 +29,7 @@ public enum HelpTopic {
     PARAMETER_SWEEP("Parameter Sweep", "Analysis"),
     MONTE_CARLO("Monte Carlo Analysis", "Analysis"),
     OPTIMIZATION("Optimization", "Analysis"),
+    CALIBRATION("Calibration", "Analysis"),
     MULTI_SWEEP("Multi-Parameter Sweep", "Analysis"),
 
     // Structure

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/CalibrationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/CalibrationResultPane.java
@@ -1,0 +1,185 @@
+package systems.courant.sd.app.canvas.charts;
+
+import systems.courant.sd.app.canvas.dialogs.CalibrateDialog;
+import systems.courant.sd.sweep.OptimizationResult;
+import systems.courant.sd.sweep.RunResult;
+
+import com.opencsv.CSVWriter;
+
+import javafx.geometry.Insets;
+import javafx.scene.chart.LineChart;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.VBox;
+
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import systems.courant.sd.app.canvas.ChartUtils;
+import systems.courant.sd.app.canvas.ClipboardExporter;
+import systems.courant.sd.app.canvas.Styles;
+
+/**
+ * Displays calibration results: a summary grid showing recovered parameters
+ * and SSE, plus a line chart overlaying simulated vs observed data for each
+ * fit target.
+ */
+public class CalibrationResultPane extends BorderPane {
+
+    private final OptimizationResult result;
+    private LineChart<Number, Number> chart;
+
+    public CalibrationResultPane(OptimizationResult result,
+                                  List<CalibrateDialog.FitTarget> fitTargets) {
+        this.result = result;
+
+        // Summary grid
+        GridPane summaryGrid = new GridPane();
+        summaryGrid.setHgap(10);
+        summaryGrid.setVgap(4);
+        summaryGrid.setPadding(new Insets(10));
+
+        int row = 0;
+        Label headerLabel = new Label("Calibration Results");
+        headerLabel.setStyle(Styles.SECTION_HEADER);
+        summaryGrid.add(headerLabel, 0, row++, 2, 1);
+
+        summaryGrid.add(boldLabel("SSE:"), 0, row);
+        summaryGrid.add(new Label(ChartUtils.formatNumber(result.getBestObjectiveValue())), 1, row++);
+
+        summaryGrid.add(boldLabel("Evaluations:"), 0, row);
+        summaryGrid.add(new Label(String.valueOf(result.getEvaluationCount())), 1, row++);
+
+        for (Map.Entry<String, Double> entry : result.getBestParameters().entrySet()) {
+            summaryGrid.add(boldLabel(entry.getKey() + ":"), 0, row);
+            summaryGrid.add(new Label(ChartUtils.formatNumber(entry.getValue())), 1, row++);
+        }
+
+        // Chart overlaying simulated vs observed
+        RunResult bestRun = result.getBestRunResult();
+        chart = buildChart(bestRun, fitTargets);
+
+        ContextMenu contextMenu = new ContextMenu();
+        MenuItem saveItem = new MenuItem("Save as PNG...");
+        saveItem.setOnAction(e -> saveChartAsPng());
+        MenuItem exportCsv = new MenuItem("Export CSV (Best Run)...");
+        exportCsv.setOnAction(e -> exportBestRunCsv());
+        MenuItem copyItem = new MenuItem("Copy to Clipboard (Best Run)");
+        copyItem.setOnAction(e -> ClipboardExporter.copyCalibrationBestRun(result));
+        contextMenu.getItems().addAll(saveItem, exportCsv, copyItem);
+        chart.setOnContextMenuRequested(e ->
+                contextMenu.show(chart, e.getScreenX(), e.getScreenY()));
+
+        VBox topSection = new VBox(summaryGrid);
+        setTop(topSection);
+        setCenter(chart);
+    }
+
+    private LineChart<Number, Number> buildChart(RunResult bestRun,
+                                                  List<CalibrateDialog.FitTarget> fitTargets) {
+        NumberAxis xAxis = new NumberAxis();
+        xAxis.setLabel("Step");
+        NumberAxis yAxis = new NumberAxis();
+        yAxis.setLabel("Value");
+
+        LineChart<Number, Number> lineChart = new LineChart<>(xAxis, yAxis);
+        lineChart.setCreateSymbols(false);
+        lineChart.setAnimated(false);
+
+        int colorIndex = 0;
+        List<String> colors = ChartUtils.SERIES_COLORS;
+
+        for (CalibrateDialog.FitTarget target : fitTargets) {
+            String color = colors.get(colorIndex % colors.size());
+
+            // Simulated series
+            double[] simulated = bestRun.getStockSeries(target.stockName());
+            XYChart.Series<Number, Number> simSeries = new XYChart.Series<>();
+            simSeries.setName(target.stockName() + " (simulated)");
+            for (int s = 0; s < simulated.length; s++) {
+                simSeries.getData().add(new XYChart.Data<>(bestRun.getStep(s), simulated[s]));
+            }
+            lineChart.getData().add(simSeries);
+            applyLineStyle(simSeries, color, false);
+
+            // Observed series
+            double[] observed = target.observedData();
+            XYChart.Series<Number, Number> obsSeries = new XYChart.Series<>();
+            obsSeries.setName(target.csvColumnName() + " (observed)");
+            int obsLen = Math.min(observed.length, bestRun.getStepCount());
+            for (int s = 0; s < obsLen; s++) {
+                obsSeries.getData().add(new XYChart.Data<>(bestRun.getStep(s), observed[s]));
+            }
+            lineChart.getData().add(obsSeries);
+            applyLineStyle(obsSeries, color, true);
+
+            colorIndex++;
+        }
+
+        return lineChart;
+    }
+
+    private static void applyLineStyle(XYChart.Series<Number, Number> series,
+                                        String color, boolean dashed) {
+        String style = "-fx-stroke: " + color + ";"
+                + (dashed ? " -fx-stroke-dash-array: 5 5;" : "");
+        series.nodeProperty().addListener((obs, oldNode, newNode) -> {
+            if (newNode != null) {
+                newNode.setStyle(style);
+            }
+        });
+        if (series.getNode() != null) {
+            series.getNode().setStyle(style);
+        }
+    }
+
+    private void saveChartAsPng() {
+        ChartUtils.saveNodeAsPng(chart, "calibration_chart.png",
+                getScene() != null ? getScene().getWindow() : null);
+    }
+
+    private void exportBestRunCsv() {
+        ChartUtils.showCsvSaveDialog("Export Best Run CSV", "calibration_best_run.csv",
+                getScene() != null ? getScene().getWindow() : null, file -> {
+                    RunResult bestRun = result.getBestRunResult();
+                    List<String> stockNames = bestRun.getStockNames();
+                    List<String> varNames = bestRun.getVariableNames();
+
+                    try (CSVWriter writer = new CSVWriter(new OutputStreamWriter(
+                            Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8))) {
+                        List<String> header = new ArrayList<>();
+                        header.add("Step");
+                        header.addAll(stockNames);
+                        header.addAll(varNames);
+                        writer.writeNext(header.toArray(new String[0]));
+
+                        for (int s = 0; s < bestRun.getStepCount(); s++) {
+                            List<String> csvRow = new ArrayList<>();
+                            csvRow.add(String.valueOf(bestRun.getStep(s)));
+                            for (double v : bestRun.getStockValuesAtStep(s)) {
+                                csvRow.add(String.valueOf(v));
+                            }
+                            for (double v : bestRun.getVariableValuesAtStep(s)) {
+                                csvRow.add(String.valueOf(v));
+                            }
+                            writer.writeNext(csvRow.toArray(new String[0]));
+                        }
+                    }
+                });
+    }
+
+    private static Label boldLabel(String text) {
+        Label label = new Label(text);
+        label.setStyle(Styles.BOLD_TEXT);
+        return label;
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialog.java
@@ -1,0 +1,356 @@
+package systems.courant.sd.app.canvas.dialogs;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.stage.FileChooser;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import systems.courant.sd.app.canvas.ParameterRowBase;
+import systems.courant.sd.app.canvas.Styles;
+import systems.courant.sd.io.ReferenceDataCsvReader;
+import systems.courant.sd.model.def.ReferenceDataset;
+
+/**
+ * Dialog for configuring a calibration run: import observed CSV data,
+ * map columns to model stocks, set parameter bounds, and choose algorithm.
+ */
+public class CalibrateDialog extends Dialog<CalibrateDialog.Config> {
+
+    public record FitTarget(String stockName, String csvColumnName, double[] observedData) {
+    }
+
+    public record ParamConfig(String name, double lower, double upper, double initialGuess) {
+    }
+
+    public record Config(
+            List<FitTarget> fitTargets,
+            List<ParamConfig> parameters,
+            String algorithm,
+            int maxEvaluations
+    ) {
+    }
+
+    private final ObservableList<ParamRow> paramRows = FXCollections.observableArrayList();
+    private final IntegerProperty fieldChangeCounter = new SimpleIntegerProperty(0);
+    private final Label datasetLabel;
+    private final ComboBox<String> algorithmCombo;
+    private final TextField maxEvalsField;
+    private final Label validationLabel;
+    private final VBox fitTargetBox;
+    private final List<String> stockNames;
+
+    private ReferenceDataset importedDataset;
+    private final List<FitTargetRow> fitTargetRows = new ArrayList<>();
+
+    public CalibrateDialog(List<String> constantNames, List<String> stockNames) {
+        this.stockNames = stockNames;
+        setTitle("Calibrate");
+        setHeaderText("Fit model parameters to observed data");
+
+        // --- Observed Data section ---
+        Label dataLabel = new Label("Observed Data");
+        dataLabel.setStyle(Styles.SECTION_HEADER);
+
+        datasetLabel = new Label("No data loaded");
+        datasetLabel.setId("calibDatasetLabel");
+
+        Button importBtn = new Button("Import CSV...");
+        importBtn.setId("calibImportCsv");
+        importBtn.setOnAction(e -> importCsv());
+
+        HBox dataRow = new HBox(10, importBtn, datasetLabel);
+
+        // --- Fit Targets section ---
+        Label fitLabel = new Label("Fit Targets");
+        fitLabel.setStyle(Styles.SECTION_HEADER);
+
+        fitTargetBox = new VBox(6);
+        fitTargetBox.setPadding(new Insets(5));
+
+        // --- Parameters section ---
+        Label paramsLabel = new Label("Parameters");
+        paramsLabel.setStyle(Styles.SECTION_HEADER);
+
+        VBox paramBox = new VBox(6);
+        paramBox.setPadding(new Insets(5));
+
+        Button addButton = new Button("Add Parameter");
+        addButton.setId("calibAddParam");
+        addButton.setOnAction(e -> {
+            ParamRow row = new ParamRow(constantNames, paramBox);
+            paramRows.add(row);
+            paramBox.getChildren().add(paramBox.getChildren().size() - 1, row.getPane());
+        });
+
+        paramBox.getChildren().add(addButton);
+
+        // Add one default row
+        ParamRow defaultRow = new ParamRow(constantNames, paramBox);
+        paramRows.add(defaultRow);
+        paramBox.getChildren().add(0, defaultRow.getPane());
+
+        ScrollPane paramScroll = new ScrollPane(paramBox);
+        paramScroll.setFitToWidth(true);
+        paramScroll.setPrefHeight(150);
+
+        // --- Settings section ---
+        Label settingsLabel = new Label("Settings");
+        settingsLabel.setStyle(Styles.SECTION_HEADER);
+
+        algorithmCombo = new ComboBox<>(FXCollections.observableArrayList(
+                "NELDER_MEAD", "BOBYQA", "CMAES"));
+        algorithmCombo.setValue("NELDER_MEAD");
+        algorithmCombo.setId("calibAlgorithm");
+
+        maxEvalsField = new TextField("1000");
+        maxEvalsField.setId("calibMaxEvals");
+
+        GridPane settingsGrid = new GridPane();
+        settingsGrid.setHgap(10);
+        settingsGrid.setVgap(10);
+        settingsGrid.setPadding(new Insets(10, 0, 0, 0));
+
+        settingsGrid.add(new Label("Algorithm:"), 0, 0);
+        settingsGrid.add(algorithmCombo, 1, 0);
+        settingsGrid.add(new Label("Max Evaluations:"), 0, 1);
+        settingsGrid.add(maxEvalsField, 1, 1);
+
+        // --- Validation ---
+        validationLabel = new Label();
+        validationLabel.setStyle(Styles.VALIDATION_ERROR);
+        validationLabel.setWrapText(true);
+        validationLabel.setMaxWidth(Double.MAX_VALUE);
+        validationLabel.setId("calibValidationLabel");
+        validationLabel.textProperty().bind(
+                Bindings.createStringBinding(this::getValidationMessage,
+                        maxEvalsField.textProperty(), paramRows, fieldChangeCounter)
+        );
+
+        VBox content = new VBox(10,
+                dataLabel, dataRow,
+                fitLabel, fitTargetBox,
+                paramsLabel, paramScroll,
+                settingsLabel, settingsGrid,
+                validationLabel);
+        content.setPadding(new Insets(10));
+        getDialogPane().setContent(content);
+        getDialogPane().setPrefWidth(Styles.screenAwareWidth(Styles.CONFIG_DIALOG_WIDTH));
+
+        ButtonType okButton = new ButtonType("OK", ButtonBar.ButtonData.OK_DONE);
+        getDialogPane().getButtonTypes().addAll(okButton, ButtonType.CANCEL);
+
+        getDialogPane().lookupButton(okButton).disableProperty().bind(
+                Bindings.createBooleanBinding(this::isInvalid,
+                        maxEvalsField.textProperty(), paramRows, fieldChangeCounter)
+        );
+
+        setResultConverter(button -> {
+            if (button == okButton) {
+                List<FitTarget> targets = new ArrayList<>();
+                for (FitTargetRow row : fitTargetRows) {
+                    String stock = row.stockCombo.getValue();
+                    if (stock != null && !stock.isEmpty()) {
+                        double[] data = importedDataset.columns().get(row.csvColumn);
+                        targets.add(new FitTarget(stock, row.csvColumn, data));
+                    }
+                }
+                List<ParamConfig> params = new ArrayList<>();
+                for (ParamRow row : paramRows) {
+                    if (row.isValid()) {
+                        params.add(row.toConfig());
+                    }
+                }
+                return new Config(
+                        targets,
+                        params,
+                        algorithmCombo.getValue(),
+                        Integer.parseInt(maxEvalsField.getText().trim())
+                );
+            }
+            return null;
+        });
+    }
+
+    private void importCsv() {
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Import Observed Data CSV");
+        chooser.getExtensionFilters().add(
+                new FileChooser.ExtensionFilter("CSV Files", "*.csv"));
+        File file = chooser.showOpenDialog(getDialogPane().getScene().getWindow());
+        if (file == null) {
+            return;
+        }
+        try {
+            importedDataset = ReferenceDataCsvReader.read(file.toPath(), file.getName());
+            datasetLabel.setText(file.getName());
+
+            // Show column mapping dialog
+            ColumnMappingDialog mappingDialog = new ColumnMappingDialog(importedDataset, stockNames);
+            var mapped = mappingDialog.showAndWait().orElse(null);
+            if (mapped != null) {
+                importedDataset = mapped;
+                buildFitTargetRows();
+            }
+        } catch (IOException ex) {
+            datasetLabel.setText("Error: " + ex.getMessage());
+        }
+        fieldChangeCounter.set(fieldChangeCounter.get() + 1);
+    }
+
+    private void buildFitTargetRows() {
+        fitTargetRows.clear();
+        fitTargetBox.getChildren().clear();
+
+        for (String csvCol : importedDataset.variableNames()) {
+            FitTargetRow row = new FitTargetRow(csvCol);
+            fitTargetRows.add(row);
+            fitTargetBox.getChildren().add(row.pane);
+        }
+        fieldChangeCounter.set(fieldChangeCounter.get() + 1);
+    }
+
+    private boolean isInvalid() {
+        return !getValidationMessage().isEmpty();
+    }
+
+    private String getValidationMessage() {
+        if (importedDataset == null) {
+            return "Import CSV observed data first.";
+        }
+        if (fitTargetRows.isEmpty()
+                || fitTargetRows.stream().noneMatch(r -> r.stockCombo.getValue() != null
+                && !r.stockCombo.getValue().isEmpty())) {
+            return "At least one fit target must be mapped.";
+        }
+        if (paramRows.stream().noneMatch(ParamRow::isValid)) {
+            return "Add at least one parameter with valid bounds.";
+        }
+        try {
+            int maxEvals = Integer.parseInt(maxEvalsField.getText().trim());
+            if (maxEvals < 1) {
+                return "Max evaluations must be at least 1.";
+            }
+        } catch (NumberFormatException e) {
+            return "Max evaluations must be a valid integer.";
+        }
+        return "";
+    }
+
+    private class FitTargetRow {
+        final String csvColumn;
+        final ComboBox<String> stockCombo;
+        final HBox pane;
+
+        FitTargetRow(String csvColumn) {
+            this.csvColumn = csvColumn;
+
+            stockCombo = new ComboBox<>(FXCollections.observableArrayList(stockNames));
+            stockCombo.setPrefWidth(150);
+
+            // Auto-select matching stock
+            stockNames.stream()
+                    .filter(s -> s.equalsIgnoreCase(csvColumn)
+                            || s.replace(" ", "_").equalsIgnoreCase(csvColumn)
+                            || s.equalsIgnoreCase(csvColumn.replace("_", " ")))
+                    .findFirst()
+                    .ifPresent(stockCombo::setValue);
+
+            stockCombo.valueProperty().addListener(
+                    (obs, o, n) -> fieldChangeCounter.set(fieldChangeCounter.get() + 1));
+
+            pane = new HBox(10,
+                    new Label(csvColumn + " \u2192"),
+                    stockCombo);
+            pane.setPadding(new Insets(2));
+        }
+    }
+
+    private class ParamRow extends ParameterRowBase {
+        private final TextField lowerField;
+        private final TextField upperField;
+        private final TextField guessField;
+
+        ParamRow(List<String> constantNames, VBox container) {
+            super(constantNames, null,
+                    () -> fieldChangeCounter.set(fieldChangeCounter.get() + 1));
+            int rowIndex = paramRows.size();
+            nameCombo.setId("calibParamName" + rowIndex);
+
+            lowerField = new TextField("0");
+            lowerField.setPrefWidth(60);
+            lowerField.setPromptText("Lower");
+            lowerField.setId("calibLower" + rowIndex);
+            upperField = new TextField("10");
+            upperField.setPrefWidth(60);
+            upperField.setPromptText("Upper");
+            upperField.setId("calibUpper" + rowIndex);
+            guessField = new TextField("");
+            guessField.setPrefWidth(60);
+            guessField.setPromptText("Guess");
+            guessField.setId("calibGuess" + rowIndex);
+
+            wireFieldChange(lowerField);
+            wireFieldChange(upperField);
+            wireFieldChange(guessField);
+
+            Button removeBtn = createRemoveButton(() -> {
+                paramRows.remove(this);
+                container.getChildren().remove(getPane());
+            });
+
+            buildPane(removeBtn,
+                    new Label("Low:"), lowerField,
+                    new Label("High:"), upperField,
+                    new Label("Guess:"), guessField);
+        }
+
+        @Override
+        public boolean isValid() {
+            if (!isNameSelected()) {
+                return false;
+            }
+            try {
+                double low = Double.parseDouble(lowerField.getText().trim());
+                double high = Double.parseDouble(upperField.getText().trim());
+                if (low >= high) {
+                    return false;
+                }
+                String guessText = guessField.getText().trim();
+                if (!guessText.isEmpty()) {
+                    double guess = Double.parseDouble(guessText);
+                    return guess >= low && guess <= high;
+                }
+                return true;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+
+        ParamConfig toConfig() {
+            double low = Double.parseDouble(lowerField.getText().trim());
+            double high = Double.parseDouble(upperField.getText().trim());
+            String guessText = guessField.getText().trim();
+            double guess = guessText.isEmpty() ? Double.NaN : Double.parseDouble(guessText);
+            return new ParamConfig(getSelectedName(), low, high, guess);
+        }
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/CalibrationResultPaneFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/CalibrationResultPaneFxTest.java
@@ -1,0 +1,128 @@
+package systems.courant.sd.app.canvas.charts;
+
+import systems.courant.sd.Simulation;
+import systems.courant.sd.app.canvas.dialogs.CalibrateDialog;
+import systems.courant.sd.measure.Quantity;
+import systems.courant.sd.model.Flow;
+import systems.courant.sd.model.Model;
+import systems.courant.sd.model.Stock;
+import systems.courant.sd.sweep.OptimizationResult;
+import systems.courant.sd.sweep.RunResult;
+
+import javafx.scene.Scene;
+import javafx.scene.chart.LineChart;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static systems.courant.sd.measure.Units.GALLON_US;
+import static systems.courant.sd.measure.Units.MINUTE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CalibrationResultPane (TestFX)")
+@ExtendWith(ApplicationExtension.class)
+class CalibrationResultPaneFxTest {
+
+    private CalibrationResultPane pane;
+
+    @Start
+    void start(Stage stage) {
+        OptimizationResult result = buildOptimizationResult();
+        List<CalibrateDialog.FitTarget> fitTargets = List.of(
+                new CalibrateDialog.FitTarget("Tank", "Observed_Tank",
+                        new double[]{100, 92, 85, 77, 70, 62}));
+        pane = new CalibrationResultPane(result, fitTargets);
+        stage.setScene(new Scene(pane, 800, 600));
+        stage.show();
+    }
+
+    @Test
+    @DisplayName("Pane contains a LineChart in center")
+    void shouldContainLineChart(FxRobot robot) {
+        LineChart<?, ?> chart = robot.lookup(".chart").queryAs(LineChart.class);
+        assertThat(chart).isNotNull();
+        assertThat(chart.animatedProperty().get()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Chart has both simulated and observed series")
+    void chartHasSimulatedAndObservedSeries(FxRobot robot) {
+        LineChart<?, ?> chart = robot.lookup(".chart").queryAs(LineChart.class);
+        assertThat(chart.getData()).hasSize(2);
+        boolean foundSimulated = chart.getData().stream()
+                .anyMatch(s -> s.getName().contains("simulated"));
+        boolean foundObserved = chart.getData().stream()
+                .anyMatch(s -> s.getName().contains("observed"));
+        assertThat(foundSimulated).isTrue();
+        assertThat(foundObserved).isTrue();
+    }
+
+    @Test
+    @DisplayName("Top section contains summary grid with calibration results")
+    void topContainsSummaryGrid(FxRobot robot) {
+        assertThat(pane.getTop()).isNotNull();
+
+        Set<Label> labels = robot.lookup(".label").queryAllAs(Label.class);
+        boolean foundHeader = labels.stream()
+                .anyMatch(l -> l.getText() != null && l.getText().contains("Calibration Results"));
+        assertThat(foundHeader).isTrue();
+    }
+
+    @Test
+    @DisplayName("Summary grid shows SSE and evaluation count")
+    void summaryGridShowsSseAndEvaluations(FxRobot robot) {
+        Set<Label> labels = robot.lookup(".label").queryAllAs(Label.class);
+
+        boolean foundSse = labels.stream()
+                .anyMatch(l -> l.getText() != null && l.getText().contains("SSE"));
+        boolean foundEvaluations = labels.stream()
+                .anyMatch(l -> l.getText() != null && l.getText().contains("Evaluations"));
+
+        assertThat(foundSse).isTrue();
+        assertThat(foundEvaluations).isTrue();
+    }
+
+    @Test
+    @DisplayName("Summary grid shows best parameter values")
+    void summaryGridShowsBestParameters(FxRobot robot) {
+        Set<Label> labels = robot.lookup(".label").queryAllAs(Label.class);
+
+        boolean foundDrainRate = labels.stream()
+                .anyMatch(l -> l.getText() != null && l.getText().contains("drainRate"));
+        assertThat(foundDrainRate).isTrue();
+    }
+
+    private static OptimizationResult buildOptimizationResult() {
+        Map<String, Double> bestParams = new LinkedHashMap<>();
+        bestParams.put("drainRate", 7.5);
+
+        RunResult bestRun = buildRunResult(7.5);
+
+        return new OptimizationResult(bestParams, 42.0, bestRun, 100);
+    }
+
+    private static RunResult buildRunResult(double drainRate) {
+        Model model = new Model("Calib Test");
+        Stock tank = new Stock("Tank", 100, GALLON_US);
+        Flow outflow = Flow.create("Drain", MINUTE, () -> new Quantity(drainRate, GALLON_US));
+        tank.addOutflow(outflow);
+        model.addStock(tank);
+
+        RunResult rr = new RunResult(Map.of("drainRate", drainRate));
+        Simulation sim = new Simulation(model, MINUTE, MINUTE, 5);
+        sim.addEventHandler(rr);
+        sim.execute();
+        return rr;
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialogFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialogFxTest.java
@@ -1,0 +1,113 @@
+package systems.courant.sd.app.canvas.dialogs;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.DialogPane;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CalibrateDialog (TestFX)")
+@ExtendWith(ApplicationExtension.class)
+class CalibrateDialogFxTest {
+
+    private CalibrateDialog dialog;
+    private DialogPane dialogPane;
+
+    @Start
+    void start(Stage stage) {
+        stage.setScene(new Scene(new StackPane(), 200, 200));
+        stage.show();
+    }
+
+    private void showDialog(List<String> constants, List<String> stocks) {
+        Platform.runLater(() -> {
+            dialog = new CalibrateDialog(constants, stocks);
+            dialogPane = dialog.getDialogPane();
+            dialog.show();
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    private Node okButton() {
+        return dialogPane.lookupButton(
+                dialogPane.getButtonTypes().stream()
+                        .filter(bt -> bt.getButtonData().isDefaultButton())
+                        .findFirst().orElseThrow());
+    }
+
+    @Test
+    @DisplayName("Dialog opens with OK disabled (no CSV imported)")
+    void okDisabledInitially(FxRobot robot) {
+        showDialog(List.of("alpha"), List.of("Population"));
+
+        assertThat(okButton().isDisabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Default algorithm is NELDER_MEAD")
+    void defaultAlgorithm(FxRobot robot) {
+        showDialog(List.of("alpha"), List.of("Pop"));
+
+        Set<ComboBox> combos = robot.lookup(".combo-box").queryAllAs(ComboBox.class);
+        boolean foundNM = combos.stream()
+                .anyMatch(c -> "NELDER_MEAD".equals(c.getValue()));
+        assertThat(foundNM).isTrue();
+    }
+
+    @Test
+    @DisplayName("Default max evaluations is 1000")
+    void defaultMaxEvals(FxRobot robot) {
+        showDialog(List.of("alpha"), List.of("Pop"));
+
+        Set<TextField> fields = robot.lookup(".text-field").queryAllAs(TextField.class);
+        boolean found1000 = fields.stream().anyMatch(f -> "1000".equals(f.getText()));
+        assertThat(found1000).isTrue();
+    }
+
+    @Test
+    @DisplayName("Validation shows 'Import CSV observed data first' initially")
+    void validationShowsImportMessage(FxRobot robot) {
+        showDialog(List.of("alpha"), List.of("Population"));
+
+        Label validationLabel = robot.lookup("#calibValidationLabel").queryAs(Label.class);
+        assertThat(validationLabel.getText()).contains("Import CSV observed data first");
+    }
+
+    @Test
+    @DisplayName("OK disabled when max evaluations is non-numeric")
+    void okDisabledWhenMaxEvalsNonNumeric(FxRobot robot) {
+        showDialog(List.of("alpha"), List.of("Pop"));
+
+        TextField maxEvalsField = robot.lookup("#calibMaxEvals").queryAs(TextField.class);
+        robot.clickOn(maxEvalsField).eraseText(4).write("abc");
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(okButton().isDisabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Dataset label shows 'No data loaded' initially")
+    void datasetLabelInitial(FxRobot robot) {
+        showDialog(List.of("alpha"), List.of("Pop"));
+
+        Label datasetLabel = robot.lookup("#calibDatasetLabel").queryAs(Label.class);
+        assertThat(datasetLabel.getText()).isEqualTo("No data loaded");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a dedicated **Calibrate...** menu item and command palette entry under Simulate, wiring existing engine support (`Objectives.fitToTimeSeries`, `Optimizer`, `ReferenceDataCsvReader`) into a new calibration workflow
- `CalibrateDialog` handles CSV import, column mapping via `ColumnMappingDialog`, parameter bounds, algorithm selection, and validation
- `CalibrationResultPane` displays recovered parameters, SSE, and an overlay chart with simulated (solid) vs observed (dashed) series
- Adds calibration help topic with setup steps, SSE explanation, and algorithm descriptions

Closes #676

## Test plan
- [x] `mvn clean compile` — full reactor passes
- [x] `mvn test` — 1665 tests pass (0 failures)
- [x] `mvn spotbugs:check` — no new findings
- [ ] Manual: Simulate → Calibrate → import CSV → map columns → set param bounds → run → verify results tab with overlay chart
- [ ] Manual: F1 in Calibrate dialog → verify help content appears
- [ ] Manual: Command palette → type "Calibrate" → verify it launches dialog