### PR TITLE
Fix menu auto-close and enable F1 help in dialogs

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -126,6 +126,7 @@ public class ModelWindow {
     private SplitPane editorSplitPane;
     private VBox topContainer;
     private CanvasToolBar toolBar;
+    private MenuBar menuBar;
     private LoopNavigatorBar loopNavigatorBar;
     private boolean editorShown;
     private final List<MenuItem> editorOnlyItems = new ArrayList<>();
@@ -180,7 +181,7 @@ public class ModelWindow {
         configureCanvasCallbacks();
         createRightPanel();
 
-        MenuBar menuBar = createMenuBar();
+        menuBar = createMenuBar();
         topContainer = new VBox(menuBar, toolBar, loopNavigatorBar, breadcrumbBar);
 
         root = new BorderPane();
@@ -217,6 +218,11 @@ public class ModelWindow {
         // immediately without requiring a click first.
         stage.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
             if (isFocused) {
+                // Don't steal focus from MenuBar menus — doing so closes them
+                boolean menuShowing = menuBar.getMenus().stream().anyMatch(Menu::isShowing);
+                if (menuShowing) {
+                    return;
+                }
                 Node focused = scene.getFocusOwner();
                 if (focused == null || focused == root
                         || !(focused instanceof javafx.scene.control.TextInputControl)) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContextResolver.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContextResolver.java
@@ -3,10 +3,15 @@ package systems.courant.sd.app.canvas;
 import systems.courant.sd.model.def.ElementType;
 
 import javafx.scene.Node;
+import javafx.scene.control.Dialog;
 import javafx.scene.control.TabPane;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 
 import java.util.Set;
+
 import systems.courant.sd.app.canvas.dialogs.BindingConfigDialog;
+import systems.courant.sd.app.canvas.dialogs.ContextHelpDialog;
 import systems.courant.sd.app.canvas.dialogs.DefinePortsDialog;
 import systems.courant.sd.app.canvas.dialogs.ExpressionLanguageDialog;
 import systems.courant.sd.app.canvas.dialogs.MonteCarloDialog;
@@ -189,6 +194,30 @@ public final class HelpContextResolver {
             case PLACE_COMMENT -> HelpTopic.COMMENT;
             case SELECT -> null;
         };
+    }
+
+    /**
+     * Installs an F1 key handler on a {@link Dialog} so that pressing F1
+     * opens context help for that dialog type.
+     *
+     * <p>Modal dialogs have their own Stage, so they don't receive the
+     * Scene-level F1 filter installed in ModelWindow. This method bridges
+     * the gap by adding a filter directly on the dialog pane.
+     *
+     * @param dialog the dialog to install the handler on
+     */
+    public static void installF1Handler(Dialog<?> dialog) {
+        dialog.getDialogPane().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.F1) {
+                String className = dialog.getClass().getSimpleName();
+                HelpTopic topic = topicForDialog(className);
+                ContextHelpDialog helpDialog = new ContextHelpDialog();
+                helpDialog.initOwner(dialog.getDialogPane().getScene().getWindow());
+                helpDialog.showTopic(topic);
+                helpDialog.show();
+                event.consume();
+            }
+        });
     }
 
     private static boolean isEquationFieldFocused(Node focusOwner) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/BindingConfigDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/BindingConfigDialog.java
