### PR TITLE
Add unit field to LookupTableDef

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
@@ -749,7 +749,19 @@ public class ModelEditor {
         checkFxThread();
         return updateInList(lookupTables, name, LookupTableDef::name,
                 lt -> new LookupTableDef(name, comment,
-                        lt.xValues(), lt.yValues(), lt.interpolation()));
+                        lt.xValues(), lt.yValues(), lt.interpolation(), lt.unit()));
+    }
+
+    /**
+     * Sets the unit of a lookup table.
+     *
+     * @return true if the lookup table was found and updated
+     */
+    public boolean setLookupUnit(String name, String unit) {
+        checkFxThread();
+        return updateInList(lookupTables, name, LookupTableDef::name,
+                lt -> new LookupTableDef(lt.name(), lt.comment(),
+                        lt.xValues(), lt.yValues(), lt.interpolation(), unit));
     }
 
     private <T> boolean renameInList(List<T> list, String oldName, String newName,

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/LookupForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/LookupForm.java
@@ -79,6 +79,12 @@ public class LookupForm implements ElementForm {
         ctx.addFieldRow(row++, "Description", commentArea,
                 "Documentation for this element");
 
+        // Unit dropdown
+        ComboBox<String> unitBox = ctx.createUnitComboBox(lookup.unit());
+        ctx.addComboCommitHandlers(unitBox, this::commitUnit);
+        ctx.addFieldRow(row++, "Unit", unitBox,
+                "The unit of measurement for the lookup output");
+
         // Interpolation dropdown
         ComboBox<String> interpBox = new ComboBox<>();
         interpBox.getItems().addAll("LINEAR", "SPLINE");
@@ -91,7 +97,7 @@ public class LookupForm implements ElementForm {
                     if (!Objects.equals(newInterp, lt.interpolation())) {
                         LookupTableDef updated = new LookupTableDef(
                                 ctx.getElementName(), lt.comment(),
-                                lt.xValues(), lt.yValues(), newInterp);
+                                lt.xValues(), lt.yValues(), newInterp, lt.unit());
                         ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
                         replaceChart(lt.xValues(), lt.yValues(), newInterp);
                     }
@@ -418,7 +424,7 @@ public class LookupForm implements ElementForm {
         System.arraycopy(oldY, insertAt, newY, insertAt + 1, oldY.length - insertAt);
 
         LookupTableDef updated = new LookupTableDef(
-                ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation());
+                ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation(), lt.unit());
         ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
     }
 
@@ -440,7 +446,7 @@ public class LookupForm implements ElementForm {
         System.arraycopy(oldY, 0, newY, 0, index);
         System.arraycopy(oldY, index + 1, newY, index, oldY.length - index - 1);
         LookupTableDef updated = new LookupTableDef(
-                ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation());
+                ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation(), lt.unit());
         ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
     }
 
@@ -469,7 +475,7 @@ public class LookupForm implements ElementForm {
             }
         }
         LookupTableDef updated = new LookupTableDef(
-                ctx.getElementName(), lt.comment(), newXs, newYs, lt.interpolation());
+                ctx.getElementName(), lt.comment(), newXs, newYs, lt.interpolation(), lt.unit());
         ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
     }
 
@@ -518,7 +524,7 @@ public class LookupForm implements ElementForm {
                 }
             }
             LookupTableDef updated = new LookupTableDef(
-                    ctx.getElementName(), lt.comment(), newXs, newYs, lt.interpolation());
+                    ctx.getElementName(), lt.comment(), newXs, newYs, lt.interpolation(), lt.unit());
             ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
         } catch (NumberFormatException ignored) {
             xField.setText(ElementRenderer.formatValue(lt.xValues()[index]));
@@ -546,7 +552,7 @@ public class LookupForm implements ElementForm {
         newX[oldX.length] = oldX[oldX.length - 1] + 1;
         newY[oldY.length] = oldY[oldY.length - 1];
         LookupTableDef updated = new LookupTableDef(
-                ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation());
+                ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation(), lt.unit());
         ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
     }
 
@@ -563,7 +569,17 @@ public class LookupForm implements ElementForm {
         System.arraycopy(oldX, 0, newX, 0, newX.length);
         System.arraycopy(oldY, 0, newY, 0, newY.length);
         LookupTableDef updated = new LookupTableDef(
-                ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation());
+                ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation(), lt.unit());
         ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
+    }
+
+    private void commitUnit(ComboBox<String> box) {
+        String unit = box.getValue() != null ? box.getValue().trim() : "";
+        String normalizedUnit = unit.isEmpty() ? null : unit;
+        Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        if (ltOpt.isPresent() && Objects.equals(normalizedUnit, ltOpt.get().unit())) {
+            return;
+        }
+        ctx.canvas.applyMutation(() -> ctx.editor.setLookupUnit(ctx.getElementName(), normalizedUnit));
     }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -276,6 +276,9 @@ public class ModelDefinitionSerializer {
             node.set("xValues", doubleArrayToJson(t.xValues()));
             node.set("yValues", doubleArrayToJson(t.yValues()));
             node.put("interpolation", t.interpolation());
+            if (t.unit() != null) {
+                node.put("unit", t.unit());
+            }
             arr.add(node);
         }
         return arr;
