### PR TITLE
Skip VensimBatchImportTest when model dirs are absent

### DIFF
--- a/courant-engine/src/test/java/systems/courant/sd/integration/VensimBatchImportTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/integration/VensimBatchImportTest.java
@@ -8,6 +8,7 @@ import systems.courant.sd.model.compile.CompiledModel;
 import systems.courant.sd.model.compile.ModelCompiler;
 import systems.courant.sd.model.def.ModelDefinition;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Batch import test: scans Vensim Sample, UserGuide, and Delft directories,
@@ -86,7 +86,8 @@ class VensimBatchImportTest {
             }
         }
 
-        assertThat(results).isNotEmpty();
+        Assumptions.assumeFalse(results.isEmpty(),
+                "No .mdl model files found — skipping (model directories are not present in CI)");
 
         Files.createDirectories(DEVDOCS);
 


### PR DESCRIPTION
## Summary
- VensimBatchImportTest uses hardcoded paths to local model directories (`models/Vensim/Sample`, `models/Vensim/UserGuide`, `models/Delft`) that don't exist in CI
- The test asserted `results.isNotEmpty()` which failed on every CI run since the test was extended
- Replace the hard assertion with `Assumptions.assumeFalse` so the test is gracefully skipped when no models are found

## Test plan
- [x] Verified all 1998 other tests pass locally
- [ ] CI should now pass (test will be skipped on Ubuntu/Windows runners)