### PR TITLE
Eliminate per-evaluation LookupTable allocations in LOOKUP_AREA

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/LookupTable.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/LookupTable.java
@@ -133,17 +133,24 @@ public class LookupTable implements Formula {
 
     @Override
     public double getCurrentValue() {
-        double input = inputSupplier.getAsDouble();
-        if (Double.isNaN(input)) {
+        return evaluate(inputSupplier.getAsDouble());
+    }
+
+    /**
+     * Evaluates the lookup table at the given x value without allocating a new object.
+     * Handles NaN and out-of-range clamping identically to {@link #getCurrentValue()}.
+     */
+    public double evaluate(double x) {
+        if (Double.isNaN(x)) {
             return Double.NaN;
         }
-        if (input <= xMin) {
+        if (x <= xMin) {
             return yAtXMin;
         }
-        if (input >= xMax) {
+        if (x >= xMax) {
             return yAtXMax;
         }
-        return interpolation.value(input);
+        return interpolation.value(x);
     }
 
     private static void validateArrays(double[] xValues, double[] yValues, int minPoints) {

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -1026,7 +1026,7 @@ public class ExprCompiler {
             // Trapezoidal integration using the lookup table's data points
             double area = 0.0;
             double prevX = lo;
-            double prevY = table.withInput(() -> lo).getCurrentValue();
+            double prevY = table.evaluate(lo);
             for (double xVal : xValues) {
                 if (xVal <= lo) {
                     continue;
@@ -1034,13 +1034,13 @@ public class ExprCompiler {
                 if (xVal >= hi) {
                     break;
                 }
-                double curY = table.withInput(() -> xVal).getCurrentValue();
+                double curY = table.evaluate(xVal);
                 area += (xVal - prevX) * (prevY + curY) / 2.0;
                 prevX = xVal;
                 prevY = curY;
             }
             // Final segment to hi
-            double hiY = table.withInput(() -> hi).getCurrentValue();
+            double hiY = table.evaluate(hi);
             area += (hi - prevX) * (prevY + hiY) / 2.0;
             return negate ? -area : area;
         };


### PR DESCRIPTION
## Summary

- Added `LookupTable.evaluate(double)` for direct interpolation without object allocation
- Replaced `withInput()`/`getCurrentValue()` chains in `compileLookupArea` with direct `evaluate()` calls
- Eliminates GC pressure from temporary `LookupTable` wrappers created per data point per simulation step

## Test plan

- [x] SpotBugs passes clean (0 findings)
- [x] All tests pass

Fixes #600