@@ -623,7 +626,8 @@ public class ModelDefinitionSerializer {
                         textOrNull(n, "comment"),
                         jsonToDoubleArray(requiredNode(n, "xValues")),
                         jsonToDoubleArray(requiredNode(n, "yValues")),
-                        requiredText(n, "interpolation")));
+                        requiredText(n, "interpolation"),
+                        textOrNull(n, "unit")));
             }
         }
         return lookupTables;

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -314,7 +314,7 @@ public final class VensimExporter {
         }
 
         String equation = range + "," + pairs;
-        String units = "";
+        String units = lookup.unit() != null ? lookup.unit() : "";
         String comment = lookup.comment() != null ? lookup.comment() : "";
 
         // Lookup tables use the () operator format: Name( data )

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
@@ -1165,7 +1165,7 @@ public class VensimImporter implements ModelImporter {
 
         points = deduplicateLookupPoints(points, displayName, warnings);
         builder.lookupTable(new LookupTableDef(displayName, comment,
-                points[0], points[1], "LINEAR"));
+                points[0], points[1], "LINEAR", unit));
         lookupNames.add(eqName);
     }
 

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/LookupTableDef.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/LookupTableDef.java
@@ -11,13 +11,15 @@ import java.util.Objects;
  * @param xValues the x-axis data points
  * @param yValues the y-axis data points (same length as xValues)
  * @param interpolation the interpolation method: "LINEAR" or "SPLINE"
