### PR TITLE
Rename Tutorials card to 'Do a Tutorial'

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/StartScreen.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/StartScreen.java
@@ -118,7 +118,7 @@ final class StartScreen extends VBox {
                 () -> { if (onOpenFile != null) onOpenFile.run(); });
         openModelCard.setId("startOpenModel");
 
-        VBox tutorialsCard = buildActionCard("Tutorials",
+        VBox tutorialsCard = buildActionCard("Do a Tutorial",
                 "Step-by-step guides to learn modeling",
                 "#2C3E50",
                 () -> { if (onTutorials != null) onTutorials.run(); });


### PR DESCRIPTION
## Summary
- Renames the start screen tutorial card from "Tutorials" to "Do a Tutorial" for clarity

## Test plan
- All tests pass, SpotBugs clean

Fixes #658