@@ -16,6 +16,7 @@ import javafx.scene.layout.VBox;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.app.canvas.Styles;
 
 /**
@@ -37,6 +38,7 @@ public class BindingConfigDialog extends Dialog<BindingConfigDialog.BindingResul
     private final Map<String, TextField> outputFields = new HashMap<>();
 
     public BindingConfigDialog(ModuleInstanceDef module) {
+        HelpContextResolver.installF1Handler(this);
         setTitle("Configure Bindings — " + module.instanceName());
         setHeaderText("Configure port bindings for module '" + module.instanceName() + "'");
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ColumnMappingDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ColumnMappingDialog.java
@@ -13,6 +13,7 @@ import javafx.scene.layout.GridPane;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.app.canvas.Styles;
 
 /**
@@ -31,6 +32,7 @@ public class ColumnMappingDialog extends Dialog<ReferenceDataset> {
      * @param modelVariables the known model variable names available for mapping
      */
     public ColumnMappingDialog(ReferenceDataset dataset, List<String> modelVariables) {
+        HelpContextResolver.installF1Handler(this);
         setTitle("Map Reference Data Columns");
         setHeaderText("Map CSV columns to model variables");
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/DefinePortsDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/DefinePortsDialog.java
@@ -18,6 +18,7 @@ import javafx.scene.layout.VBox;
 
 import java.util.ArrayList;
 import java.util.List;
+import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.app.canvas.Styles;
 
 /**
@@ -34,6 +35,7 @@ public class DefinePortsDialog extends Dialog<ModuleInterface> {
     private record PortRow(TextField nameField, TextField unitField, HBox container) {}
 
     public DefinePortsDialog(String moduleName, ModuleInterface existing) {
+        HelpContextResolver.installF1Handler(this);
         setTitle("Define Ports — " + moduleName);
         setHeaderText("Define input and output ports for module '" + moduleName + "'");
         setResizable(true);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ExtremeConditionDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ExtremeConditionDialog.java
@@ -1,5 +1,6 @@
 package systems.courant.sd.app.canvas.dialogs;
 
+import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.sweep.ExtremeConditionFinding;
 import systems.courant.sd.sweep.ExtremeConditionResult;
 
@@ -70,6 +71,7 @@ public class ExtremeConditionDialog extends Dialog<Void> {
     }
 
     public ExtremeConditionDialog(ExtremeConditionResult result) {
+        HelpContextResolver.installF1Handler(this);
         initModality(Modality.NONE);
         setTitle("Extreme Condition Test Results");
         this.currentResult = result;

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/MonteCarloDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/MonteCarloDialog.java
@@ -19,6 +19,7 @@ import javafx.scene.layout.VBox;
 
 import java.util.ArrayList;
 import java.util.List;
+import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.app.canvas.ParameterRowBase;
 import systems.courant.sd.app.canvas.Styles;
 
@@ -52,6 +53,7 @@ public class MonteCarloDialog extends Dialog<MonteCarloDialog.Config> {
     private final TextField seedField;
 
     public MonteCarloDialog(List<String> constantNames) {
+        HelpContextResolver.installF1Handler(this);
         this.constantNames = constantNames;
         setTitle("Monte Carlo Simulation");
         setHeaderText("Configure Monte Carlo parameters");

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/MultiParameterSweepDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/MultiParameterSweepDialog.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.app.canvas.ParameterRowBase;
 import systems.courant.sd.app.canvas.Styles;
 
@@ -46,6 +47,7 @@ public class MultiParameterSweepDialog extends Dialog<MultiParameterSweepDialog.
     private final Label combinationCountLabel;
 
     public MultiParameterSweepDialog(List<String> constantNames) {
+        HelpContextResolver.installF1Handler(this);
         setTitle("Multi-Parameter Sweep");
         setHeaderText("Configure parameters to sweep (at least 2)");
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/OptimizerDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/OptimizerDialog.java
@@ -19,6 +19,7 @@ import javafx.scene.layout.VBox;
 
 import java.util.ArrayList;
 import java.util.List;
+import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.app.canvas.ParameterRowBase;
 import systems.courant.sd.app.canvas.Styles;
 
@@ -55,6 +56,7 @@ public class OptimizerDialog extends Dialog<OptimizerDialog.Config> {
     private final TextField maxEvalsField;
 
     public OptimizerDialog(List<String> constantNames, List<String> stockNames) {
+        HelpContextResolver.installF1Handler(this);
         setTitle("Optimize");
         setHeaderText("Configure optimization");
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ParameterSweepDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ParameterSweepDialog.java
@@ -12,6 +12,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 
 import java.util.List;
+import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.app.canvas.Styles;
 
 /**
@@ -36,6 +37,7 @@ public class ParameterSweepDialog extends Dialog<ParameterSweepDialog.Config> {
     private final ComboBox<String> trackCombo;
 
     public ParameterSweepDialog(List<String> constantNames, List<String> trackableNames) {
+        HelpContextResolver.installF1Handler(this);
         setTitle("Parameter Sweep");
         setHeaderText("Configure parameter sweep");
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SimulationSettingsDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SimulationSettingsDialog.java
@@ -13,6 +13,7 @@ import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
+import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.app.canvas.Styles;
 
 /**
@@ -33,6 +34,7 @@ public class SimulationSettingsDialog extends Dialog<SimulationSettings> {
     private final TextField savePerField;
 
     public SimulationSettingsDialog(SimulationSettings existing) {
+        HelpContextResolver.installF1Handler(this);
         setTitle("Simulation Settings");
         setHeaderText("Configure simulation parameters");
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ValidationDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ValidationDialog.java
@@ -1,5 +1,6 @@
 package systems.courant.sd.app.canvas.dialogs;
 
+import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.model.def.ValidationIssue;
 import systems.courant.sd.model.def.ValidationResult;
 
@@ -103,6 +104,7 @@ public class ValidationDialog extends Dialog<Void> {
 
     public ValidationDialog(ValidationResult result, Consumer<String> onSelectElement,
                             Stage owner) {
+        HelpContextResolver.installF1Handler(this);
         initModality(Modality.NONE);
         setTitle("Model Validation");
         this.currentResult = result;


### PR DESCRIPTION
## Summary
- Skip `canvas.requestFocus()` when a MenuBar menu is showing, preventing the Simulate menu from closing itself at certain window positions (#674)
- Add `HelpContextResolver.installF1Handler()` and wire it into all 10 Dialog subclasses so F1 opens context help even from modal dialogs (#675)

## Test plan
- [ ] Open app, position window at various screen locations, verify Simulate menu stays open
- [ ] Open any modal dialog (e.g. Optimize), press F1, verify context help opens
- [ ] Verify F1 still works from the main canvas
- [ ] All existing tests pass

Closes #674
Closes #675