### PR TITLE
Preserve all-uppercase acronyms in toPascalCase

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/JavaSourceEscaper.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/JavaSourceEscaper.java
@@ -53,10 +53,11 @@ public final class JavaSourceEscaper {
     }
 
     /**
-     * Converts a string to PascalCase. Splits on spaces, hyphens, underscores,
-     * and camelCase boundaries.
+     * Converts a string to PascalCase. Splits on non-alphanumeric characters
+     * (spaces, hyphens, underscores, etc.). All-uppercase tokens (acronyms like
+     * SIR, HIV, GDP) are preserved as-is.
      *
-     * <p>Examples: "my model name" → "MyModelName", "SIR-model" → "SirModel"
+     * <p>Examples: "my model name" → "MyModelName", "SIR-model" → "SIRModel"
      */
     public static String toPascalCase(String input) {
         if (input == null || input.isBlank()) {
@@ -69,9 +70,14 @@ public final class JavaSourceEscaper {
             if (token.isEmpty()) {
                 continue;
             }
-            sb.append(Character.toUpperCase(token.charAt(0)));
-            if (token.length() > 1) {
-                sb.append(token.substring(1).toLowerCase());
+            if (token.length() > 1 && token.equals(token.toUpperCase())) {
+                // Preserve all-uppercase tokens (acronyms)
+                sb.append(token);
+            } else {
+                sb.append(Character.toUpperCase(token.charAt(0)));
+                if (token.length() > 1) {
+                    sb.append(token.substring(1).toLowerCase());
+                }
             }
         }
         return sb.toString();

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/JavaSourceEscaperTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/JavaSourceEscaperTest.java
@@ -69,7 +69,20 @@ class JavaSourceEscaperTest {
 
         @Test
         void shouldConvertHyphenSeparated() {
-            assertThat(JavaSourceEscaper.toPascalCase("SIR-model")).isEqualTo("SirModel");
+            assertThat(JavaSourceEscaper.toPascalCase("SIR-model")).isEqualTo("SIRModel");
+        }
+
+        @Test
+        void shouldPreserveAllUppercaseAcronyms() {
+            assertThat(JavaSourceEscaper.toPascalCase("HIV AIDS model")).isEqualTo("HIVAIDSModel");
+            assertThat(JavaSourceEscaper.toPascalCase("GDP growth")).isEqualTo("GDPGrowth");
+            assertThat(JavaSourceEscaper.toPascalCase("SIR")).isEqualTo("SIR");
+        }
+
+        @Test
+        void shouldNotPreserveSingleCharUppercase() {
+            // Single uppercase chars are just capitalized, not "acronyms"
+            assertThat(JavaSourceEscaper.toPascalCase("A-B-C")).isEqualTo("ABC");
         }
 
         @Test


### PR DESCRIPTION
## Summary
- `toPascalCase` now keeps all-uppercase tokens (SIR, HIV, GDP) intact instead of lowercasing them to Sir, Hiv, Gdp
- Fixed misleading Javadoc that claimed camelCase splitting (not implemented)

## Test plan
- [x] `mvn clean test` — 127 tests pass, 0 failures
- [x] `mvn spotbugs:check` — clean
- [x] Deep audit of JavaSourceEscaper — no new issues

Closes #569