### PR TITLE
Remove background fill from comments

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ColorPalette.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ColorPalette.java
@@ -64,7 +64,6 @@ public final class ColorPalette {
     public static final Color HOVER_FILL = Color.web("#E8ECF0");
 
     // Comment annotation colors
-    public static final Color COMMENT_FILL = Color.web("#F0F1F3");
     public static final Color COMMENT_BORDER = Color.web("#95A5A6", 0.7);
     public static final Color COMMENT_TEXT = Color.web("#5D6D7E");
     public static final Color COMMENT_ACCENT = Color.web("#95A5A6", 0.7);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
@@ -575,13 +575,6 @@ public final class SvgExporter {
         double y = cy - height / 2;
         double r = LayoutMetrics.COMMENT_CORNER_RADIUS;
 
-        // Fill — no full border
-        w.printf(Locale.US,
-                "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.2f\" height=\"%.2f\" " +
-                "rx=\"%.1f\" ry=\"%.1f\" fill=\"%s\"/>%n",
-                x, y, width, height, r, r,
-                svgColor(ColorPalette.COMMENT_FILL));
-
         // Left accent bar
         w.printf(Locale.US,
                 "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.1f\" height=\"%.2f\" " +

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
@@ -296,11 +296,7 @@ public final class ElementRenderer {
                                    double x, double y, double width, double height) {
         double r = LayoutMetrics.COMMENT_CORNER_RADIUS;
 
-        // Fill — neutral gray note appearance
-        gc.setFill(ColorPalette.COMMENT_FILL);
-        gc.fillRoundRect(x, y, width, height, r, r);
-
-        // Left accent bar instead of full border
+        // Left accent bar
         gc.setFill(ColorPalette.COMMENT_ACCENT);
         gc.fillRect(x, y + r, LayoutMetrics.COMMENT_ACCENT_WIDTH, height - r * 2);
 

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ColorPaletteTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ColorPaletteTest.java
@@ -80,7 +80,6 @@ class ColorPaletteTest {
             assertThat(ColorPalette.TEXT).isNotNull();
             assertThat(ColorPalette.TEXT_SECONDARY).isNotNull();
             assertThat(ColorPalette.CLOUD).isNotNull();
-            assertThat(ColorPalette.COMMENT_FILL).isNotNull();
             assertThat(ColorPalette.COMMENT_BORDER).isNotNull();
             assertThat(ColorPalette.DELAY_BADGE).isNotNull();
             assertThat(ColorPalette.VARIABLE_FILL).isNotNull();


### PR DESCRIPTION
## Summary
- Remove gray background fill from comment elements, leaving only the left accent bar
- Delete unused `COMMENT_FILL` constant from `ColorPalette`

## Test plan
- [x] `mvn clean test` passes
- [x] `mvn spotbugs:check` clean