### PR TITLE
Fix Vensim import parse failures (#596)

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
@@ -57,6 +57,10 @@ public final class VensimExprTranslator {
             "(?i)RANDOM\\s+UNIFORM\\s*\\(");
     private static final Pattern PULSE_TRAIN_PATTERN = Pattern.compile(
             "(?i)PULSE\\s+TRAIN\\s*\\(");
+    private static final Pattern DELAY_MATERIAL_PATTERN = Pattern.compile(
+            "(?i)DELAY\\s+MATERIAL\\s*\\(");
+    private static final Pattern RANDOM_0_1_PATTERN = Pattern.compile(
+            "(?i)RANDOM\\s+0\\s+1\\s*\\(\\s*\\)");
     private static final Pattern NOT_EQUAL_PATTERN = Pattern.compile("<>");
     private static final Pattern MESSAGE_PATTERN = Pattern.compile(
             "(?i)MESSAGE\\s*\\(");
@@ -178,6 +182,10 @@ public final class VensimExprTranslator {
         // 4a. Not-equal operator: <> → !=
         expr = NOT_EQUAL_PATTERN.matcher(expr).replaceAll("!=");
 
+        // 4b. Single = (equality) → == (Vensim uses = for both assignment and comparison;
+        // by this point we're processing the RHS, so any remaining = is equality)
+        expr = expr.replaceAll("(?<![<>=!])=(?!=)", "==");
+
         // 5. XIDZ and ZIDZ
         expr = translateXidz(expr, warnings);
         expr = translateZidz(expr, warnings);
@@ -193,6 +201,12 @@ public final class VensimExprTranslator {
 
         // 8. DELAY FIXED → DELAY_FIXED
         expr = DELAY_FIXED_PATTERN.matcher(expr).replaceAll("DELAY_FIXED(");
+
+        // 8-1. DELAY MATERIAL(input, delay, init, transit) → DELAY_FIXED(input, delay, init)
+        expr = translateDelayMaterial(expr);
+
+        // 8-2. RANDOM 0 1() → RANDOM_UNIFORM(0, 1, 0)
+        expr = RANDOM_0_1_PATTERN.matcher(expr).replaceAll("RANDOM_UNIFORM(0, 1, 0)");
 
         // 8a. GAME(expr) → expr (pass-through; GAME is Vensim's interactive override)
         expr = translateGame(expr);
@@ -746,6 +760,39 @@ public final class VensimExprTranslator {
             if (closeParen > 0) {
                 expr = expr.substring(0, m.start()) + "0" + expr.substring(closeParen + 1);
                 m = SIMULTANEOUS_PATTERN.matcher(expr);
+            } else {
+                break;
+            }
+        }
+        return expr;
+    }
+
+    /**
+     * Translates DELAY MATERIAL(input, delay, init, transit) to DELAY_FIXED(input, delay, init).
+     * DELAY MATERIAL is a pipeline delay; dropping the 4th transit argument gives equivalent
+     * behavior for Euler integration.
+     */
+    private static String translateDelayMaterial(String expr) {
+        Matcher m = DELAY_MATERIAL_PATTERN.matcher(expr);
+        while (m.find()) {
+            int openParen = m.end() - 1;
+            int closeParen = findMatchingParen(expr, openParen);
+            if (closeParen > 0) {
+                String argsContent = expr.substring(openParen + 1, closeParen);
+                List<String> args = splitTopLevelArgs(argsContent);
+                // Take first 3 args (input, delay, init), drop 4th (transit)
+                String replacement;
+                if (args.size() >= 3) {
+                    replacement = "DELAY_FIXED(" + args.get(0).strip()
+                            + ", " + args.get(1).strip()
+                            + ", " + args.get(2).strip() + ")";
+                } else {
+                    // Fallback: just rename the function
+                    replacement = "DELAY_FIXED(" + argsContent + ")";
+                }
+                expr = expr.substring(0, m.start()) + replacement
+                        + expr.substring(closeParen + 1);
+                m = DELAY_MATERIAL_PATTERN.matcher(expr);
             } else {
                 break;
             }

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExprTranslatorTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExprTranslatorTest.java
@@ -722,6 +722,103 @@ class VensimExprTranslatorTest {
     }
 
     @Nested
+    @DisplayName("Equality operator translation (#596)")
+    class EqualityOperator {
+
+        @Test
+        void shouldTranslateSingleEqualsToDoubleEquals() {
+            var result = VensimExprTranslator.translate(
+                    "IF THEN ELSE(x = 0, 1, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("IF(x == 0, 1, 0)");
+        }
+
+        @Test
+        void shouldNotDoubleExistingDoubleEquals() {
+            var result = VensimExprTranslator.translate(
+                    "IF THEN ELSE(x == 0, 1, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("IF(x == 0, 1, 0)");
+        }
+
+        @Test
+        void shouldNotAffectNotEquals() {
+            var result = VensimExprTranslator.translate("x != 0", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("x != 0");
+        }
+
+        @Test
+        void shouldNotAffectLessEquals() {
+            var result = VensimExprTranslator.translate("x <= 5", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("x <= 5");
+        }
+
+        @Test
+        void shouldNotAffectGreaterEquals() {
+            var result = VensimExprTranslator.translate("x >= 5", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("x >= 5");
+        }
+
+        @Test
+        void shouldHandleMultipleEqualityChecks() {
+            var result = VensimExprTranslator.translate(
+                    "IF THEN ELSE(scenario = 0 :OR: scenario = 1, a, b)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).contains("scenario == 0");
+            assertThat(result.expression()).contains("scenario == 1");
+        }
+    }
+
+    @Nested
+    @DisplayName("DELAY MATERIAL translation (#596)")
+    class DelayMaterial {
+
+        @Test
+        void shouldTranslateDelayMaterialToDelayFixed() {
+            var result = VensimExprTranslator.translate(
+                    "DELAY MATERIAL(input, 5, init, 3)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("DELAY_FIXED(input, 5, init)");
+        }
+
+        @Test
+        void shouldBeCaseInsensitive() {
+            var result = VensimExprTranslator.translate(
+                    "delay material(x, 10, 0, 5)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("DELAY_FIXED(x, 10, 0)");
+        }
+
+        @Test
+        void shouldHandleComplexArguments() {
+            var result = VensimExprTranslator.translate(
+                    "DELAY MATERIAL(a + b, c * d, e, f)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("DELAY_FIXED(a + b, c * d, e)");
+        }
+    }
+
+    @Nested
+    @DisplayName("RANDOM 0 1 translation (#596)")
+    class Random01 {
+
+        @Test
+        void shouldTranslateRandom01() {
+            var result = VensimExprTranslator.translate(
+                    "RANDOM 0 1()", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("RANDOM_UNIFORM(0, 1, 0)");
+        }
+
+        @Test
+        void shouldBeCaseInsensitive() {
+            var result = VensimExprTranslator.translate(
+                    "random 0 1()", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("RANDOM_UNIFORM(0, 1, 0)");
+        }
+
+        @Test
+        void shouldHandleRandom01InExpression() {
+            var result = VensimExprTranslator.translate(
+                    "x + RANDOM 0 1() * 10", "var", EMPTY_NAMES);
+            assertThat(result.expression()).isEqualTo("x + RANDOM_UNIFORM(0, 1, 0) * 10");
+        }
+    }
+
+    @Nested
     @DisplayName("Edge cases")
     class EdgeCases {
 


### PR DESCRIPTION
## Summary
- Translate single `=` to `==` for equality in Vensim IF conditions
- Map `DELAY MATERIAL(input, delay, init, transit)` to `DELAY_FIXED(input, delay, init)`
- Map `RANDOM 0 1()` to `RANDOM_UNIFORM(0, 1, 0)`

## Test plan
- [x] 12 new unit tests for all three translations
- [x] All 2010 existing tests pass
- [x] SpotBugs clean

Fixes #596