### PR TITLE
Ensure window title bar stays within screen bounds

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/CourantApp.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/CourantApp.java
@@ -3,6 +3,8 @@ package systems.courant.sd.app;
 import systems.courant.sd.app.canvas.Clipboard;
 
 import javafx.application.Application;
+import javafx.geometry.Rectangle2D;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 
@@ -42,6 +44,34 @@ public class CourantApp extends Application {
             }
         });
         stage.show();
+        ensureWindowOnScreen(stage);
+    }
+
+    /**
+     * Ensures that the window's title bar is within the visible bounds of at least one
+     * active screen. If the title bar region is offscreen, the window is repositioned
+     * to the center of the primary screen.
+     */
+    void ensureWindowOnScreen(Stage stage) {
+        double titleBarHeight = 30;
+        double x = stage.getX();
+        double y = stage.getY();
+        double width = stage.getWidth();
+
+        // The title bar region: full window width, top edge down to titleBarHeight
+        Rectangle2D titleBarRegion = new Rectangle2D(x, y, width, titleBarHeight);
+
+        boolean titleBarVisible = Screen.getScreens().stream()
+                .map(Screen::getVisualBounds)
+                .anyMatch(bounds -> bounds.intersects(titleBarRegion));
+
+        if (!titleBarVisible) {
+            Rectangle2D primaryBounds = Screen.getPrimary().getVisualBounds();
+            stage.setX(primaryBounds.getMinX()
+                    + (primaryBounds.getWidth() - stage.getWidth()) / 2);
+            stage.setY(primaryBounds.getMinY()
+                    + (primaryBounds.getHeight() - stage.getHeight()) / 2);
+        }
     }
 
     public static void main(String[] args) {

--- a/courant-app/src/test/java/systems/courant/sd/app/CourantAppFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/CourantAppFxTest.java
@@ -1,0 +1,95 @@
+package systems.courant.sd.app;
+
+import javafx.geometry.Rectangle2D;
+import javafx.stage.Screen;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CourantApp window positioning (TestFX)")
+@ExtendWith(ApplicationExtension.class)
+class CourantAppFxTest {
+
+    private Stage stage;
+    private CourantApp app;
+
+    @Start
+    void start(Stage stage) {
+        this.stage = stage;
+        this.app = new CourantApp();
+        app.start(stage);
+    }
+
+    @Test
+    @DisplayName("window should be within screen bounds after startup")
+    void shouldPlaceWindowOnScreenAfterStartup() {
+        WaitForAsyncUtils.waitForFxEvents();
+
+        Rectangle2D titleBar = new Rectangle2D(
+                stage.getX(), stage.getY(), stage.getWidth(), 30);
+
+        boolean onScreen = Screen.getScreens().stream()
+                .map(Screen::getVisualBounds)
+                .anyMatch(bounds -> bounds.intersects(titleBar));
+
+        assertThat(onScreen)
+                .as("title bar should intersect at least one screen's visual bounds")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("should reposition window to primary screen when title bar is offscreen")
+    void shouldRepositionWindowWhenTitleBarIsOffscreen() {
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Move the window far offscreen (above and to the left of any display)
+        WaitForAsyncUtils.asyncFx(() -> {
+            stage.setX(-5000);
+            stage.setY(-5000);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Call ensureWindowOnScreen
+        WaitForAsyncUtils.asyncFx(() -> app.ensureWindowOnScreen(stage));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        Rectangle2D primaryBounds = Screen.getPrimary().getVisualBounds();
+
+        assertThat(stage.getX()).isGreaterThanOrEqualTo(primaryBounds.getMinX());
+        assertThat(stage.getY()).isGreaterThanOrEqualTo(primaryBounds.getMinY());
+        assertThat(stage.getX() + stage.getWidth())
+                .isLessThanOrEqualTo(primaryBounds.getMaxX() + 1);
+        assertThat(stage.getY() + stage.getHeight())
+                .isLessThanOrEqualTo(primaryBounds.getMaxY() + 1);
+    }
+
+    @Test
+    @DisplayName("should not reposition window when title bar is visible")
+    void shouldNotRepositionWindowWhenTitleBarIsVisible() {
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Place window at a known on-screen position
+        Rectangle2D primaryBounds = Screen.getPrimary().getVisualBounds();
+        double targetX = primaryBounds.getMinX() + 50;
+        double targetY = primaryBounds.getMinY() + 50;
+
+        WaitForAsyncUtils.asyncFx(() -> {
+            stage.setX(targetX);
+            stage.setY(targetY);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        WaitForAsyncUtils.asyncFx(() -> app.ensureWindowOnScreen(stage));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(stage.getX()).isEqualTo(targetX);
+        assertThat(stage.getY()).isEqualTo(targetY);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds screen bounds checking in `CourantApp.openWindow()` after the stage is shown
- If the window's title bar region doesn't intersect any active screen's visual bounds, the window is repositioned to center of the primary screen
- Adds 3 TestFX tests covering: on-screen after startup, repositioning when offscreen, no-op when already visible

Fixes #731

## Test plan
- [x] All 106 tests pass
- [x] SpotBugs clean
- [x] New tests verify offscreen detection and repositioning