### PR TITLE
Consolidate start screen tutorials into chooser dialog

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -22,6 +22,7 @@ import systems.courant.sd.app.canvas.PropertiesPanel;
 import systems.courant.sd.app.canvas.dialogs.QuickstartDialog;
 import systems.courant.sd.app.canvas.dialogs.SirTutorialDialog;
 import systems.courant.sd.app.canvas.dialogs.SupplyChainTutorialDialog;
+import systems.courant.sd.app.canvas.dialogs.TutorialChooserDialog;
 import systems.courant.sd.app.canvas.dialogs.KeyboardShortcutsDialog;
 import systems.courant.sd.app.canvas.dialogs.SdConceptsDialog;
 import systems.courant.sd.app.canvas.StatusBar;
@@ -361,24 +362,28 @@ public class ModelWindow {
             // If user cancelled the file chooser, still show the editor
             canvas.requestFocus();
         });
-        startScreen.setOnGettingStarted(() -> {
-            showEditor();
-            fileController.newModel();
-            quickstartWindow = showHelpWindow(quickstartWindow, QuickstartDialog::new);
-            canvas.requestFocus();
-        });
-        startScreen.setOnSirTutorial(() -> {
-            showEditor();
-            fileController.newModel();
-            sirTutorialWindow = showHelpWindow(sirTutorialWindow, SirTutorialDialog::new);
-            canvas.requestFocus();
-        });
-        startScreen.setOnSupplyChainTutorial(() -> {
-            showEditor();
-            fileController.newModel();
-            supplyChainTutorialWindow = showHelpWindow(supplyChainTutorialWindow,
-                    SupplyChainTutorialDialog::new);
-            canvas.requestFocus();
+        startScreen.setOnTutorials(() -> {
+            TutorialChooserDialog chooser = new TutorialChooserDialog();
+            chooser.setOnGettingStarted(() -> {
+                showEditor();
+                fileController.newModel();
+                quickstartWindow = showHelpWindow(quickstartWindow, QuickstartDialog::new);
+                canvas.requestFocus();
+            });
+            chooser.setOnSirTutorial(() -> {
+                showEditor();
+                fileController.newModel();
+                sirTutorialWindow = showHelpWindow(sirTutorialWindow, SirTutorialDialog::new);
+                canvas.requestFocus();
+            });
+            chooser.setOnSupplyChainTutorial(() -> {
+                showEditor();
+                fileController.newModel();
+                supplyChainTutorialWindow = showHelpWindow(supplyChainTutorialWindow,
+                        SupplyChainTutorialDialog::new);
+                canvas.requestFocus();
+            });
+            chooser.show();
         });
         startScreen.setOnOpenExample((name, path) -> {
             showEditor();

--- a/courant-app/src/main/java/systems/courant/sd/app/StartScreen.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/StartScreen.java
@@ -41,9 +41,7 @@ final class StartScreen extends VBox {
 
     private Runnable onNewModel;
     private Runnable onOpenFile;
-    private Runnable onGettingStarted;
-    private Runnable onSirTutorial;
-    private Runnable onSupplyChainTutorial;
+    private Runnable onTutorials;
     private BiConsumer<String, String> onOpenExample;
 
     private List<ExampleEntry> allExamples = List.of();
@@ -120,26 +118,13 @@ final class StartScreen extends VBox {
                 () -> { if (onOpenFile != null) onOpenFile.run(); });
         openModelCard.setId("startOpenModel");
 
-        VBox gettingStartedCard = buildActionCard("Getting Started",
-                "Learn the basics step by step",
+        VBox tutorialsCard = buildActionCard("Tutorials",
+                "Step-by-step guides to learn modeling",
                 "#2C3E50",
-                () -> { if (onGettingStarted != null) onGettingStarted.run(); });
-        gettingStartedCard.setId("startGettingStarted");
+                () -> { if (onTutorials != null) onTutorials.run(); });
+        tutorialsCard.setId("startTutorials");
 
-        VBox sirTutorialCard = buildActionCard("SIR Epidemic",
-                "Reinforcing feedback and S-shaped growth",
-                "#2C3E50",
-                () -> { if (onSirTutorial != null) onSirTutorial.run(); });
-        sirTutorialCard.setId("startSirTutorial");
-
-        VBox supplyChainCard = buildActionCard("Supply Chain",
-                "Delays, oscillation, and the bullwhip effect",
-                "#2C3E50",
-                () -> { if (onSupplyChainTutorial != null) onSupplyChainTutorial.run(); });
-        supplyChainCard.setId("startSupplyChainTutorial");
-
-        cards.getChildren().addAll(newModelCard, openModelCard, gettingStartedCard,
-                sirTutorialCard, supplyChainCard);
+        cards.getChildren().addAll(newModelCard, openModelCard, tutorialsCard);
 
         return cards;
     }
@@ -419,16 +404,8 @@ final class StartScreen extends VBox {
         this.onOpenFile = handler;
     }
 
-    void setOnGettingStarted(Runnable handler) {
-        this.onGettingStarted = handler;
-    }
-
-    void setOnSirTutorial(Runnable handler) {
-        this.onSirTutorial = handler;
-    }
-
-    void setOnSupplyChainTutorial(Runnable handler) {
-        this.onSupplyChainTutorial = handler;
+    void setOnTutorials(Runnable handler) {
+        this.onTutorials = handler;
     }
 
     void setOnOpenExample(BiConsumer<String, String> handler) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/TutorialChooserDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/TutorialChooserDialog.java
@@ -1,0 +1,142 @@
+package systems.courant.sd.app.canvas.dialogs;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Cursor;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+
+/**
+ * A dialog that presents the available tutorials as clickable cards.
+ * Replaces the three separate tutorial cards on the start screen top row.
+ */
+public class TutorialChooserDialog extends Stage {
+
+    private Runnable onGettingStarted;
+    private Runnable onSirTutorial;
+    private Runnable onSupplyChainTutorial;
+
+    public TutorialChooserDialog() {
+        setTitle("Tutorials");
+        initModality(Modality.APPLICATION_MODAL);
+
+        VBox content = new VBox(24);
+        content.setPadding(new Insets(32, 36, 32, 36));
+        content.setAlignment(Pos.TOP_CENTER);
+        content.setStyle("-fx-background-color: #F5F6F8;");
+
+        Label heading = new Label("Choose a Tutorial");
+        heading.setStyle("-fx-font-size: 20px; -fx-font-weight: bold; -fx-text-fill: #2C3E50;");
+
+        Label subtitle = new Label("Step-by-step guides to learn system dynamics modeling");
+        subtitle.setStyle("-fx-font-size: 13px; -fx-text-fill: #7F8C8D;");
+
+        VBox header = new VBox(6, heading, subtitle);
+        header.setAlignment(Pos.CENTER);
+
+        VBox gettingStarted = buildTutorialCard(
+                "Getting Started",
+                "Build your first model — a simple coffee cooling simulation. "
+                        + "Learn to place stocks, flows, and variables, write equations, and run a simulation.",
+                "Beginner",
+                "#27AE60",
+                () -> {
+                    if (onGettingStarted != null) {
+                        close();
+                        onGettingStarted.run();
+                    }
+                });
+        gettingStarted.setId("tutorialGettingStarted");
+
+        VBox sir = buildTutorialCard(
+                "SIR Epidemic Model",
+                "Model infectious disease spread with Susceptible, Infected, and Recovered populations. "
+                        + "Explore reinforcing feedback, balancing loops, and S-shaped growth.",
+                "Beginner",
+                "#27AE60",
+                () -> {
+                    if (onSirTutorial != null) {
+                        close();
+                        onSirTutorial.run();
+                    }
+                });
+        sir.setId("tutorialSir");
+
+        VBox supplyChain = buildTutorialCard(
+                "Supply Chain Model",
+                "Build a supply chain with inventory, orders, and delivery delays. "
+                        + "Discover oscillation, overshoot, and the bullwhip effect.",
+                "Intermediate",
+                "#F59E0B",
+                () -> {
+                    if (onSupplyChainTutorial != null) {
+                        close();
+                        onSupplyChainTutorial.run();
+                    }
+                });
+        supplyChain.setId("tutorialSupplyChain");
+
+        VBox cards = new VBox(12, gettingStarted, sir, supplyChain);
+        cards.setAlignment(Pos.TOP_CENTER);
+
+        content.getChildren().addAll(header, cards);
+
+        Scene scene = new Scene(content, 480, 420);
+        setScene(scene);
+    }
+
+    private VBox buildTutorialCard(String title, String description, String level,
+                                    String levelColor, Runnable action) {
+        VBox card = new VBox(6);
+        card.setPadding(new Insets(16, 20, 16, 20));
+        card.setCursor(Cursor.HAND);
+        card.setMaxWidth(Double.MAX_VALUE);
+
+        String baseStyle = "-fx-background-color: white; -fx-background-radius: 8;"
+                + " -fx-border-color: #DDE1E6; -fx-border-radius: 8; -fx-border-width: 1;"
+                + " -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.06), 4, 0, 0, 2);";
+        String hoverStyle = "-fx-background-color: white; -fx-background-radius: 8;"
+                + " -fx-border-color: #4A90D9; -fx-border-radius: 8; -fx-border-width: 1.5;"
+                + " -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.1), 8, 0, 0, 3);";
+
+        card.setStyle(baseStyle);
+        card.setOnMouseEntered(e -> card.setStyle(hoverStyle));
+        card.setOnMouseExited(e -> card.setStyle(baseStyle));
+        card.setOnMouseClicked(e -> action.run());
+
+        Label titleLabel = new Label(title);
+        titleLabel.setStyle("-fx-font-size: 15px; -fx-font-weight: bold; -fx-text-fill: #2C3E50;");
+
+        Label descLabel = new Label(description);
+        descLabel.setStyle("-fx-font-size: 12px; -fx-text-fill: #5A6A7A;");
+        descLabel.setWrapText(true);
+
+        Label levelLabel = new Label(level);
+        levelLabel.setStyle("-fx-font-size: 11px; -fx-font-weight: bold; -fx-text-fill: " + levelColor + ";");
+
+        HBox topRow = new HBox(titleLabel);
+        HBox.setHgrow(titleLabel, Priority.ALWAYS);
+        topRow.getChildren().add(levelLabel);
+        topRow.setAlignment(Pos.CENTER_LEFT);
+
+        card.getChildren().addAll(topRow, descLabel);
+        return card;
+    }
+
+    public void setOnGettingStarted(Runnable handler) {
+        this.onGettingStarted = handler;
+    }
+
+    public void setOnSirTutorial(Runnable handler) {
+        this.onSirTutorial = handler;
+    }
+
+    public void setOnSupplyChainTutorial(Runnable handler) {
+        this.onSupplyChainTutorial = handler;
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/ModelWindowFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/ModelWindowFxTest.java
@@ -47,11 +47,11 @@ class ModelWindowFxTest {
     }
 
     @Test
-    @DisplayName("Start screen shows New Model, Open Model, and Getting Started cards")
+    @DisplayName("Start screen shows New Model, Open Model, and Tutorials cards")
     void startScreenCardsPresent(FxRobot robot) {
         assertThat(robot.lookup("#startNewModel").tryQuery()).isPresent();
         assertThat(robot.lookup("#startOpenModel").tryQuery()).isPresent();
-        assertThat(robot.lookup("#startGettingStarted").tryQuery()).isPresent();
+        assertThat(robot.lookup("#startTutorials").tryQuery()).isPresent();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace 5 crowded top-row cards with 3 (New Model, Open Model, Tutorials)
- New `TutorialChooserDialog` presents all tutorials as clickable cards with descriptions and difficulty levels
- Updated `ModelWindowFxTest` to match new card IDs

Fixes #658

## Test plan
- [x] All tests pass (1998 tests, 0 failures)
- [x] SpotBugs clean
- [ ] Manual: verify start screen top row is readable with 3 cards
- [ ] Manual: click Tutorials card, verify chooser dialog opens with 3 tutorials
- [ ] Manual: click each tutorial in chooser, verify it opens correctly