### PR TITLE
Fix XMILE exporter paren matching and view parser descendant search

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/FormatUtils.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/FormatUtils.java
@@ -60,4 +60,28 @@ public final class FormatUtils {
         }
         return -1;
     }
+
+    /**
+     * Finds the index of the closing parenthesis that matches the opening
+     * parenthesis at {@code openParenPos}, respecting nested parentheses.
+     *
+     * @param content      the string to search
+     * @param openParenPos the index of the opening parenthesis
+     * @return the index of the matching closing parenthesis, or {@code -1} if not found
+     */
+    public static int findMatchingCloseParen(String content, int openParenPos) {
+        int depth = 1;
+        for (int i = openParenPos + 1; i < content.length(); i++) {
+            char c = content.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+                if (depth == 0) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
@@ -470,8 +470,8 @@ public final class XmileExporter {
         if (comma < 0) {
             return Optional.empty();
         }
-        int closeParen = trimmed.lastIndexOf(')');
-        if (closeParen <= comma) {
+        int closeParen = FormatUtils.findMatchingCloseParen(trimmed, openParen);
+        if (closeParen < 0 || closeParen <= comma) {
             return Optional.empty();
         }
         return Optional.of(trimmed.substring(comma + 1, closeParen).strip());

--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileViewParser.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileViewParser.java
@@ -9,7 +9,7 @@ import systems.courant.sd.model.def.ViewDef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
+import org.w3c.dom.Node;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,25 +43,11 @@ public final class XmileViewParser {
                                        Set<String> flowNames, Set<String> lookupNames,
                                        List<String> warnings) {
         List<ViewDef> views = new ArrayList<>();
-        NodeList viewNodes = viewsElement.getElementsByTagNameNS(
-                XmileConstants.NAMESPACE_URI, XmileConstants.VIEW);
 
-        // Also try without namespace for compatibility
-        if (viewNodes.getLength() == 0) {
-            viewNodes = viewsElement.getElementsByTagName(XmileConstants.VIEW);
-        }
-
-        for (int i = 0; i < viewNodes.getLength(); i++) {
-            if (!(viewNodes.item(i) instanceof Element viewElem)) {
-                continue;
-            }
-            // Only parse direct children of <views>
-            if (viewElem.getParentNode() != viewsElement) {
-                continue;
-            }
+        for (Element viewElem : getDirectChildren(viewsElement, XmileConstants.VIEW)) {
             String viewName = viewElem.getAttribute(XmileConstants.ATTR_NAME);
-            if (viewName == null || viewName.isBlank()) {
-                viewName = "View " + (i + 1);
+            if (viewName.isBlank()) {
+                viewName = "View " + (views.size() + 1);
             }
 
             List<ElementPlacement> elements = new ArrayList<>();
@@ -90,18 +76,9 @@ public final class XmileViewParser {
                                        List<ElementPlacement> elements,
                                        Set<String> stockNames, Set<String> flowNames,
                                        Set<String> lookupNames) {
-        NodeList nodes = viewElem.getElementsByTagNameNS(
-                XmileConstants.NAMESPACE_URI, tagName);
-        if (nodes.getLength() == 0) {
-            nodes = viewElem.getElementsByTagName(tagName);
-        }
-
-        for (int i = 0; i < nodes.getLength(); i++) {
-            if (!(nodes.item(i) instanceof Element elem)) {
-                continue;
-            }
+        for (Element elem : getDirectChildren(viewElem, tagName)) {
             String name = elem.getAttribute(XmileConstants.ATTR_NAME);
-            if (name == null || name.isBlank()) {
+            if (name.isBlank()) {
                 continue;
             }
 
@@ -126,16 +103,7 @@ public final class XmileViewParser {
     }
 
     private static void parseConnectors(Element viewElem, List<ConnectorRoute> connectors) {
-        NodeList nodes = viewElem.getElementsByTagNameNS(
-                XmileConstants.NAMESPACE_URI, XmileConstants.CONNECTOR);
-        if (nodes.getLength() == 0) {
-            nodes = viewElem.getElementsByTagName(XmileConstants.CONNECTOR);
-        }
-
-        for (int i = 0; i < nodes.getLength(); i++) {
-            if (!(nodes.item(i) instanceof Element elem)) {
-                continue;
-            }
+        for (Element elem : getDirectChildren(viewElem, XmileConstants.CONNECTOR)) {
             String from = getChildText(elem, XmileConstants.FROM).orElse(null);
             String to = getChildText(elem, XmileConstants.TO).orElse(null);
             if (from == null || from.isBlank() || to == null || to.isBlank()) {
@@ -148,18 +116,9 @@ public final class XmileViewParser {
     }
 
     private static void parseFlowRoutes(Element viewElem, List<FlowRoute> flowRoutes) {
-        NodeList nodes = viewElem.getElementsByTagNameNS(
-                XmileConstants.NAMESPACE_URI, XmileConstants.FLOW);
-        if (nodes.getLength() == 0) {
-            nodes = viewElem.getElementsByTagName(XmileConstants.FLOW);
-        }
-
-        for (int i = 0; i < nodes.getLength(); i++) {
-            if (!(nodes.item(i) instanceof Element elem)) {
-                continue;
-            }
+        for (Element elem : getDirectChildren(viewElem, XmileConstants.FLOW)) {
             String name = elem.getAttribute(XmileConstants.ATTR_NAME);
-            if (name == null || name.isBlank()) {
+            if (name.isBlank()) {
                 continue;
             }
 
@@ -172,25 +131,8 @@ public final class XmileViewParser {
 
     private static List<double[]> parseControlPoints(Element elem) {
         List<double[]> points = new ArrayList<>();
-        NodeList ptsNodes = elem.getElementsByTagNameNS(
-                XmileConstants.NAMESPACE_URI, XmileConstants.PTS);
-        if (ptsNodes.getLength() == 0) {
-            ptsNodes = elem.getElementsByTagName(XmileConstants.PTS);
-        }
-
-        for (int i = 0; i < ptsNodes.getLength(); i++) {
-            if (!(ptsNodes.item(i) instanceof Element ptsElem)) {
-                continue;
-            }
-            NodeList ptNodes = ptsElem.getElementsByTagNameNS(
-                    XmileConstants.NAMESPACE_URI, XmileConstants.PT);
-            if (ptNodes.getLength() == 0) {
-                ptNodes = ptsElem.getElementsByTagName(XmileConstants.PT);
-            }
-            for (int j = 0; j < ptNodes.getLength(); j++) {
-                if (!(ptNodes.item(j) instanceof Element ptElem)) {
-                    continue;
-                }
+        for (Element ptsElem : getDirectChildren(elem, XmileConstants.PTS)) {
+            for (Element ptElem : getDirectChildren(ptsElem, XmileConstants.PT)) {
                 String xStr = ptElem.getAttribute(XmileConstants.ATTR_X);
                 String yStr = ptElem.getAttribute(XmileConstants.ATTR_Y);
                 if (!xStr.isBlank() && !yStr.isBlank()) {
@@ -221,14 +163,33 @@ public final class XmileViewParser {
     }
 
     private static Optional<String> getChildText(Element parent, String tagName) {
-        NodeList nodes = parent.getElementsByTagNameNS(
-                XmileConstants.NAMESPACE_URI, tagName);
-        if (nodes.getLength() == 0) {
-            nodes = parent.getElementsByTagName(tagName);
-        }
-        if (nodes.getLength() > 0 && nodes.item(0) instanceof Element child) {
+        for (Element child : getDirectChildren(parent, tagName)) {
             return Optional.of(child.getTextContent().strip());
         }
         return Optional.empty();
+    }
+
+    /**
+     * Returns direct child elements of {@code parent} matching the given local tag name,
+     * checking both namespaced and non-namespaced variants.
+     * Unlike {@code getElementsByTagNameNS}, this does not search the entire subtree.
+     */
+    private static List<Element> getDirectChildren(Element parent, String localName) {
+        List<Element> result = new ArrayList<>();
+        for (Node n = parent.getFirstChild(); n != null; n = n.getNextSibling()) {
+            if (n instanceof Element child && matchesTag(child, localName)) {
+                result.add(child);
+            }
+        }
+        return result;
+    }
+
+    private static boolean matchesTag(Element elem, String localName) {
+        if (localName.equals(elem.getLocalName())) {
+            String ns = elem.getNamespaceURI();
+            return ns == null || ns.equals(XmileConstants.NAMESPACE_URI);
+        }
+        // Fallback for non-namespace-aware documents
+        return localName.equals(elem.getTagName());
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/FormatUtilsTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/FormatUtilsTest.java
@@ -79,4 +79,38 @@ class FormatUtilsTest {
                     .isEqualTo(13);
         }
     }
+
+    @Nested
+    @DisplayName("findMatchingCloseParen")
+    class FindMatchingCloseParen {
+
+        @Test
+        void shouldFindMatchingParen() {
+            // "LOOKUP(name, x)" — ( at 6, matching ) at 14
+            assertThat(FormatUtils.findMatchingCloseParen("LOOKUP(name, x)", 6)).isEqualTo(14);
+        }
+
+        @Test
+        void shouldHandleNestedParens() {
+            // "LOOKUP(name, max(a, b))" — ( at 6, matching ) at 22
+            assertThat(FormatUtils.findMatchingCloseParen("LOOKUP(name, max(a, b))", 6)).isEqualTo(22);
+        }
+
+        @Test
+        void shouldStopAtMatchingParen() {
+            // "LOOKUP(name, x) + foo(y)" — ( at 6, matching ) at 14 (not the last one)
+            assertThat(FormatUtils.findMatchingCloseParen("LOOKUP(name, x) + foo(y)", 6)).isEqualTo(14);
+        }
+
+        @Test
+        void shouldReturnMinusOneIfUnmatched() {
+            assertThat(FormatUtils.findMatchingCloseParen("LOOKUP(name, x", 6)).isEqualTo(-1);
+        }
+
+        @Test
+        void shouldHandleDeeplyNested() {
+            // "f(g(h(x)))" — ( at 1, matching ) at 9
+            assertThat(FormatUtils.findMatchingCloseParen("f(g(h(x)))", 1)).isEqualTo(9);
+        }
+    }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileExporterTest.java
@@ -368,5 +368,23 @@ class XmileExporterTest {
             assertThat(XmileExporter.extractLookupReference("a + b")).isEmpty();
             assertThat(XmileExporter.extractLookupInput("a + b")).isEmpty();
         }
+
+        @Test
+        void shouldExtractInputWithTrailingExpression() {
+            // Issue #631: lastIndexOf(')') would grab ') + foo(y' instead of just 'x'
+            assertThat(XmileExporter.extractLookupInput("LOOKUP(name, x) + foo(y)"))
+                    .hasValue("x");
+        }
+
+        @Test
+        void shouldExtractInputWithNestedParens() {
+            assertThat(XmileExporter.extractLookupInput("LOOKUP(my_table, max(a, b))"))
+                    .hasValue("max(a, b)");
+        }
+
+        @Test
+        void shouldReturnEmptyForUnmatchedParen() {
+            assertThat(XmileExporter.extractLookupInput("LOOKUP(name, x")).isEmpty();
+        }
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileViewParserTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileViewParserTest.java
@@ -123,6 +123,32 @@ class XmileViewParserTest {
         assertThat(views.get(0).name()).isEqualTo("View 1");
     }
 
+    @Test
+    void shouldIgnoreNestedDescendantElements() throws Exception {
+        // Issue #635: getElementsByTagName searches all descendants, so nested
+        // elements inside groups would be duplicated in the parent view
+        String xml = """
+                <views xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0">
+                  <view name="Main">
+                    <stock name="Population" x="100" y="200"/>
+                    <group>
+                      <stock name="Nested" x="300" y="400"/>
+                    </group>
+                  </view>
+                </views>
+                """;
+
+        Element viewsElem = parseElement(xml);
+        List<String> warnings = new ArrayList<>();
+        List<ViewDef> views = XmileViewParser.parse(
+                viewsElem, Set.of("Population", "Nested"), Set.of(), Set.of(), warnings);
+
+        assertThat(views).hasSize(1);
+        // Only "Population" is a direct child; "Nested" is inside <group> and must be excluded
+        assertThat(views.get(0).elements()).hasSize(1);
+        assertThat(views.get(0).elements().get(0).name()).isEqualTo("Population");
+    }
+
     private static Element parseElement(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);


### PR DESCRIPTION
## Summary
- Replace `lastIndexOf(')')` with balanced paren matching in `extractLookupInput` so trailing expressions like `LOOKUP(n, x) + foo(y)` extract only the correct input argument (#631)
- Replace `getElementsByTagNameNS` with direct-child iteration in `XmileViewParser` so nested elements inside groups are not duplicated (#635)

## Test plan
- [x] 8 new tests covering balanced paren matching, trailing expressions, nested parens, unmatched parens, and nested descendant filtering
- [x] All existing tests pass
- [x] SpotBugs clean

Closes #631
Closes #635