### PR TITLE
Fix MdlParser macro misclassification and VensimExprTranslator case replacement

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/MdlParser.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/MdlParser.java
@@ -148,27 +148,52 @@ public final class MdlParser {
             // an equation (the header line followed by the first body equation, or
             // :END OF MACRO: followed by the next regular equation). Split by
             // newlines to detect and separate them.
+            //
+            // When both :END OF MACRO: and :MACRO: appear in the same block,
+            // lines fall into three phases:
+            //   1. preEndLines   — before :END OF MACRO: → belong to current macro
+            //   2. betweenLines  — between :END OF MACRO: and :MACRO: → regular equations
+            //   3. postMacroLines — after :MACRO: → first body of new macro
             String[] eqLines = equationPart.split("\n");
             String macroHeaderLine = null;
             boolean endMacroInBlock = false;
-            List<String> bodyLines = new ArrayList<>();
+            List<String> preEndLines = new ArrayList<>();
+            List<String> betweenLines = new ArrayList<>();
+            List<String> postMacroLines = new ArrayList<>();
+            // 0 = before END, 1 = between END and MACRO, 2 = after MACRO
+            int phase = 0;
 
             for (String line : eqLines) {
                 String lineStripped = line.strip();
                 if (lineStripped.isEmpty()) {
                     continue;
                 }
-                if (MACRO_START_PATTERN.matcher(lineStripped).find()) {
-                    macroHeaderLine = lineStripped;
-                } else if (MACRO_END_PATTERN.matcher(lineStripped).find()) {
+                if (MACRO_END_PATTERN.matcher(lineStripped).find()) {
                     endMacroInBlock = true;
+                    phase = 1;
+                } else if (MACRO_START_PATTERN.matcher(lineStripped).find()) {
+                    macroHeaderLine = lineStripped;
+                    phase = 2;
                 } else {
-                    bodyLines.add(lineStripped);
+                    switch (phase) {
+                        case 0 -> preEndLines.add(lineStripped);
+                        case 1 -> betweenLines.add(lineStripped);
+                        default -> postMacroLines.add(lineStripped);
+                    }
                 }
             }
 
             // Handle :END OF MACRO: — finalize current macro
             if (endMacroInBlock) {
+                // Lines before END belong to the current macro body
+                String preEndEq = String.join(" ", preEndLines).strip();
+                if (!preEndEq.isEmpty() && inMacro && macroBody != null) {
+                    MdlEquation preEq = parseEquationBlock(preEndEq, unitsPart,
+                            commentPart, currentGroup);
+                    if (preEq != null) {
+                        macroBody.add(preEq);
+                    }
+                }
                 if (inMacro && macroName != null && macroParams != null && macroBody != null) {
                     macros.add(buildMacroDef(macroName, macroParams, macroBody));
                 }
@@ -176,9 +201,39 @@ public final class MdlParser {
                 macroName = null;
                 macroParams = null;
                 macroBody = null;
+
+                // Lines between END and MACRO (or end of block) are regular equations
+                String betweenEq = String.join(" ", betweenLines).strip();
+                if (!betweenEq.isEmpty()) {
+                    MdlEquation bEq = parseEquationBlock(betweenEq, unitsPart,
+                            commentPart, currentGroup);
+                    if (bEq != null) {
+                        equations.add(bEq);
+                    }
+                }
+            }
+
+            // When no END was seen, preEndLines hold lines that appeared before
+            // a :MACRO: header (or all lines if no directives at all). They belong
+            // to whatever context was active before this block.
+            if (!endMacroInBlock && !preEndLines.isEmpty()) {
+                String preEq = String.join(" ", preEndLines).strip();
+                if (!preEq.isEmpty()) {
+                    MdlEquation eq = parseEquationBlock(preEq, unitsPart,
+                            commentPart, currentGroup);
+                    if (eq != null) {
+                        if (inMacro && macroBody != null) {
+                            macroBody.add(eq);
+                        } else {
+                            equations.add(eq);
+                        }
+                    }
+                }
             }
 
             // Handle :MACRO: header — start new macro
+            // (must come after preEndLines processing so those lines go to the
+            // previous context, not the new macro)
             if (macroHeaderLine != null) {
                 inMacro = true;
                 macroBody = new ArrayList<>();
@@ -201,8 +256,12 @@ public final class MdlParser {
                 }
             }
 
-            // Process the remaining equation text (if any) from the same block
-            String remainingEq = String.join(" ", bodyLines).strip();
+            // Lines after :MACRO: header are the first body equation of the new
+            // macro. Otherwise, all lines were already dispatched above.
+            List<String> remainingLines = macroHeaderLine != null
+                    ? postMacroLines : List.of();
+
+            String remainingEq = String.join(" ", remainingLines).strip();
             if (remainingEq.isEmpty()) {
                 continue;
             }

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
@@ -530,13 +530,29 @@ public final class VensimExprTranslator {
         // Sort names longest-first to avoid partial matches
         List<String> sortedNames = knownNames.stream()
                 .filter(n -> n.contains(" "))
-                .sorted(Comparator.comparingInt(String::length).reversed())
+                .sorted(Comparator.comparingInt(String::length).reversed()
+                        .thenComparing(Comparator.naturalOrder()))
                 .toList();
 
+        // Two-pass approach: first try exact (case-sensitive) match, then fall back
+        // to case-insensitive for any names not found exactly. This ensures that when
+        // two names differ only by case, each is replaced with its own normalized form.
+        List<String> unmatchedNames = new ArrayList<>();
         for (String name : sortedNames) {
             String normalized = normalizeName(name);
-            // Use word-boundary-aware replacement
-            // Vensim names with spaces: match the literal multi-word name
+            String escaped = Pattern.quote(name);
+            Pattern exact = Pattern.compile("(?<![a-zA-Z0-9_])" + escaped + "(?![a-zA-Z0-9_])");
+            Matcher m = exact.matcher(expr);
+            if (m.find()) {
+                expr = m.replaceAll(normalized);
+            } else {
+                unmatchedNames.add(name);
+            }
+        }
+
+        // Second pass: case-insensitive fallback for names not found exactly
+        for (String name : unmatchedNames) {
+            String normalized = normalizeName(name);
             String escaped = Pattern.quote(name);
             Pattern p = Pattern.compile("(?<![a-zA-Z0-9_])" + escaped + "(?![a-zA-Z0-9_])",
                     Pattern.CASE_INSENSITIVE);

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/MdlParserTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/MdlParserTest.java
@@ -346,6 +346,43 @@ class MdlParserTest {
         }
 
         @Test
+        void shouldClassifyEquationBetweenEndAndMacroAsRegular() {
+            // When :END OF MACRO: and :MACRO: appear in the same pipe-block with
+            // an equation between them, the middle equation should be a regular
+            // equation, not part of either macro.
+            String content = """
+                    :MACRO: FIRST(a, out)
+                    out = a * 2
+                    \t~\t
+                    \t~\t
+                    \t|
+                    :END OF MACRO:
+                    middle = 99
+                    :MACRO: SECOND(b, out)
+                    \t~\t
+                    \t~\t
+                    \t|
+                    out = b + 1
+                    \t~\t
+                    \t~\t
+                    \t|
+                    :END OF MACRO:
+                    """;
+            MdlParser.ParsedMdl result = MdlParser.parse(content);
+
+            // "middle" should be in main equations, not in either macro
+            assertThat(result.equations()).hasSize(1);
+            assertThat(result.equations().get(0).name()).isEqualTo("middle");
+
+            // Both macros should be parsed
+            assertThat(result.macros()).hasSize(2);
+            assertThat(result.macros().get(0).name()).isEqualTo("FIRST");
+            assertThat(result.macros().get(0).bodyEquations()).hasSize(1);
+            assertThat(result.macros().get(1).name()).isEqualTo("SECOND");
+            assertThat(result.macros().get(1).bodyEquations()).hasSize(1);
+        }
+
+        @Test
         void shouldHandleNoParsedMacros() {
             String content = "x = 5\n\t~\t\n\t~\t\n\t|";
             MdlParser.ParsedMdl result = MdlParser.parse(content);

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExprTranslatorTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExprTranslatorTest.java
@@ -229,6 +229,26 @@ class VensimExprTranslatorTest {
         }
 
         @Test
+        void shouldPreferExactCaseMatchOverCaseInsensitive() {
+            // Two names that differ only by case should each be replaced with their
+            // own normalized form, not conflated by the case-insensitive fallback.
+            Set<String> names = Set.of("Time Step", "time step");
+            var result = VensimExprTranslator.translate(
+                    "Time Step + time step", "var", names);
+            assertThat(result.expression()).isEqualTo("Time_Step + time_step");
+        }
+
+        @Test
+        void shouldFallBackToCaseInsensitiveWhenNoExactMatch() {
+            // If only "Contact Rate" is known but expression uses "contact rate",
+            // the case-insensitive fallback should still replace it.
+            Set<String> names = Set.of("Contact Rate");
+            var result = VensimExprTranslator.translate(
+                    "contact rate * 2", "var", names);
+            assertThat(result.expression()).isEqualTo("Contact_Rate * 2");
+        }
+
+        @Test
         void shouldNotReplacePartialMatches() {
             Set<String> names = Set.of("Contact Rate");
             var result = VensimExprTranslator.translate(


### PR DESCRIPTION
## Summary
- **MdlParser (#646):** Three-phase state machine correctly routes lines between `:END OF MACRO:` and `:MACRO:` directives — lines between them are now regular equations, not macro body
- **VensimExprTranslator (#558):** Two-pass name replacement (exact case-sensitive first, case-insensitive fallback) with deterministic sort for equal-length names

## Test plan
- [x] New test: `shouldClassifyEquationBetweenEndAndMacroAsRegular` verifies middle equation is in main equations list
- [x] New test: `shouldPreferExactCaseMatchOverCaseInsensitive` verifies case-differing names get distinct replacements
- [x] New test: `shouldFallBackToCaseInsensitiveWhenNoExactMatch` verifies case-insensitive fallback still works
- [x] All 2076+ tests pass
- [x] SpotBugs clean (0 findings)

Fixes #646, Fixes #558