### PR TITLE
Fix MdlParser sketch separator (three backslashes)

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/MdlParser.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/MdlParser.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
  */
 public final class MdlParser {
 
-    private static final String SKETCH_SEPARATOR = "\\---///";
+    private static final String SKETCH_SEPARATOR = "\\\\\\---///";
     private static final String GROUP_DELIMITER = "****";
     private static final Pattern GROUP_NAME_PATTERN = Pattern.compile(
             "^\\*{4,}\\s*$");

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -125,7 +125,7 @@ public final class VensimExporter {
         sb.append(buildControlSection(def));
 
         // Sketch section
-        sb.append("\\---///\n");
+        sb.append("\\\\\\---///\n");
         for (ViewDef view : def.views()) {
             sb.append(buildSketchView(view));
         }

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/MdlParserTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/MdlParserTest.java
@@ -208,7 +208,7 @@ class MdlParserTest {
 
         @Test
         void shouldSeparateSketchFromEquations() {
-            String content = "x = 5\n\t~\t\n\t~\t\n\t|\n\n\\---///\n*View 1\n10,1,x,100,200";
+            String content = "x = 5\n\t~\t\n\t~\t\n\t|\n\n\\\\\\---///\n*View 1\n10,1,x,100,200";
             MdlParser.ParsedMdl result = MdlParser.parse(content);
 
             assertThat(result.equations()).hasSize(1);

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
@@ -50,7 +50,7 @@ class VensimExporterTest {
             assertThat(mdl).contains("INITIAL TIME");
             assertThat(mdl).contains("TIME STEP");
             assertThat(mdl).contains("SAVEPER");
-            assertThat(mdl).contains("\\---///");
+            assertThat(mdl).contains("\\\\\\---///");
 
             // Re-import the exported content and verify structures preserved
             ImportResult reImported = importer.importModel(mdl, "sir");
@@ -320,7 +320,7 @@ class VensimExporterTest {
             assertThat(mdl).contains("INITIAL TIME");
             assertThat(mdl).contains("TIME STEP");
             assertThat(mdl).contains("SAVEPER");
-            assertThat(mdl).contains("\\---///");
+            assertThat(mdl).contains("\\\\\\---///");
         }
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
@@ -798,7 +798,7 @@ class VensimImporterTest {
                     \t~\t
                     \t|
 
-                    \\---///
+                    \\\\\\---///
                     *View
                     10,1,Population,200,200
                     10,2,Birth Rate,100,100
@@ -855,7 +855,7 @@ class VensimImporterTest {
                     \t~\t
                     \t|
 
-                    \\---///
+                    \\\\\\---///
                     *View
                     10,1,A,100,100
                     10,2,B,200,100
@@ -908,7 +908,7 @@ class VensimImporterTest {
                     \t~\t
                     \t|
 
-                    \\---///
+                    \\\\\\---///
                     *View
                     10,1,X,100,100
                     10,2,Y,200,100
@@ -2588,7 +2588,7 @@ class VensimImporterTest {
                     \t~\t
                     \t|
 
-                    \\---///
+                    \\\\\\---///
                     *View 1
                     10,1,Population,200,200
                     11,2,Birth Rate,100,200
@@ -2717,7 +2717,7 @@ class VensimImporterTest {
                     \t~\t
                     \t|
 
-                    \\---///
+                    \\\\\\---///
                     *View 1
                     10,1,Tank,200,200
                     11,2,flow out,300,200

--- a/courant-engine/src/test/resources/vensim/simple-cld.mdl
+++ b/courant-engine/src/test/resources/vensim/simple-cld.mdl
@@ -46,7 +46,7 @@ SAVEPER  =
 	~	The frequency with which output is stored.
 	|
 
-\---///
+\\\---///
 *CLD View
 10,1,Population,200,200
 10,2,Birth Rate,100,100

--- a/courant-engine/src/test/resources/vensim/sir.mdl
+++ b/courant-engine/src/test/resources/vensim/sir.mdl
@@ -77,7 +77,7 @@ SAVEPER  =
 	~	The frequency with which output is stored.
 	|
 
-\---///
+\\\---///
 *SIR Model
 10,1,Susceptible,100,200
 10,2,Infected,300,200

--- a/courant-engine/src/test/resources/vensim/teacup.mdl
+++ b/courant-engine/src/test/resources/vensim/teacup.mdl
@@ -51,7 +51,7 @@ SAVEPER  =
 	~	The frequency with which output is stored.
 	|
 
-\---///
+\\\---///
 *Teacup Model
 10,1,Teacup Temperature,200,150
 10,2,Room Temperature,400,300


### PR DESCRIPTION
## Summary
- Fix `SKETCH_SEPARATOR` in `MdlParser` to match Vensim's actual `\\---///` format (was only matching one backslash)
- Update `VensimExporter` to write the correct three-backslash separator
- Eliminates 205 of 253 import warnings (81% reduction) across all models

## Test plan
- [x] All 106 unit tests pass
- [x] SpotBugs clean
- [x] Batch import test confirms warnings dropped from 253 to 48