### PR TITLE
Fix thread safety test and audit findings (#388)

### DIFF
--- a/courant-ui/src/main/java/systems/courant/sd/ui/ChartViewerApplication.java
+++ b/courant-ui/src/main/java/systems/courant/sd/ui/ChartViewerApplication.java
@@ -26,6 +26,9 @@ import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -45,6 +48,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * accumulation of data from the simulation thread before the FX thread reads it.
  */
 public class ChartViewerApplication extends Application {
+
+    private static final Logger log = LoggerFactory.getLogger(ChartViewerApplication.class);
 
     private static final Object LOCK = new Object();
     private static final AtomicBoolean FX_STARTED = new AtomicBoolean(false);
@@ -135,6 +140,9 @@ public class ChartViewerApplication extends Application {
                 Platform.startup(() -> {});
             } catch (IllegalStateException e) {
                 // Toolkit already initialized (e.g., by the app or TestFX)
+            } catch (RuntimeException e) {
+                FX_STARTED.set(false);
+                throw e;
             }
             Platform.setImplicitExit(false);
         }
@@ -338,6 +346,7 @@ public class ChartViewerApplication extends Application {
         try {
             ImageIO.write(bImage, "png", outputFile);
         } catch (IOException e) {
+            log.error("Failed to save chart image to {}", outputFile, e);
             Alert alert = new Alert(Alert.AlertType.ERROR,
                     "Failed to save chart image: " + e.getMessage());
             alert.setHeaderText("Save Error");

--- a/courant-ui/src/test/java/systems/courant/sd/ui/ChartViewerApplicationTest.java
+++ b/courant-ui/src/test/java/systems/courant/sd/ui/ChartViewerApplicationTest.java
@@ -4,6 +4,7 @@ import javafx.application.Platform;
 import javafx.scene.chart.XYChart;
 import javafx.stage.Stage;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,14 +28,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(ApplicationExtension.class)
 class ChartViewerApplicationTest {
 
+    @BeforeEach
+    void setUp() {
+        ChartViewerApplication.reset();
+    }
+
     @Test
     @DisplayName("setSeries creates series from stock and variable names")
     void shouldCreateSeriesFromNames() {
         ChartViewerApplication.setSeries(List.of("S1", "S2"), List.of("V1"));
-
-        // Verify by adding values — if series count mismatches, the value won't be added
         ChartViewerApplication.addValues(List.of(1.0, 2.0), List.of(3.0), 0);
-        // No exception means the series were created correctly
+
+        ChartViewerApplication.ChartData snap = ChartViewerApplication.snapshot();
+        assertThat(snap.series()).hasSize(3);
+        assertThat(snap.series().get(0).getName()).isEqualTo("S1");
+        assertThat(snap.series().get(1).getName()).isEqualTo("S2");
+        assertThat(snap.series().get(2).getName()).isEqualTo("V1");
     }
 
     @Test
@@ -42,62 +51,88 @@ class ChartViewerApplicationTest {
     void shouldCreateFlowSeries() {
         ChartViewerApplication.setFlowSeries(List.of("FlowA", "FlowB"));
         ChartViewerApplication.addValues(List.of(), List.of(10.0, 20.0), 1);
+
+        ChartViewerApplication.ChartData snap = ChartViewerApplication.snapshot();
+        assertThat(snap.series()).hasSize(2);
+        assertThat(snap.series().get(0).getName()).isEqualTo("FlowA");
+        assertThat(snap.series().get(1).getName()).isEqualTo("FlowB");
     }
 
     @Test
-    @DisplayName("addValues with step number does not throw")
+    @DisplayName("addValues with step number records data point")
     void shouldAcceptStepBasedValues() {
         ChartViewerApplication.setSeries(List.of("X"), List.of());
         ChartViewerApplication.addValues(List.of(42.0), List.of(), 5);
+
+        XYChart.Data<String, Number> dp =
+                ChartViewerApplication.snapshot().series().getFirst().getData().getFirst();
+        assertThat(dp.getXValue()).isEqualTo("5");
+        assertThat(dp.getYValue().doubleValue()).isEqualTo(42.0);
     }
 
     @Test
-    @DisplayName("addValues with timestamp does not throw")
+    @DisplayName("addValues with timestamp records data point")
     void shouldAcceptTimestampBasedValues() {
         ChartViewerApplication.setSeries(List.of("X"), List.of());
         ChartViewerApplication.addValues(List.of(42.0), List.of(),
                 LocalDateTime.of(2026, 1, 1, 12, 0));
+
+        ChartViewerApplication.ChartData snap = ChartViewerApplication.snapshot();
+        assertThat(snap.series().getFirst().getData()).hasSize(1);
+        assertThat(snap.series().getFirst().getData().getFirst().getYValue().doubleValue())
+                .isEqualTo(42.0);
     }
 
     @Test
-    @DisplayName("setSize does not throw")
+    @DisplayName("setSize updates snapshot dimensions")
     void shouldAcceptSizeChange() {
         ChartViewerApplication.setSize(1024, 768);
+
+        ChartViewerApplication.ChartData snap = ChartViewerApplication.snapshot();
+        assertThat(snap.width()).isEqualTo(1024);
+        assertThat(snap.height()).isEqualTo(768);
     }
 
     @Test
     @DisplayName("addValues gracefully handles more values than series")
     void shouldHandleExtraValues() {
         ChartViewerApplication.setSeries(List.of("OnlyOne"), List.of());
-        // Pass more values than series — should not throw
         ChartViewerApplication.addValues(List.of(1.0, 2.0, 3.0), List.of(), 0);
+
+        // Only the first value should be recorded (one series exists)
+        ChartViewerApplication.ChartData snap = ChartViewerApplication.snapshot();
+        assertThat(snap.series()).hasSize(1);
+        assertThat(snap.series().getFirst().getData()).hasSize(1);
+        assertThat(snap.series().getFirst().getData().getFirst().getYValue().doubleValue())
+                .isEqualTo(1.0);
     }
 
     @Test
     @DisplayName("addValues gracefully handles fewer values than series")
     void shouldHandleFewerValues() {
         ChartViewerApplication.setSeries(List.of("A", "B", "C"), List.of());
-        // Pass fewer values than series — should not throw
         ChartViewerApplication.addValues(List.of(1.0), List.of(), 0);
+
+        // Only the first series should have a data point
+        ChartViewerApplication.ChartData snap = ChartViewerApplication.snapshot();
+        assertThat(snap.series().get(0).getData()).hasSize(1);
+        assertThat(snap.series().get(1).getData()).isEmpty();
+        assertThat(snap.series().get(2).getData()).isEmpty();
     }
 
     @Test
     @DisplayName("reset clears all accumulated state")
     void shouldClearStateOnReset() {
-        // Accumulate some state
         ChartViewerApplication.setSeries(List.of("A", "B"), List.of("C"));
         ChartViewerApplication.addValues(List.of(1.0, 2.0), List.of(3.0), 0);
         ChartViewerApplication.setSize(1920, 1080);
 
-        // Reset should clear everything
         ChartViewerApplication.reset();
 
-        // After reset, adding values with no series should be a no-op (no exception)
-        ChartViewerApplication.addValues(List.of(1.0), List.of(), 0);
-
-        // Re-adding a single series should work cleanly without leftover data
-        ChartViewerApplication.setSeries(List.of("Fresh"), List.of());
-        ChartViewerApplication.addValues(List.of(99.0), List.of(), 1);
+        ChartViewerApplication.ChartData snap = ChartViewerApplication.snapshot();
+        assertThat(snap.series()).isEmpty();
+        assertThat(snap.width()).isEqualTo(800);
+        assertThat(snap.height()).isEqualTo(600);
     }
 
     @Test
@@ -127,7 +162,6 @@ class ChartViewerApplicationTest {
     @Test
     @DisplayName("snapshot deep-copies series so mutations do not leak (#530)")
     void shouldDeepCopySeriesInSnapshot() {
-        ChartViewerApplication.reset();
         ChartViewerApplication.setSeries(List.of("Stock"), List.of());
         ChartViewerApplication.addValues(List.of(10.0), List.of(), 0);
         ChartViewerApplication.addValues(List.of(20.0), List.of(), 1);
@@ -145,7 +179,6 @@ class ChartViewerApplicationTest {
     @Test
     @DisplayName("snapshot preserves series names")
     void shouldPreserveSeriesNamesInSnapshot() {
-        ChartViewerApplication.reset();
         ChartViewerApplication.setSeries(List.of("Alpha", "Beta"), List.of("Gamma"));
         ChartViewerApplication.addValues(List.of(1.0, 2.0), List.of(3.0), 0);
 
@@ -160,7 +193,6 @@ class ChartViewerApplicationTest {
     @Test
     @DisplayName("snapshot preserves data point values")
     void shouldPreserveDataPointValuesInSnapshot() {
-        ChartViewerApplication.reset();
         ChartViewerApplication.setSeries(List.of("S"), List.of());
         ChartViewerApplication.addValues(List.of(42.0), List.of(), 5);
 


### PR DESCRIPTION
## Summary
- Fix `shouldReadSizeUnderLockFromAnotherThread` test that was re-writing values instead of reading them (#388)
- Add `@BeforeEach reset()` for test isolation across all tests
- Add real assertions to previously assertion-free tests (series names, data points, dimensions, edge cases)
- Add SLF4J logger to `ChartViewerApplication` and log `IOException` in `saveToFile`
- Fix `ensureFxRunning` to reset `FX_STARTED` flag on unexpected startup failure

## Test plan
- [x] All 106+ tests pass across all modules
- [x] SpotBugs clean
- [x] Thread safety test now actually reads values via `snapshot()` instead of re-setting them