+ * @param unit the output unit of the lookup table, or {@code null} if unspecified
  */
 public record LookupTableDef(
         String name,
         String comment,
         double[] xValues,
         double[] yValues,
-        String interpolation
+        String interpolation,
+        String unit
 ) implements ElementDef {
 
     public LookupTableDef {
@@ -81,7 +83,21 @@ public record LookupTableDef(
     }
 
     /**
-     * Convenience constructor that creates a lookup table definition without a comment.
+     * Backward-compatible constructor without unit.
+     *
+     * @param name          the table name
+     * @param comment       optional description
+     * @param xValues       the x-axis data points (must be strictly increasing)
+     * @param yValues       the y-axis data points (same length as xValues)
+     * @param interpolation the interpolation method: {@code "LINEAR"} or {@code "SPLINE"}
+     */
+    public LookupTableDef(String name, String comment, double[] xValues, double[] yValues,
+                           String interpolation) {
+        this(name, comment, xValues, yValues, interpolation, null);
+    }
+
+    /**
+     * Convenience constructor without comment or unit.
      *
      * @param name          the table name
      * @param xValues       the x-axis data points (must be strictly increasing)
@@ -89,7 +105,7 @@ public record LookupTableDef(
      * @param interpolation the interpolation method: {@code "LINEAR"} or {@code "SPLINE"}
      */
     public LookupTableDef(String name, double[] xValues, double[] yValues, String interpolation) {
-        this(name, null, xValues, yValues, interpolation);
+        this(name, null, xValues, yValues, interpolation, null);
     }
 
     @Override
@@ -104,12 +120,13 @@ public record LookupTableDef(
                 && Objects.equals(comment, that.comment)
                 && Arrays.equals(xValues, that.xValues)
                 && Arrays.equals(yValues, that.yValues)
-                && Objects.equals(interpolation, that.interpolation);
+                && Objects.equals(interpolation, that.interpolation)
+                && Objects.equals(unit, that.unit);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(name, comment, interpolation);
+        int result = Objects.hash(name, comment, interpolation, unit);
         result = 31 * result + Arrays.hashCode(xValues);
         result = 31 * result + Arrays.hashCode(yValues);
         return result;

--- a/courant-engine/src/test/java/systems/courant/sd/model/def/LookupTableDefTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/def/LookupTableDefTest.java
@@ -1,0 +1,78 @@
+package systems.courant.sd.model.def;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("LookupTableDef (#743)")
+class LookupTableDefTest {
+
+    private static final double[] XS = {0, 1, 2};
+    private static final double[] YS = {0, 0.5, 1.0};
+
+    @Nested
+    @DisplayName("unit field")
+    class UnitField {
+
+        @Test
+        void shouldStoreAndRetrieveUnit() {
+            LookupTableDef def = new LookupTableDef("tbl", null, XS, YS, "LINEAR", "Widget");
+            assertThat(def.unit()).isEqualTo("Widget");
+        }
+
+        @Test
+        void shouldAllowNullUnit() {
+            LookupTableDef def = new LookupTableDef("tbl", null, XS, YS, "LINEAR", null);
+            assertThat(def.unit()).isNull();
+        }
+
+        @Test
+        void shouldDefaultToNullUnitFromFiveParamConstructor() {
+            LookupTableDef def = new LookupTableDef("tbl", null, XS, YS, "LINEAR");
+            assertThat(def.unit()).isNull();
+        }
+
+        @Test
+        void shouldDefaultToNullUnitFromFourParamConstructor() {
+            LookupTableDef def = new LookupTableDef("tbl", XS, YS, "LINEAR");
+            assertThat(def.unit()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("equals and hashCode with unit")
+    class EqualsHashCode {
+
+        @Test
+        void shouldBeEqualWhenUnitsMatch() {
+            LookupTableDef a = new LookupTableDef("tbl", null, XS, YS, "LINEAR", "kg");
+            LookupTableDef b = new LookupTableDef("tbl", null, XS, YS, "LINEAR", "kg");
+            assertThat(a).isEqualTo(b);
+            assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        }
+
+        @Test
+        void shouldNotBeEqualWhenUnitsDiffer() {
+            LookupTableDef a = new LookupTableDef("tbl", null, XS, YS, "LINEAR", "kg");
+            LookupTableDef b = new LookupTableDef("tbl", null, XS, YS, "LINEAR", "lb");
+            assertThat(a).isNotEqualTo(b);
+        }
+
+        @Test
+        void shouldNotBeEqualWhenOneUnitIsNull() {
+            LookupTableDef a = new LookupTableDef("tbl", null, XS, YS, "LINEAR", "kg");
+            LookupTableDef b = new LookupTableDef("tbl", null, XS, YS, "LINEAR", null);
+            assertThat(a).isNotEqualTo(b);
+        }
+
+        @Test
+        void shouldBeEqualWhenBothUnitsAreNull() {
+            LookupTableDef a = new LookupTableDef("tbl", null, XS, YS, "LINEAR", null);
+            LookupTableDef b = new LookupTableDef("tbl", null, XS, YS, "LINEAR");
+            assertThat(a).isEqualTo(b);
+            assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        }
+    }
+}

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
@@ -230,13 +230,7 @@ public class DemoClassGenerator {
         if (!definition.lookupTables().isEmpty()) {
             sb.append(INDENT).append("// Lookup tables\n");
             for (LookupTableDef table : definition.lookupTables()) {
-                sb.append(INDENT).append("builder.lookupTable(new LookupTableDef(")
-                        .append(escapeString(table.name())).append(", ")
-                        .append(escapeString(table.comment())).append(", ")
-                        .append(doubleArrayLiteral(table.xValues())).append(", ")
-                        .append(doubleArrayLiteral(table.yValues())).append(", ")
-                        .append(escapeString(table.interpolation()))
-                        .append("));\n");
+                emitLookupTableDef(sb, table, INDENT, "builder");
             }
             sb.append('\n');
         }
@@ -340,13 +334,7 @@ public class DemoClassGenerator {
             }
         }
         for (LookupTableDef table : inner.lookupTables()) {
-            sb.append(blockIndent).append("innerBuilder.lookupTable(new LookupTableDef(")
-                    .append(escapeString(table.name())).append(", ")
-                    .append(escapeString(table.comment())).append(", ")
-                    .append(doubleArrayLiteral(table.xValues())).append(", ")
-                    .append(doubleArrayLiteral(table.yValues())).append(", ")
-                    .append(escapeString(table.interpolation()))
-                    .append("));\n");
+            emitLookupTableDef(sb, table, blockIndent, "innerBuilder");
         }
         for (VariableDef v : inner.variables().stream().filter(a -> !a.isLiteral()).toList()) {
             emitVariableDef(sb, v, blockIndent, "innerBuilder");
@@ -448,6 +436,23 @@ public class DemoClassGenerator {
                     .append(escapeString(flow.sink()))
                     .append("));\n");
         }
+    }
+
+    /**
+     * Emits a LookupTableDef constructor call, including unit when present.
+     */
+    private void emitLookupTableDef(StringBuilder sb, LookupTableDef table,
+                                     String indent, String builderName) {
+        sb.append(indent).append(builderName).append(".lookupTable(new LookupTableDef(")
+                .append(escapeString(table.name())).append(", ")
+                .append(escapeString(table.comment())).append(", ")
+                .append(doubleArrayLiteral(table.xValues())).append(", ")
+                .append(doubleArrayLiteral(table.yValues())).append(", ")
+                .append(escapeString(table.interpolation()));
+        if (table.unit() != null) {
+            sb.append(", ").append(escapeString(table.unit()));
+        }
+        sb.append("));\n");
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add nullable `unit` field to `LookupTableDef` record with backward-compatible constructors
- Wire unit through JSON serialization/deserialization, Vensim import/export, UI form (ComboBox), and demo code generation
- Add `setLookupUnit()` to `ModelEditor`; preserve unit in all existing mutation paths

Closes #743

## Test plan
- [x] New `LookupTableDefTest` — unit storage, null handling, equals/hashCode
- [x] All existing tests pass unchanged (backward-compatible constructors)
- [x] `mvn clean compile` — full reactor
- [x] `mvn test` — all tests pass
- [x] `mvn spotbugs:check` — clean