### PR TITLE
Fix 7 easy issues from milestone A4

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -50,9 +50,9 @@ public final class VensimExporter {
     private static final Logger logger = LoggerFactory.getLogger(VensimExporter.class);
 
     private static final Pattern IF_FUNC_PATTERN = Pattern.compile("(?i)\\bIF\\s*\\(");
-    private static final Pattern AND_OP_PATTERN = Pattern.compile("\\band\\b");
-    private static final Pattern OR_OP_PATTERN = Pattern.compile("\\bor\\b");
-    private static final Pattern NOT_OP_PATTERN = Pattern.compile("\\bnot\\b");
+    private static final Pattern AND_OP_PATTERN = Pattern.compile("\\band\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern OR_OP_PATTERN = Pattern.compile("\\bor\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern NOT_OP_PATTERN = Pattern.compile("\\bnot\\b", Pattern.CASE_INSENSITIVE);
     private static final Pattern DOUBLE_STAR_PATTERN = Pattern.compile("\\*\\*");
     private static final Pattern DOUBLE_EQ_PATTERN = Pattern.compile("==");
     private static final Pattern NOT_EQ_PATTERN = Pattern.compile("!=");

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
@@ -102,6 +102,22 @@ public final class VensimExprTranslator {
             "VECTOR SELECT", "VECTOR ELM MAP", "VECTOR SORT ORDER",
             "ALLOCATE AVAILABLE");
 
+    private static final Pattern QUOTED_NAME_PATTERN = Pattern.compile("\"([^\"]+)\"");
+    private static final Pattern LOOKUP_RANGE_PATTERN = Pattern.compile(
+            "^\\s*\\(?\\s*\\[\\s*\\([^)]*\\)\\s*-\\s*\\([^)]*\\)\\s*\\]\\s*,?");
+    private static final Pattern LOOKUP_PAIR_PATTERN = Pattern.compile(
+            "\\(\\s*(-?[\\d.eE+\\-]+)\\s*,\\s*(-?[\\d.eE+\\-]+)\\s*\\)");
+    private static final Pattern NUMBER_PATTERN = Pattern.compile("-?[\\d.eE+\\-]+");
+    private static final List<Pattern> UNSUPPORTED_FUNCTION_PATTERNS;
+    static {
+        List<Pattern> patterns = new ArrayList<>();
+        for (String func : UNSUPPORTED_FUNCTIONS) {
+            patterns.add(Pattern.compile(
+                    "(?i)\\b" + Pattern.quote(func) + "\\s*\\("));
+        }
+        UNSUPPORTED_FUNCTION_PATTERNS = List.copyOf(patterns);
+    }
+
     /**
      * Result of translating a Vensim expression.
      *
@@ -368,8 +384,7 @@ public final class VensimExprTranslator {
      * Vensim uses quotes for names containing special characters: "electric vehicles (EV)".
      */
     private static String translateQuotedNames(String expr) {
-        Pattern quoted = Pattern.compile("\"([^\"]+)\"");
-        Matcher m = quoted.matcher(expr);
+        Matcher m = QUOTED_NAME_PATTERN.matcher(expr);
         StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String name = m.group(1);
@@ -678,9 +693,7 @@ public final class VensimExprTranslator {
         // Strip Vensim range annotation: [(xmin,ymin)-(xmax,ymax)]
         // May be preceded by an outer paren from WITH LOOKUP context
         // This is a display range hint, not a data point
-        Pattern rangePattern = Pattern.compile(
-                "^\\s*\\(?\\s*\\[\\s*\\([^)]*\\)\\s*-\\s*\\([^)]*\\)\\s*\\]\\s*,?");
-        Matcher rangeMatcher = rangePattern.matcher(cleaned);
+        Matcher rangeMatcher = LOOKUP_RANGE_PATTERN.matcher(cleaned);
         if (rangeMatcher.find()) {
             cleaned = cleaned.substring(rangeMatcher.end()).strip();
         } else {
@@ -696,9 +709,7 @@ public final class VensimExprTranslator {
 
         // Try parenthesized pair format: (x1,y1),(x2,y2),...
         List<double[]> points = new ArrayList<>();
-        Pattern pairPattern = Pattern.compile(
-                "\\(\\s*(-?[\\d.eE+\\-]+)\\s*,\\s*(-?[\\d.eE+\\-]+)\\s*\\)");
-        Matcher m = pairPattern.matcher(cleaned);
+        Matcher m = LOOKUP_PAIR_PATTERN.matcher(cleaned);
         while (m.find()) {
             try {
                 double x = Double.parseDouble(m.group(1));
@@ -725,8 +736,7 @@ public final class VensimExprTranslator {
     }
 
     private static Optional<double[][]> parseFlatCsvLookup(String data) {
-        Pattern numberPattern = Pattern.compile("-?[\\d.eE+\\-]+");
-        Matcher m = numberPattern.matcher(data);
+        Matcher m = NUMBER_PATTERN.matcher(data);
         List<Double> values = new ArrayList<>();
         while (m.find()) {
             try {
@@ -1038,15 +1048,16 @@ public final class VensimExprTranslator {
     }
 
     private static void checkUnsupportedFunctions(String expr, List<String> warnings) {
-        String upper = expr.toUpperCase();
-        for (String func : UNSUPPORTED_FUNCTIONS) {
-            if (upper.contains(func.toUpperCase())) {
-                // Verify it's a function call: name must be followed by whitespace+paren or direct paren
-                Pattern p = Pattern.compile(
-                        "(?i)\\b" + Pattern.quote(func) + "\\s*\\(");
-                if (p.matcher(expr).find()) {
-                    warnings.add("Unsupported Vensim function: " + func);
-                }
+        for (Pattern p : UNSUPPORTED_FUNCTION_PATTERNS) {
+            Matcher m = p.matcher(expr);
+            if (m.find()) {
+                // Extract the function name from the matched text (everything before whitespace/paren)
+                String matched = m.group().strip();
+                int parenIdx = matched.indexOf('(');
+                String funcName = (parenIdx > 0)
+                        ? matched.substring(0, parenIdx).strip()
+                        : matched;
+                warnings.add("Unsupported Vensim function: " + funcName);
             }
         }
     }

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
@@ -246,6 +246,20 @@ class VensimExporterTest {
         }
 
         @Test
+        @DisplayName("Issue #648 — mixed-case AND/OR/NOT should be converted")
+        void shouldTranslateMixedCaseLogicalOperators() {
+            assertThat(VensimExporter.toVensimExpr("x AND y"))
+                    .contains(":AND:");
+            assertThat(VensimExporter.toVensimExpr("a Or b"))
+                    .contains(":OR:");
+            assertThat(VensimExporter.toVensimExpr("NOT(flag)"))
+                    .contains(":NOT:");
+            assertThat(VensimExporter.toVensimExpr("x And y Or z"))
+                    .contains(":AND:")
+                    .contains(":OR:");
+        }
+
+        @Test
         void shouldTranslateComparisonOperators() {
             assertThat(VensimExporter.toVensimExpr("x == 0"))
                     .contains("x = 0");

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
@@ -81,9 +81,13 @@ public class BatchImportCli {
                     i + 1, entries.size(), entry.className(), entry.url());
 
             Path tempFile = null;
+            // tempDir tracks the unique temporary directory created by downloadToTemp
+            // so the finally block deletes the correct directory even if downloadToTemp changes
+            Path tempDir = null;
             try {
                 // Download
                 tempFile = downloadToTemp(entry.url());
+                tempDir = tempFile.getParent();
                 log.info("  Downloaded to {}", tempFile);
 
                 // Check if output already exists
@@ -140,9 +144,8 @@ public class BatchImportCli {
                 if (tempFile != null) {
                     try {
                         Files.deleteIfExists(tempFile);
-                        Path tempParent = tempFile.getParent();
-                        if (tempParent != null) {
-                            Files.deleteIfExists(tempParent);
+                        if (tempDir != null) {
+                            Files.deleteIfExists(tempDir);
                         }
                     } catch (IOException e) {
                         log.warn("  Could not delete temp file: {}", tempFile);
@@ -288,8 +291,8 @@ public class BatchImportCli {
         CliArgs parsed = new CliArgs();
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
-                case "--manifest" -> parsed.manifestFile = requireValue(args, i++);
-                case "--output-dir" -> parsed.outputDir = requireValue(args, i++);
+                case "--manifest" -> { parsed.manifestFile = requireValue(args, i); i++; }
+                case "--output-dir" -> { parsed.outputDir = requireValue(args, i); i++; }
                 case "--json-only" -> parsed.jsonOnly = true;
                 case "--dry-run" -> parsed.dryRun = true;
                 case "--overwrite" -> parsed.overwrite = true;

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
@@ -9,7 +9,6 @@ import systems.courant.sd.model.def.ModuleInstanceDef;
 import systems.courant.sd.model.def.SimulationSettings;
 import systems.courant.sd.model.def.StockDef;
 
-import java.time.Year;
 import java.util.List;
 import java.util.Map;
 
@@ -26,6 +25,24 @@ public class DemoClassGenerator {
 
     private static final String INDENT = "        ";
     private static final String INDENT2 = "                ";
+
+    private final int copyrightYear;
+
+    /**
+     * Creates a generator that uses the given copyright year in license headers.
+     *
+     * @param copyrightYear the year to emit in Courant copyright headers
+     */
+    public DemoClassGenerator(int copyrightYear) {
+        this.copyrightYear = copyrightYear;
+    }
+
+    /**
+     * Creates a generator using the current year for copyright headers.
+     */
+    public DemoClassGenerator() {
+        this(java.time.Year.now().getValue());
+    }
 
     /**
      * Generates the full Java source for a demo class.
@@ -65,7 +82,7 @@ public class DemoClassGenerator {
             sb.append(" */\n");
         } else {
             sb.append("/*\n");
-            sb.append(" * Copyright (c) ").append(Year.now().getValue()).append(" Courant Systems\n");
+            sb.append(" * Copyright (c) ").append(copyrightYear).append(" Courant Systems\n");
             sb.append(" * Licensed under CC-BY-SA-4.0. See LICENSE in this module for details.\n");
             sb.append(" */\n");
         }

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipeline.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipeline.java
@@ -149,8 +149,10 @@ public class ImportPipeline {
                 compiled.createSimulation();
             }
         } catch (systems.courant.sd.model.compile.CompilationException
-                 | systems.courant.sd.model.expr.ParseException
-                 | IllegalStateException e) {
+                 | systems.courant.sd.model.expr.ParseException e) {
+            errors.add(e.getClass().getSimpleName() + ": " + e.getMessage());
+        } catch (IllegalStateException e) {
+            log.warn("Unexpected IllegalStateException during trial compile", e);
             errors.add(e.getClass().getSimpleName() + ": " + e.getMessage());
         }
         return errors;

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
@@ -97,7 +97,7 @@ public class ImportPipelineCli implements Closeable {
         System.err.println("=== Import Summary ===");
         result.printReport(System.err);
 
-        return 0;
+        return result.hasValidationErrors() || result.hasTrialCompileErrors() ? 1 : 0;
     }
 
     private ModelMetadata buildMetadata(CliArgs parsed) throws IOException {
@@ -165,15 +165,15 @@ public class ImportPipelineCli implements Closeable {
         CliArgs parsed = new CliArgs();
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
-                case "--file" -> parsed.file = requireValue(args, i++);
-                case "--class-name" -> parsed.className = requireValue(args, i++);
-                case "--category" -> parsed.category = requireValue(args, i++);
-                case "--author" -> parsed.author = requireValue(args, i++);
-                case "--source" -> parsed.source = requireValue(args, i++);
-                case "--license" -> parsed.license = requireValue(args, i++);
-                case "--url" -> parsed.url = requireValue(args, i++);
-                case "--output-dir" -> parsed.outputDir = requireValue(args, i++);
-                case "--metadata-file" -> parsed.metadataFile = requireValue(args, i++);
+                case "--file" -> { parsed.file = requireValue(args, i); i++; }
+                case "--class-name" -> { parsed.className = requireValue(args, i); i++; }
+                case "--category" -> { parsed.category = requireValue(args, i); i++; }
+                case "--author" -> { parsed.author = requireValue(args, i); i++; }
+                case "--source" -> { parsed.source = requireValue(args, i); i++; }
+                case "--license" -> { parsed.license = requireValue(args, i); i++; }
+                case "--url" -> { parsed.url = requireValue(args, i); i++; }
+                case "--output-dir" -> { parsed.outputDir = requireValue(args, i); i++; }
+                case "--metadata-file" -> { parsed.metadataFile = requireValue(args, i); i++; }
                 case "--dry-run" -> parsed.dryRun = true;
                 case "--overwrite" -> parsed.overwrite = true;
                 case "--json-only" -> parsed.jsonOnly = true;

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/DemoClassGeneratorTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/DemoClassGeneratorTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("DemoClassGenerator")
 class DemoClassGeneratorTest {
 
-    private final DemoClassGenerator generator = new DemoClassGenerator();
+    private final DemoClassGenerator generator = new DemoClassGenerator(2025);
 
     @Test
     void shouldGenerateMinimalModel() {
@@ -244,7 +244,7 @@ class DemoClassGeneratorTest {
 
         assertThat(source).contains("CC-BY-NC-SA-4.0");
         assertThat(source).contains("THIRD-PARTY-LICENSES");
-        assertThat(source).doesNotContain("Copyright (c) 2026 Courant Systems");
+        assertThat(source).doesNotContain("Copyright (c) 2025 Courant Systems");
     }
 
     @Test
@@ -263,7 +263,7 @@ class DemoClassGeneratorTest {
                 "systems.courant.sd.demo", "test.xmile",
                 List.of(), List.of());
 
-        assertThat(source).contains("Copyright (c) 2026 Courant Systems");
+        assertThat(source).contains("Copyright (c) 2025 Courant Systems");
         assertThat(source).doesNotContain("THIRD-PARTY-LICENSES");
     }
 
@@ -370,6 +370,45 @@ class DemoClassGeneratorTest {
 
         assertThat(source).contains("Unsupported PULSE function");
         assertThat(source).contains("Unresolved reference: missing_var");
+    }
+
+    @Nested
+    @DisplayName("Issue #718 — copyrightYear reproducibility")
+    class CopyrightYearReproducibility {
+
+        @Test
+        void shouldProduceIdenticalOutputWithSameYear() {
+            DemoClassGenerator gen = new DemoClassGenerator(2025);
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("S", 100.0, "people")
+                    .defaultSimulation("Day", 10.0, "Day")
+                    .build();
+            ModelMetadata metadata = ModelMetadata.builder().license("CC-BY-SA-4.0").build();
+
+            String first = gen.generate(def, metadata, "TestDemo",
+                    "systems.courant.sd.demo", "test.xmile", List.of(), List.of());
+            String second = gen.generate(def, metadata, "TestDemo",
+                    "systems.courant.sd.demo", "test.xmile", List.of(), List.of());
+
+            assertThat(first).isEqualTo(second);
+        }
+
+        @Test
+        void shouldUseProvidedCopyrightYear() {
+            DemoClassGenerator gen = new DemoClassGenerator(2024);
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("S", 100.0, "people")
+                    .defaultSimulation("Day", 10.0, "Day")
+                    .build();
+            ModelMetadata metadata = ModelMetadata.builder().license("CC-BY-SA-4.0").build();
+
+            String source = gen.generate(def, metadata, "TestDemo",
+                    "systems.courant.sd.demo", "test.xmile", List.of(), List.of());
+
+            assertThat(source).contains("Copyright (c) 2024 Courant Systems");
+        }
     }
 
     @Nested

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/ImportPipelineCliTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/ImportPipelineCliTest.java
@@ -207,6 +207,36 @@ class ImportPipelineCliTest {
         }
 
         @Test
+        void shouldReturnOneWhenPipelineHasErrors(@TempDir Path tempDir) throws IOException {
+            // Create a model file with invalid content that will cause trial-compile errors
+            Path brokenModel = tempDir.resolve("broken.xmile");
+            Files.writeString(brokenModel, """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <xmile version="1.0" xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0">
+                        <header><name>Broken</name></header>
+                        <sim_specs><stop>10</stop><dt>1</dt></sim_specs>
+                        <model>
+                            <variables>
+                                <aux name="bad_ref">
+                                    <eqn>nonexistent_var * 2</eqn>
+                                </aux>
+                            </variables>
+                        </model>
+                    </xmile>
+                    """);
+            try (ImportPipelineCli cli = new ImportPipelineCli()) {
+                int exitCode = cli.run(new String[]{
+                        "--file", brokenModel.toString(),
+                        "--class-name", "BrokenDemo",
+                        "--license", "CC-BY-SA-4.0",
+                        "--output-dir", tempDir.toString(),
+                        "--dry-run"
+                });
+                assertThat(exitCode).isEqualTo(1);
+            }
+        }
+
+        @Test
         void shouldWriteJsonOnlyOutput(@TempDir Path tempDir) throws IOException {
             Path model = copyTestModel(tempDir);
             try (ImportPipelineCli cli = new ImportPipelineCli()) {


### PR DESCRIPTION
## Summary
- **#718**: DemoClassGenerator copyrightYear is now a constructor param for reproducible output
- **#717**: ImportPipelineCli.run() returns exit code 1 when pipeline has validation/compile errors
- **#698**: VensimExprTranslator hoists 5 regex patterns to static fields
- **#648**: VensimExporter AND/OR/NOT patterns now case-insensitive
- **#570**: ImportPipeline.trialCompile logs IllegalStateException at WARN with stack trace
- **#567**: CLI parseArgs uses explicit block + increment instead of fragile post-increment idiom
- **#566**: BatchImportCli.run extracts tempDir variable for clarity in finally block

## Test plan
- [x] `mvn clean test` — 125 tests pass, 0 failures
- [x] `mvn spotbugs:check` — clean
- [x] Deep audit of all 6 touched source files — no new issues

Closes #718, #717, #698, #648, #570, #567, #566