### PR TITLE
Guard against null column data in CalibrateDialog

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialog.java
@@ -172,6 +172,9 @@ public class CalibrateDialog extends Dialog<CalibrateDialog.Config> {
                     String stock = row.stockCombo.getValue();
                     if (stock != null && !stock.isEmpty()) {
                         double[] data = importedDataset.columns().get(row.csvColumn);
+                        if (data == null) {
+                            continue;
+                        }
                         targets.add(new FitTarget(stock, row.csvColumn, data));
                     }
                 }


### PR DESCRIPTION
## Summary
- Added null check for column data lookup in CalibrateDialog result converter
- Rows with missing CSV columns after remapping are now silently skipped instead of causing NPE

## Test plan
- [x] Full reactor build and test pass
- [x] SpotBugs clean

Closes #791