### PR TITLE
Add dimensional consistency checking for lookup table units

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EditorUnitContext.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EditorUnitContext.java
@@ -66,11 +66,17 @@ public final class EditorUnitContext implements DimensionalAnalyzer.UnitContext 
             return Optional.of(CompositeUnit.dimensionless());
         }
 
-        // Check lookup tables — return dimensionless
-        var lookupNames = editor.getLookupTables().stream()
-                .map(t -> t.name())
-                .toList();
-        if (lookupNames.contains(elementName) || lookupNames.contains(resolved)) {
+        // Check lookup tables — use declared unit if present, else dimensionless
+        var lookupOpt = editor.getLookupTableByName(elementName);
+        if (lookupOpt.isEmpty()) {
+            lookupOpt = editor.getLookupTableByName(resolved);
+        }
+        if (lookupOpt.isPresent()) {
+            String unitName = lookupOpt.get().unit();
+            if (unitName != null && !unitName.isBlank()) {
+                Unit unit = registry.resolve(unitName);
+                return Optional.of(CompositeUnit.of(unit));
+            }
             return Optional.of(CompositeUnit.dimensionless());
         }
 

--- a/courant-engine/src/main/java/systems/courant/sd/measure/DimensionalAnalyzer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/DimensionalAnalyzer.java
@@ -224,7 +224,15 @@ public class DimensionalAnalyzer {
             return CompositeUnit.dimensionless();
         }
 
-        if ("LOOKUP".equals(name)) {
+        if ("LOOKUP".equals(name) || "LOOKUP_AREA".equals(name)) {
+            // Resolve the table's declared output unit from the first argument (table name)
+            if (!call.arguments().isEmpty()
+                    && call.arguments().getFirst() instanceof Expr.Ref tableRef) {
+                CompositeUnit tableUnit = context.resolveUnit(tableRef.name()).orElse(null);
+                if (tableUnit != null) {
+                    return tableUnit;
+                }
+            }
             return CompositeUnit.dimensionless();
         }
 

--- a/courant-engine/src/test/java/systems/courant/sd/measure/DimensionalAnalyzerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/DimensionalAnalyzerTest.java
@@ -266,10 +266,48 @@ class DimensionalAnalyzerTest {
         }
 
         @Test
-        void shouldReturnDimensionlessForLOOKUP() {
+        void shouldReturnDimensionlessForLOOKUPWithNoUnit() {
             TestContext ctx = new TestContext().put("table", CompositeUnit.dimensionless());
             var result = analyze("LOOKUP(table, 5)", ctx);
             assertThat(result.inferredUnit().isDimensionless()).isTrue();
+            assertThat(result.isConsistent()).isTrue();
+        }
+
+        @Test
+        void shouldReturnDeclaredUnitForLOOKUP() {
+            TestContext ctx = new TestContext().put("effect_table", ITEMS);
+            var result = analyze("LOOKUP(effect_table, 5)", ctx);
+            assertThat(result.inferredUnit()).isEqualTo(ITEMS);
+            assertThat(result.isConsistent()).isTrue();
+        }
+
+        @Test
+        void shouldReturnDeclaredUnitForLOOKUP_AREA() {
+            TestContext ctx = new TestContext().put("area_table", MASS);
+            var result = analyze("LOOKUP_AREA(area_table, 1, 10)", ctx);
+            assertThat(result.inferredUnit()).isEqualTo(MASS);
+            assertThat(result.isConsistent()).isTrue();
+        }
+
+        @Test
+        void shouldWarnWhenLOOKUPUnitMismatchesContext() {
+            TestContext ctx = new TestContext()
+                    .put("effect_table", ITEMS)
+                    .put("Weight", MASS);
+            var result = analyze("LOOKUP(effect_table, 5) + Weight", ctx);
+            assertThat(result.isConsistent()).isFalse();
+            assertThat(result.warnings().getFirst().message())
+                    .contains("incompatible");
+        }
+
+        @Test
+        void shouldNotWarnWhenLOOKUPUnitMatchesContext() {
+            TestContext ctx = new TestContext()
+                    .put("effect_table", ITEMS)
+                    .put("Pop", ITEMS);
+            var result = analyze("LOOKUP(effect_table, 5) + Pop", ctx);
+            assertThat(result.isConsistent()).isTrue();
+            assertThat(result.inferredUnit()).isEqualTo(ITEMS);
         }
 
         @Test


### PR DESCRIPTION
## Summary
- DimensionalAnalyzer now resolves lookup table declared units for LOOKUP() and LOOKUP_AREA() calls instead of hardcoding dimensionless
- EditorUnitContext reads the `unit` field from LookupTableDef when resolving lookup table units
- No false positives when unit is null/unspecified — falls back to dimensionless

## Test plan
- [x] Unit tests for LOOKUP with declared unit returns that unit
- [x] Unit tests for LOOKUP_AREA with declared unit
- [x] Unit test for LOOKUP without unit remains dimensionless
- [x] Unit test for mismatch detection when LOOKUP unit conflicts with context
- [x] Unit test for compatible LOOKUP unit in addition expression
- [x] Full reactor build and test pass
- [x] SpotBugs clean

Closes #809