### PR TITLE
Widen getHistoryAtTimeStep to accept long index

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/Flow.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Flow.java
@@ -122,11 +122,11 @@ public abstract class Flow extends Element {
      *
      * @param i the zero-based time step index
      */
-    public double getHistoryAtTimeStep(int i) {
-        if (i < 0 || history.size() <= i) {
+    public double getHistoryAtTimeStep(long i) {
+        if (i < 0 || i >= history.size()) {
             return 0;
         }
-        return history.get(i);
+        return history.get((int) i);
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/model/Flows.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Flows.java
@@ -105,7 +105,7 @@ public final class Flows {
                                      LongSupplier stepSupplier, long delay) {
         return Flow.create(name, timeUnit, () -> {
             long referenceStep = stepSupplier.getAsLong() - delay;
-            double value = inflow.getHistoryAtTimeStep((int) referenceStep);
+            double value = inflow.getHistoryAtTimeStep(referenceStep);
             Stock sink = inflow.getSink();
             Preconditions.checkArgument(sink != null, "inflow must have a sink stock assigned");
             return new Quantity(value, sink.getUnit());

--- a/courant-engine/src/main/java/systems/courant/sd/model/Variable.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Variable.java
@@ -82,11 +82,11 @@ public class Variable extends Element {
      *
      * @param i the zero-based time step index
      */
-    public double getHistoryAtTimeStep(int i) {
-        if (i < 0 || history.size() <= i) {
+    public double getHistoryAtTimeStep(long i) {
+        if (i < 0 || i >= history.size()) {
             return 0;
         }
-        return history.get(i);
+        return history.get((int) i);
     }
 
     /**

--- a/courant-engine/src/test/java/systems/courant/sd/model/FlowsTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/FlowsTest.java
@@ -121,6 +121,20 @@ public class FlowsTest {
         assertEquals(5.0, departures.flowPerTimeUnit(DAY).getValue(), 0.001);
     }
 
+    @Test
+    public void pipelineDelayShouldHandleLongStepWithoutTruncation() {
+        Stock wip = new Stock("WIP", 0, THING);
+        Flow arrivals = Flows.constant("arrivals", DAY, new Quantity(5, THING));
+        wip.addInflow(arrivals);
+
+        // Step exceeds Integer.MAX_VALUE — reference step also exceeds int range
+        long bigStep = Integer.MAX_VALUE + 10L;
+        Flow departures = Flows.pipelineDelay("departures", DAY, arrivals, () -> bigStep, 3);
+
+        // Reference step is beyond any recorded history, so should return 0 (not wrap negative)
+        assertEquals(0.0, departures.flowPerTimeUnit(DAY).getValue(), 0.001);
+    }
+
     // Flow name and time unit
 
     @Test

--- a/courant-engine/src/test/java/systems/courant/sd/model/VariableTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/VariableTest.java
@@ -43,6 +43,14 @@ public class VariableTest {
     }
 
     @Test
+    public void shouldReturnZeroForLongIndexBeyondIntRange() {
+        Variable var = new Variable("V1", THING, () -> 10.0);
+        var.recordValue();
+        assertEquals(0.0, var.getHistoryAtTimeStep(Integer.MAX_VALUE + 1L), 0.0);
+        assertEquals(0.0, var.getHistoryAtTimeStep(Long.MAX_VALUE), 0.0);
+    }
+
+    @Test
     public void shouldReturnUnit() {
         Variable var = new Variable("V1", THING, () -> 0);
         assertEquals(THING, var.getUnit());


### PR DESCRIPTION
## Summary
- Changes `Variable.getHistoryAtTimeStep` and `Flow.getHistoryAtTimeStep` from `int` to `long` parameter
- Removes unsafe `(int)` cast in `Flows.pipelineDelay` that could wrap to negative for step counts exceeding `Integer.MAX_VALUE`
- Indices beyond `ArrayList` range safely return 0 instead of silently producing incorrect results

## Test plan
- [x] Added test in `FlowsTest` verifying pipeline delay with step beyond `Integer.MAX_VALUE` returns 0
- [x] Added test in `VariableTest` verifying `getHistoryAtTimeStep` with long indices beyond int range returns 0
- [x] All existing tests pass
- [x] SpotBugs clean

Closes #793