### PR TITLE
Fix UI unresponsiveness on startup and model loading

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -768,19 +768,36 @@ public class ModelWindow {
         editor.addListener(dirtyListener);
         editor.loadFrom(def);
 
-        ViewDef view;
         if (def.stocks().isEmpty() && def.flows().isEmpty()
                 && def.variables().isEmpty()) {
             // CLD or empty model — use embedded view if available
+            ViewDef view;
             if (!def.views().isEmpty() && !def.cldVariables().isEmpty()) {
                 view = def.views().getFirst();
             } else {
                 view = new ViewDef("Main", List.of(), List.of(), List.of());
             }
+            applyView(view, displayName);
         } else {
-            view = AutoLayout.layout(def);
+            // Run auto-layout on a background thread to keep the UI responsive.
+            // ELK initialization on first use and layout of large models can
+            // take over a second on a cold JVM.
+            statusBar.showProgress("Computing layout\u2026");
+            canvas.setDisable(true);
+            Thread layoutThread = new Thread(() -> {
+                ViewDef view = AutoLayout.layout(def);
+                Platform.runLater(() -> {
+                    canvas.setDisable(false);
+                    statusBar.clearProgress();
+                    applyView(view, displayName);
+                });
+            }, "auto-layout");
+            layoutThread.setDaemon(true);
+            layoutThread.start();
         }
+    }
 
+    private void applyView(ViewDef view, String displayName) {
         canvas.clearNavigation();
         canvas.clearSparklines();
         canvas.setModel(editor, view);

--- a/courant-app/src/main/java/systems/courant/sd/app/StartScreen.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/StartScreen.java
@@ -22,8 +22,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
@@ -45,6 +47,7 @@ final class StartScreen extends VBox {
     private BiConsumer<String, String> onOpenExample;
 
     private List<ExampleEntry> allExamples = List.of();
+    private Map<ExampleEntry, Region> cardCache = new HashMap<>();
     private FlowPane exampleGrid;
     private String activeDifficulty = ALL;
     private final Set<String> activeDomains = new HashSet<>();
@@ -183,7 +186,9 @@ final class StartScreen extends VBox {
         exampleGrid.setAlignment(Pos.CENTER);
         exampleGrid.setMaxWidth(720);
 
-        applyFilters();
+        // Defer card creation until after the stage is shown so the start
+        // screen appears immediately and cards are populated on the next pulse.
+        javafx.application.Platform.runLater(this::applyFilters);
 
         section.getChildren().addAll(headerBox, filterBar, exampleGrid);
         return section;
@@ -270,7 +275,8 @@ final class StartScreen extends VBox {
             boolean matchesDomain = activeDomains.isEmpty()
                     || activeDomains.contains(toDomain(example.category));
             if (matchesDifficulty && matchesDomain) {
-                exampleGrid.getChildren().add(buildExampleCard(example));
+                exampleGrid.getChildren().add(
+                        cardCache.computeIfAbsent(example, this::buildExampleCard));
             }
         }
     }


### PR DESCRIPTION
## Summary
- Defer start screen card creation and cache cards to avoid rebuilding 120 cards (720 nodes) synchronously during construction
- Move AutoLayout.layout() to a background thread with progress indicator — ELK init + layout blocked the FX thread for 1s+ on cold JVM even for small models

## Test plan
- [x] All 4,020 tests pass
- [x] SpotBugs clean