### PR TITLE
Less chrome, more signal: canvas redesign

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ColorPalette.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ColorPalette.java
@@ -58,9 +58,16 @@ public final class ColorPalette {
     public static final Color TRACE_DOWNSTREAM = Color.web("#E67E22");
     public static final Color TRACE_ORIGIN = Color.web("#8E44AD");
 
+    // Borderless element fills (variables, lookups)
+    public static final Color VARIABLE_FILL = Color.web("#F0F2F5");
+    public static final Color LOOKUP_FILL = Color.web("#F0F2F5");
+    public static final Color HOVER_FILL = Color.web("#E8ECF0");
+
     // Comment annotation colors
-    public static final Color COMMENT_FILL = Color.web("#FFFDE7");
-    public static final Color COMMENT_BORDER = Color.web("#F9A825", 0.6);
+    public static final Color COMMENT_FILL = Color.web("#F0F1F3");
+    public static final Color COMMENT_BORDER = Color.web("#95A5A6", 0.7);
+    public static final Color COMMENT_TEXT = Color.web("#5D6D7E");
+    public static final Color COMMENT_ACCENT = Color.web("#95A5A6", 0.7);
 
     // Delay indicator badge
     public static final Color DELAY_BADGE = Color.web("#8E44AD");

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/LayoutMetrics.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/LayoutMetrics.java
@@ -42,6 +42,7 @@ public final class LayoutMetrics {
     public static final double COMMENT_HEIGHT = 80;
     public static final double COMMENT_BORDER_WIDTH = 1;
     public static final double COMMENT_CORNER_RADIUS = 4;
+    public static final double COMMENT_ACCENT_WIDTH = 4;
     public static final Font COMMENT_TEXT_FONT = Font.font("System", FontWeight.NORMAL, 11);
 
     // CLD variable dimensions

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
@@ -121,13 +121,9 @@ public final class SvgExporter {
                 case CLD_VARIABLE -> writeCldVariable(w, name, cx, cy,
                         LayoutMetrics.effectiveWidth(canvasState, name),
                         LayoutMetrics.effectiveHeight(canvasState, name));
-                case LOOKUP -> {
-                    int pts = editor.getLookupTableByName(name)
-                            .map(lt -> lt.xValues().length).orElse(0);
-                    writeLookup(w, name, pts, cx, cy,
-                            LayoutMetrics.effectiveWidth(canvasState, name),
-                            LayoutMetrics.effectiveHeight(canvasState, name));
-                }
+                case LOOKUP -> writeLookup(w, name, cx, cy,
+                        LayoutMetrics.effectiveWidth(canvasState, name),
+                        LayoutMetrics.effectiveHeight(canvasState, name));
                 case COMMENT -> {
                     var commentDef = editor.getCommentByName(name);
                     String text = commentDef != null ? commentDef.text() : "";
@@ -470,28 +466,11 @@ public final class SvgExporter {
         double y = cy - height / 2;
         double r = LayoutMetrics.AUX_CORNER_RADIUS;
 
-        // Fill
+        // Fill — subtle gray, no border
         w.printf(Locale.US,
                 "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.2f\" height=\"%.2f\" rx=\"%.1f\" " +
                 "fill=\"%s\"/>%n",
-                x, y, width, height, r, svgColor(ColorPalette.ELEMENT_FILL));
-
-        // Border: dashed for literals, solid for formulas
-        if (isLiteral) {
-            w.printf(Locale.US,
-                    "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.2f\" height=\"%.2f\" rx=\"%.1f\" " +
-                    "fill=\"none\" stroke=\"%s\" stroke-width=\"%.1f\" " +
-                    "stroke-dasharray=\"%.0f %.0f\"/>%n",
-                    x, y, width, height, r,
-                    svgColor(ColorPalette.AUX_LITERAL_BORDER), LayoutMetrics.AUX_BORDER_WIDTH,
-                    LayoutMetrics.AUX_LITERAL_DASH_LENGTH, LayoutMetrics.AUX_LITERAL_DASH_GAP);
-        } else {
-            w.printf(Locale.US,
-                    "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.2f\" height=\"%.2f\" rx=\"%.1f\" " +
-                    "fill=\"none\" stroke=\"%s\" stroke-width=\"%.1f\"/>%n",
-                    x, y, width, height, r,
-                    svgColor(ColorPalette.AUX_BORDER), LayoutMetrics.AUX_BORDER_WIDTH);
-        }
+                x, y, width, height, r, svgColor(ColorPalette.VARIABLE_FILL));
 
         // Badge: value for literals, "fx" for formulas
         String badge;
@@ -552,25 +531,17 @@ public final class SvgExporter {
                 cx, cy, LayoutMetrics.MODULE_NAME_FONT_SIZE, svgColor(ColorPalette.TEXT), escapeXml(modLabel));
     }
 
-    private static void writeLookup(PrintWriter w, String name, int dataPoints,
+    private static void writeLookup(PrintWriter w, String name,
                                      double cx, double cy, double width, double height) {
         double x = cx - width / 2;
         double y = cy - height / 2;
         double r = LayoutMetrics.LOOKUP_CORNER_RADIUS;
 
-        // Fill
+        // Fill — subtle gray, no border
         w.printf(Locale.US,
                 "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.2f\" height=\"%.2f\" rx=\"%.1f\" " +
                 "fill=\"%s\"/>%n",
-                x, y, width, height, r, svgColor(ColorPalette.ELEMENT_FILL));
-
-        // Dot-dash border
-        w.printf(Locale.US,
-                "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.2f\" height=\"%.2f\" rx=\"%.1f\" " +
-                "fill=\"none\" stroke=\"%s\" stroke-width=\"%.1f\" " +
-                "stroke-dasharray=\"8 3 2 3\"/>%n",
-                x, y, width, height, r,
-                svgColor(ColorPalette.AUX_BORDER), LayoutMetrics.LOOKUP_BORDER_WIDTH);
+                x, y, width, height, r, svgColor(ColorPalette.LOOKUP_FILL));
 
         // Table badge
         w.printf(Locale.US,
@@ -579,20 +550,13 @@ public final class SvgExporter {
                 x + 4, y + 3, LayoutMetrics.BADGE_FONT_SIZE,
                 svgColor(ColorPalette.TEXT_SECONDARY), ElementRenderer.BADGE_LOOKUP);
 
-        // Name centered (truncated to fit)
+        // Name centered vertically (truncated to fit)
         String lookupLabel = ElementRenderer.truncate(name, LayoutMetrics.LOOKUP_NAME_FONT, width - 16);
         w.printf(Locale.US,
                 "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"middle\" dominant-baseline=\"central\" " +
                 "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
-                cx, cy + LayoutMetrics.LABEL_NAME_OFFSET,
+                cx, cy,
                 LayoutMetrics.LOOKUP_NAME_FONT_SIZE, svgColor(ColorPalette.TEXT), escapeXml(lookupLabel));
-
-        // Data point count
-        w.printf(Locale.US,
-                "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"middle\" dominant-baseline=\"central\" " +
-                "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
-                cx, cy + LayoutMetrics.LABEL_SUBLABEL_OFFSET,
-                LayoutMetrics.BADGE_FONT_SIZE, svgColor(ColorPalette.TEXT_SECONDARY), dataPoints + " pts");
     }
 
     private static void writeCldVariable(PrintWriter w, String name,
@@ -611,13 +575,19 @@ public final class SvgExporter {
         double y = cy - height / 2;
         double r = LayoutMetrics.COMMENT_CORNER_RADIUS;
 
+        // Fill — no full border
         w.printf(Locale.US,
                 "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.2f\" height=\"%.2f\" " +
-                "rx=\"%.1f\" ry=\"%.1f\" fill=\"%s\" stroke=\"%s\" stroke-width=\"%.1f\"/>%n",
+                "rx=\"%.1f\" ry=\"%.1f\" fill=\"%s\"/>%n",
                 x, y, width, height, r, r,
-                svgColor(ColorPalette.COMMENT_FILL),
-                svgColor(ColorPalette.COMMENT_BORDER),
-                LayoutMetrics.COMMENT_BORDER_WIDTH);
+                svgColor(ColorPalette.COMMENT_FILL));
+
+        // Left accent bar
+        w.printf(Locale.US,
+                "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.1f\" height=\"%.2f\" " +
+                "fill=\"%s\" fill-opacity=\"%.2f\"/>%n",
+                x, y + r, LayoutMetrics.COMMENT_ACCENT_WIDTH, height - r * 2,
+                svgColor(ColorPalette.COMMENT_ACCENT), svgOpacity(ColorPalette.COMMENT_ACCENT));
 
         if (text != null && !text.isBlank()) {
             String display = ElementRenderer.truncate(
@@ -626,7 +596,7 @@ public final class SvgExporter {
                     "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"start\" dominant-baseline=\"hanging\" " +
                     "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
                     x + 6, y + 6, LayoutMetrics.COMMENT_TEXT_FONT_SIZE,
-                    svgColor(ColorPalette.TEXT), escapeXml(display));
+                    svgColor(ColorPalette.COMMENT_TEXT), escapeXml(display));
         }
     }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CanvasRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CanvasRenderer.java
@@ -5,6 +5,8 @@ import systems.courant.sd.model.def.ConnectorRoute;
 import systems.courant.sd.model.def.ElementType;
 import systems.courant.sd.model.def.FlowDef;
 import systems.courant.sd.model.def.ValidationIssue;
+import systems.courant.sd.model.def.VariableDef;
+import systems.courant.sd.model.expr.DelayDetector;
 import systems.courant.sd.model.graph.CausalTraceAnalysis;
 import systems.courant.sd.model.graph.FeedbackAnalysis;
 import systems.courant.sd.model.graph.FeedbackAnalysis.CausalLoop;
@@ -304,7 +306,31 @@ public class CanvasRenderer {
         // 2d. Draw hover indicator (above loops, below selection)
         if (hoveredElement != null && !canvasState.getSelection().contains(hoveredElement)
                 && !isHiddenAux(hoveredElement, hideAux)) {
-            SelectionRenderer.drawHoverIndicator(gc, canvasState, hoveredElement);
+            ElementType hoverType = canvasState.getType(hoveredElement).orElse(null);
+            if (hoverType == ElementType.AUX) {
+                // Redraw aux with hover fill (paints over normal fill)
+                ModelEditor ed = ctx.editor();
+                double hw = LayoutMetrics.effectiveWidth(canvasState, hoveredElement);
+                double hh = LayoutMetrics.effectiveHeight(canvasState, hoveredElement);
+                double hx = canvasState.getX(hoveredElement) - hw / 2;
+                double hy = canvasState.getY(hoveredElement) - hh / 2;
+                boolean isLit = ed.getVariableByName(hoveredElement)
+                        .map(VariableDef::isLiteral).orElse(false);
+                String eq = ed.getVariableEquation(hoveredElement).orElse(null);
+                boolean hasDel = ctx.showDelayBadges()
+                        && DelayDetector.equationContainsDelay(eq);
+                ElementRenderer.drawAux(gc, hoveredElement, isLit, eq, hasDel,
+                        hx, hy, hw, hh, true);
+            } else if (hoverType == ElementType.LOOKUP) {
+                // Redraw lookup with hover fill
+                double hw = LayoutMetrics.effectiveWidth(canvasState, hoveredElement);
+                double hh = LayoutMetrics.effectiveHeight(canvasState, hoveredElement);
+                double hx = canvasState.getX(hoveredElement) - hw / 2;
+                double hy = canvasState.getY(hoveredElement) - hh / 2;
+                ElementRenderer.drawLookup(gc, hoveredElement, hx, hy, hw, hh, true);
+            } else {
+                SelectionRenderer.drawHoverIndicator(gc, canvasState, hoveredElement);
+            }
         }
 
         // 3. Draw selection indicators on top of everything

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
@@ -121,25 +121,21 @@ public final class ElementRenderer {
     public static void drawAux(GraphicsContext gc, String name, boolean isLiteral, String equation,
                                boolean hasDelay,
                                double x, double y, double width, double height) {
+        drawAux(gc, name, isLiteral, equation, hasDelay, x, y, width, height, false);
+    }
+
+    /**
+     * Draws a variable: rounded rectangle with subtle fill (no border), badge, and centered name.
+     * When hovered, uses a stronger fill to provide visual feedback.
+     */
+    public static void drawAux(GraphicsContext gc, String name, boolean isLiteral, String equation,
+                               boolean hasDelay, double x, double y, double width, double height,
+                               boolean hovered) {
         double r = LayoutMetrics.AUX_CORNER_RADIUS;
 
-        // Fill
-        gc.setFill(ColorPalette.ELEMENT_FILL);
+        // Fill: hover fill when hovered, subtle gray otherwise
+        gc.setFill(hovered ? ColorPalette.HOVER_FILL : ColorPalette.VARIABLE_FILL);
         gc.fillRoundRect(x, y, width, height, r, r);
-
-        // Border: dashed for literals, solid for formulas
-        if (isLiteral) {
-            gc.setStroke(ColorPalette.AUX_LITERAL_BORDER);
-            gc.setLineWidth(LayoutMetrics.AUX_BORDER_WIDTH);
-            gc.setLineDashes(LayoutMetrics.AUX_LITERAL_DASH_LENGTH,
-                    LayoutMetrics.AUX_LITERAL_DASH_GAP);
-        } else {
-            gc.setStroke(ColorPalette.AUX_BORDER);
-            gc.setLineWidth(LayoutMetrics.AUX_BORDER_WIDTH);
-            gc.setLineDashes();
-        }
-        gc.strokeRoundRect(x, y, width, height, r, r);
-        gc.setLineDashes();
 
         // Badge top-left: value for literals, "fx" for formulas
         gc.setFill(ColorPalette.TEXT_SECONDARY);
@@ -255,20 +251,23 @@ public final class ElementRenderer {
      * Draws a lookup table: rounded rectangle with dot-dash border, "tbl" badge,
      * name, and data point count.
      */
-    public static void drawLookup(GraphicsContext gc, String name, int dataPoints,
+    public static void drawLookup(GraphicsContext gc, String name,
                                   double x, double y, double width, double height) {
+        drawLookup(gc, name, x, y, width, height, false);
+    }
+
+    /**
+     * Draws a lookup table: rounded rectangle with subtle fill (no border),
+     * "Table" badge, and centered name. When hovered, uses a stronger fill.
+     */
+    public static void drawLookup(GraphicsContext gc, String name,
+                                  double x, double y, double width, double height,
+                                  boolean hovered) {
         double r = LayoutMetrics.LOOKUP_CORNER_RADIUS;
 
-        // Fill
-        gc.setFill(ColorPalette.ELEMENT_FILL);
+        // Fill: hover fill when hovered, subtle gray otherwise
+        gc.setFill(hovered ? ColorPalette.HOVER_FILL : ColorPalette.LOOKUP_FILL);
         gc.fillRoundRect(x, y, width, height, r, r);
-
-        // Dot-dash border
-        gc.setStroke(ColorPalette.AUX_BORDER);
-        gc.setLineWidth(LayoutMetrics.LOOKUP_BORDER_WIDTH);
-        gc.setLineDashes(8, 3, 2, 3);
-        gc.strokeRoundRect(x, y, width, height, r, r);
-        gc.setLineDashes();
 
         // Table badge top-left
         gc.setFill(ColorPalette.TEXT_SECONDARY);
@@ -277,21 +276,13 @@ public final class ElementRenderer {
         gc.setTextBaseline(VPos.TOP);
         gc.fillText(BADGE_LOOKUP, x + 4, y + 3);
 
-        // Name centered, slightly above middle (truncated to fit)
+        // Name centered vertically (truncated to fit)
         gc.setFill(ColorPalette.TEXT);
         gc.setFont(LayoutMetrics.LOOKUP_NAME_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
         gc.fillText(truncate(name, LayoutMetrics.LOOKUP_NAME_FONT, width - 16),
-                x + width / 2, y + height / 2 + LayoutMetrics.LABEL_NAME_OFFSET);
-
-        // Data point count below name
-        gc.setFill(ColorPalette.TEXT_SECONDARY);
-        gc.setFont(LayoutMetrics.BADGE_FONT);
-        gc.setTextAlign(TextAlignment.CENTER);
-        gc.setTextBaseline(VPos.CENTER);
-        gc.fillText(dataPoints + " pts", x + width / 2,
-                y + height / 2 + LayoutMetrics.LABEL_SUBLABEL_OFFSET);
+                x + width / 2, y + height / 2);
     }
 
     /** Padding inside the comment box (each side). */
@@ -305,19 +296,17 @@ public final class ElementRenderer {
                                    double x, double y, double width, double height) {
         double r = LayoutMetrics.COMMENT_CORNER_RADIUS;
 
-        // Fill — warm yellow note appearance
+        // Fill — neutral gray note appearance
         gc.setFill(ColorPalette.COMMENT_FILL);
         gc.fillRoundRect(x, y, width, height, r, r);
 
-        // Border
-        gc.setStroke(ColorPalette.COMMENT_BORDER);
-        gc.setLineWidth(LayoutMetrics.COMMENT_BORDER_WIDTH);
-        gc.setLineDashes();
-        gc.strokeRoundRect(x, y, width, height, r, r);
+        // Left accent bar instead of full border
+        gc.setFill(ColorPalette.COMMENT_ACCENT);
+        gc.fillRect(x, y + r, LayoutMetrics.COMMENT_ACCENT_WIDTH, height - r * 2);
 
         // Text content (word-wrapped, top-left aligned)
         if (text != null && !text.isBlank()) {
-            gc.setFill(ColorPalette.TEXT);
+            gc.setFill(ColorPalette.COMMENT_TEXT);
             gc.setFont(LayoutMetrics.COMMENT_TEXT_FONT);
             gc.setTextAlign(TextAlignment.LEFT);
             gc.setTextBaseline(VPos.TOP);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/LookupRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/LookupRenderer.java
@@ -7,7 +7,7 @@ import systems.courant.sd.app.canvas.LayoutMetrics;
 import systems.courant.sd.app.canvas.ModelEditor;
 
 /**
- * Renders lookup table elements: dot-dash bordered rectangle with data point count.
+ * Renders lookup table elements: subtle-fill rectangle with "Table" badge and name.
  */
 final class LookupRenderer implements ElementTypeRenderer {
 
@@ -16,8 +16,6 @@ final class LookupRenderer implements ElementTypeRenderer {
                        CanvasState canvasState, ModelEditor editor, boolean showDelay) {
         double w = LayoutMetrics.effectiveWidth(canvasState, name);
         double h = LayoutMetrics.effectiveHeight(canvasState, name);
-        int pts = editor.getLookupTableByName(name)
-                .map(lt -> lt.xValues().length).orElse(0);
-        ElementRenderer.drawLookup(gc, name, pts, cx - w / 2, cy - h / 2, w, h);
+        ElementRenderer.drawLookup(gc, name, cx - w / 2, cy - h / 2, w, h);
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ColorPaletteTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ColorPaletteTest.java
@@ -83,6 +83,11 @@ class ColorPaletteTest {
             assertThat(ColorPalette.COMMENT_FILL).isNotNull();
             assertThat(ColorPalette.COMMENT_BORDER).isNotNull();
             assertThat(ColorPalette.DELAY_BADGE).isNotNull();
+            assertThat(ColorPalette.VARIABLE_FILL).isNotNull();
+            assertThat(ColorPalette.LOOKUP_FILL).isNotNull();
+            assertThat(ColorPalette.HOVER_FILL).isNotNull();
+            assertThat(ColorPalette.COMMENT_TEXT).isNotNull();
+            assertThat(ColorPalette.COMMENT_ACCENT).isNotNull();
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Remove borders from variable and lookup elements, replacing with subtle gray fill (#F0F2F5)
- Hover on borderless elements shows stronger fill (#E8ECF0) instead of stroked outline
- Comments use neutral gray fill with left accent bar instead of yellow fill with amber border
- Remove data point count from lookup elements for cleaner appearance
- SVG export updated to match all canvas rendering changes

Closes #750

## Test plan
- [x] `mvn clean compile` — all signature changes consistent
- [x] `mvn clean test` — 127 tests pass, zero failures
- [x] `mvn spotbugs:check` — zero findings
- [ ] Visual: stocks/modules retain borders, variables/lookups show subtle fill, comments are gray with left accent
- [ ] Visual: hover on variable/lookup shows stronger fill; hover on stock/flow/module shows stroked outline