### PR TITLE
Encapsulate FormContext mutable fields with accessors

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/PropertiesPanel.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/PropertiesPanel.java
@@ -96,8 +96,8 @@ public class PropertiesPanel extends VBox {
         placeholderLabel.setAlignment(Pos.CENTER);
         placeholderLabel.setMaxWidth(Double.MAX_VALUE);
 
-        ctx.grid = propertyGrid;
-        ctx.onFormRebuildRequested = () -> updateSelection(ctx.canvas, ctx.editor);
+        ctx.setGrid(propertyGrid);
+        ctx.setOnFormRebuildRequested(() -> updateSelection(ctx.getCanvas(), ctx.getEditor()));
 
         showPlaceholder();
     }
@@ -107,7 +107,7 @@ public class PropertiesPanel extends VBox {
      * Called by ModelWindow after construction.
      */
     public void setOnOpenExpressionHelp(Runnable callback) {
-        ctx.onOpenExpressionHelp = callback;
+        ctx.setOnOpenExpressionHelp(callback);
     }
 
     /**
@@ -126,11 +126,9 @@ public class PropertiesPanel extends VBox {
      * Wrapped in updatingFields guard to prevent spurious focus-loss commits.
      */
     public void updateSelection(ModelCanvas canvas, ModelEditor editor) {
-        ctx.canvas = canvas;
-        ctx.editor = editor;
-        ctx.updatingFields = true;
-
-        try {
+        ctx.setCanvas(canvas);
+        ctx.setEditor(editor);
+        ctx.withUpdate(() -> {
             if (canvas == null || editor == null) {
                 showPlaceholder();
                 return;
@@ -157,9 +155,7 @@ public class PropertiesPanel extends VBox {
             } else {
                 showMultiSelection(selection.size());
             }
-        } finally {
-            ctx.updatingFields = false;
-        }
+        });
     }
 
     private void showPlaceholder() {
@@ -183,7 +179,7 @@ public class PropertiesPanel extends VBox {
         ctx.addFieldRow(row++, "Model", nameField);
         nameField.setOnAction(e -> commitModelName(nameField, editor));
         nameField.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
-            if (!isFocused && !ctx.updatingFields) {
+            if (!isFocused && !ctx.isUpdatingFields()) {
                 commitModelName(nameField, editor);
             }
         });
@@ -199,7 +195,7 @@ public class PropertiesPanel extends VBox {
         GridPane.setHgrow(descArea, Priority.ALWAYS);
         ctx.addFieldRow(row++, "Description", descArea);
         descArea.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
-            if (!isFocused && !ctx.updatingFields) {
+            if (!isFocused && !ctx.isUpdatingFields()) {
                 commitModelComment(descArea, editor);
             }
         });
@@ -318,9 +314,9 @@ public class PropertiesPanel extends VBox {
         contextToolbar.getChildren().clear();
         Button deleteBtn = createToolbarButton("Delete");
         deleteBtn.setOnAction(e -> {
-            if (ctx.canvas != null) {
-                ctx.canvas.deleteSelectedElements();
-                ctx.canvas.requestFocus();
+            if (ctx.getCanvas() != null) {
+                ctx.getCanvas().deleteSelectedElements();
+                ctx.getCanvas().requestFocus();
             }
         });
         contextToolbar.getChildren().add(deleteBtn);
@@ -340,13 +336,13 @@ public class PropertiesPanel extends VBox {
         propertyGrid.getChildren().clear();
         int row = 0;
 
-        boolean isCausalLink = ctx.canvas != null && ctx.canvas.isSelectedConnectionCausalLink();
+        boolean isCausalLink = ctx.getCanvas() != null && ctx.getCanvas().isSelectedConnectionCausalLink();
 
         ctx.addReadOnlyRow(row++, "Type", isCausalLink ? "Causal Link" : "Info Link");
         ctx.addReadOnlyRow(row++, "From", connection.from());
         ctx.addReadOnlyRow(row++, "To", connection.to());
 
-        if (isCausalLink && ctx.editor != null) {
+        if (isCausalLink && ctx.getEditor() != null) {
             CausalLinkDef link = findCausalLink(connection);
             if (link != null) {
                 // Polarity combo box
@@ -368,10 +364,10 @@ public class PropertiesPanel extends VBox {
                 propertyGrid.add(explanation, 0, row, 2, 1);
 
                 polarityBox.setOnAction(e -> {
-                    if (!ctx.updatingFields) {
+                    if (!ctx.isUpdatingFields()) {
                         CausalLinkDef.Polarity newPolarity = polarityFromDisplay(polarityBox.getValue());
-                        ctx.canvas.applyMutation(() ->
-                                ctx.editor.setCausalLinkPolarity(
+                        ctx.getCanvas().applyMutation(() ->
+                                ctx.getEditor().setCausalLinkPolarity(
                                         connection.from(), connection.to(), newPolarity));
                         explanation.setText(buildExplanation(connection, newPolarity));
                     }
@@ -383,7 +379,7 @@ public class PropertiesPanel extends VBox {
     }
 
     private CausalLinkDef findCausalLink(ConnectionId connection) {
-        for (CausalLinkDef link : ctx.editor.getCausalLinks()) {
+        for (CausalLinkDef link : ctx.getEditor().getCausalLinks()) {
             if (link.from().equals(connection.from()) && link.to().equals(connection.to())) {
                 return link;
             }
@@ -453,9 +449,9 @@ public class PropertiesPanel extends VBox {
         Button deleteBtn = createToolbarButton("Delete");
         deleteBtn.setId("propertiesDelete");
         deleteBtn.setOnAction(e -> {
-            if (ctx.canvas != null) {
-                ctx.canvas.deleteSelectedElements();
-                ctx.canvas.requestFocus();
+            if (ctx.getCanvas() != null) {
+                ctx.getCanvas().deleteSelectedElements();
+                ctx.getCanvas().requestFocus();
             }
         });
 
@@ -465,18 +461,18 @@ public class PropertiesPanel extends VBox {
             Button drillBtn = createToolbarButton("Drill Into");
             drillBtn.setId("propertiesDrill");
             drillBtn.setOnAction(e -> {
-                if (ctx.canvas != null) {
-                    ctx.canvas.drillInto(ctx.getElementName());
-                    ctx.canvas.requestFocus();
+                if (ctx.getCanvas() != null) {
+                    ctx.getCanvas().drillInto(ctx.getElementName());
+                    ctx.getCanvas().requestFocus();
                 }
             });
 
             Button bindingsBtn = createToolbarButton("Bindings");
             bindingsBtn.setId("propertiesBindings");
             bindingsBtn.setOnAction(e -> {
-                if (ctx.canvas != null) {
-                    ctx.canvas.triggerBindingConfig(ctx.getElementName());
-                    ctx.canvas.requestFocus();
+                if (ctx.getCanvas() != null) {
+                    ctx.getCanvas().triggerBindingConfig(ctx.getElementName());
+                    ctx.getCanvas().requestFocus();
                 }
             });
 
@@ -506,7 +502,7 @@ public class PropertiesPanel extends VBox {
             ctx.addReadOnlyRow(row++, "Name", name);
         }
 
-        if (type != ElementType.COMMENT && ctx.canvas != null) {
+        if (type != ElementType.COMMENT && ctx.getCanvas() != null) {
             propertyGrid.add(new Separator(), 0, row, 2, 1);
             row++;
             row = buildDependencySection(row, name);
@@ -528,7 +524,7 @@ public class PropertiesPanel extends VBox {
     }
 
     private int buildModuleForm(int row) {
-        Optional<ModuleInstanceDef> moduleOpt = ctx.editor.getModuleByName(ctx.getElementName());
+        Optional<ModuleInstanceDef> moduleOpt = ctx.getEditor().getModuleByName(ctx.getElementName());
         if (moduleOpt.isEmpty()) {
             ctx.addReadOnlyRow(row++, "Name", ctx.getElementName());
             return row;
@@ -566,8 +562,8 @@ public class PropertiesPanel extends VBox {
     }
 
     private int buildDependencySection(int row, String elementName) {
-        Set<String> usedBy = ctx.canvas.whereUsed(elementName);
-        Set<String> uses = ctx.canvas.uses(elementName);
+        Set<String> usedBy = ctx.getCanvas().whereUsed(elementName);
+        Set<String> uses = ctx.getCanvas().uses(elementName);
 
         if (!usedBy.isEmpty()) {
             Label label = new Label("Used by");
@@ -602,8 +598,8 @@ public class PropertiesPanel extends VBox {
             link.setStyle(Styles.SMALL_TEXT + " -fx-text-fill: #0066cc;");
             link.setPadding(new Insets(0, 2, 0, 0));
             link.setOnAction(e -> {
-                if (ctx.canvas != null) {
-                    ctx.canvas.selectElement(name);
+                if (ctx.getCanvas() != null) {
+                    ctx.getCanvas().selectElement(name);
                 }
             });
             pane.getChildren().add(link);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/CldVariableForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/CldVariableForm.java
@@ -26,7 +26,7 @@ public class CldVariableForm implements ElementForm {
 
     @Override
     public int build(int startRow) {
-        CldVariableDef variable = ctx.editor.getCldVariableByName(ctx.getElementName());
+        CldVariableDef variable = ctx.getEditor().getCldVariableByName(ctx.getElementName());
         if (variable == null) {
             ctx.addReadOnlyRow(startRow++, "Name", ctx.getElementName());
             return startRow;
@@ -52,7 +52,7 @@ public class CldVariableForm implements ElementForm {
 
     @Override
     public void updateValues() {
-        CldVariableDef variable = ctx.editor.getCldVariableByName(ctx.getElementName());
+        CldVariableDef variable = ctx.getEditor().getCldVariableByName(ctx.getElementName());
         if (variable == null || nameField == null) {
             return;
         }
@@ -63,10 +63,10 @@ public class CldVariableForm implements ElementForm {
     private void commitComment(TextArea area) {
         String text = area.getText().trim();
         String comment = text.isEmpty() ? null : text;
-        CldVariableDef variable = ctx.editor.getCldVariableByName(ctx.getElementName());
+        CldVariableDef variable = ctx.getEditor().getCldVariableByName(ctx.getElementName());
         if (variable == null || Objects.equals(comment, variable.comment())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setCldVariableComment(ctx.getElementName(), comment));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setCldVariableComment(ctx.getElementName(), comment));
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/CommentForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/CommentForm.java
@@ -24,7 +24,7 @@ public class CommentForm implements ElementForm {
 
     @Override
     public int build(int startRow) {
-        CommentDef comment = ctx.editor.getCommentByName(ctx.getElementName());
+        CommentDef comment = ctx.getEditor().getCommentByName(ctx.getElementName());
         if (comment == null) {
             ctx.addReadOnlyRow(startRow++, "Name", ctx.getElementName());
             return startRow;
@@ -48,7 +48,7 @@ public class CommentForm implements ElementForm {
 
     @Override
     public void updateValues() {
-        CommentDef comment = ctx.editor.getCommentByName(ctx.getElementName());
+        CommentDef comment = ctx.getEditor().getCommentByName(ctx.getElementName());
         if (comment == null || textArea == null) {
             return;
         }
@@ -57,10 +57,10 @@ public class CommentForm implements ElementForm {
 
     private void commitText(TextArea area) {
         String text = area.getText().trim();
-        CommentDef comment = ctx.editor.getCommentByName(ctx.getElementName());
+        CommentDef comment = ctx.getEditor().getCommentByName(ctx.getElementName());
         if (comment == null || Objects.equals(text, comment.text())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setCommentText(ctx.getElementName(), text));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setCommentText(ctx.getElementName(), text));
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FlowForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FlowForm.java
@@ -36,7 +36,7 @@ public class FlowForm implements ElementForm {
 
     @Override
     public int build(int startRow) {
-        Optional<FlowDef> flowOpt = ctx.editor.getFlowByName(ctx.getElementName());
+        Optional<FlowDef> flowOpt = ctx.getEditor().getFlowByName(ctx.getElementName());
         if (flowOpt.isEmpty()) {
             ctx.addReadOnlyRow(startRow++, "Name", ctx.getElementName());
             return startRow;
@@ -60,7 +60,7 @@ public class FlowForm implements ElementForm {
 
         equationField = ctx.createEquationField(flow.equation());
         ctx.addEquationCommitHandlers(equationField, this::commitEquation);
-        EquationAutoComplete.attach(equationField, ctx.editor, ctx.getElementName());
+        EquationAutoComplete.attach(equationField, ctx.getEditor(), ctx.getElementName());
         ctx.addFieldRow(row++, "Equation", ctx.wrapWithHelpButton(equationField),
                 "The rate equation determining how fast material flows.\n"
                 + "Use element names, operators (+, -, *, /), and functions.");
@@ -89,7 +89,7 @@ public class FlowForm implements ElementForm {
 
     @Override
     public void updateValues() {
-        Optional<FlowDef> flowOpt = ctx.editor.getFlowByName(ctx.getElementName());
+        Optional<FlowDef> flowOpt = ctx.getEditor().getFlowByName(ctx.getElementName());
         if (flowOpt.isEmpty() || nameField == null) {
             return;
         }
@@ -111,49 +111,49 @@ public class FlowForm implements ElementForm {
     private void commitComment(TextArea area) {
         String text = area.getText().trim();
         String comment = text.isEmpty() ? null : text;
-        Optional<FlowDef> flowOpt = ctx.editor.getFlowByName(ctx.getElementName());
+        Optional<FlowDef> flowOpt = ctx.getEditor().getFlowByName(ctx.getElementName());
         if (flowOpt.isEmpty() || Objects.equals(comment, flowOpt.get().comment())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setFlowComment(ctx.getElementName(), comment));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setFlowComment(ctx.getElementName(), comment));
     }
 
     private void commitEquation(EquationField field) {
         String equation = field.getText().trim();
         if (equation.isEmpty()) {
-            ctx.editor.getFlowByName(ctx.getElementName())
+            ctx.getEditor().getFlowByName(ctx.getElementName())
                     .ifPresent(flow -> field.setText(flow.equation()));
             return;
         }
-        Optional<FlowDef> flowOpt = ctx.editor.getFlowByName(ctx.getElementName());
+        Optional<FlowDef> flowOpt = ctx.getEditor().getFlowByName(ctx.getElementName());
         if (flowOpt.isPresent() && equation.equals(flowOpt.get().equation())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setFlowEquation(ctx.getElementName(), equation));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setFlowEquation(ctx.getElementName(), equation));
     }
 
     private void commitMaterialUnit(ComboBox<String> box) {
         String materialUnit = box.getValue() != null ? box.getValue().trim() : "";
         String resolved = materialUnit.isEmpty() ? null : materialUnit;
-        Optional<FlowDef> flowOpt = ctx.editor.getFlowByName(ctx.getElementName());
+        Optional<FlowDef> flowOpt = ctx.getEditor().getFlowByName(ctx.getElementName());
         if (flowOpt.isPresent() && Objects.equals(resolved, flowOpt.get().materialUnit())) {
             return;
         }
-        ctx.canvas.applyMutation(
-                () -> ctx.editor.setFlowMaterialUnit(ctx.getElementName(), resolved));
+        ctx.getCanvas().applyMutation(
+                () -> ctx.getEditor().setFlowMaterialUnit(ctx.getElementName(), resolved));
     }
 
     private void commitTimeUnit(ComboBox<String> box) {
         String timeUnit = box.getValue() != null ? box.getValue().trim() : "";
         if (timeUnit.isEmpty()) {
-            ctx.editor.getFlowByName(ctx.getElementName())
+            ctx.getEditor().getFlowByName(ctx.getElementName())
                     .ifPresent(flow -> box.setValue(flow.timeUnit()));
             return;
         }
-        Optional<FlowDef> flowOpt = ctx.editor.getFlowByName(ctx.getElementName());
+        Optional<FlowDef> flowOpt = ctx.getEditor().getFlowByName(ctx.getElementName());
         if (flowOpt.isPresent() && timeUnit.equals(flowOpt.get().timeUnit())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setFlowTimeUnit(ctx.getElementName(), timeUnit));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setFlowTimeUnit(ctx.getElementName(), timeUnit));
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormContext.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormContext.java
@@ -40,10 +40,37 @@ import systems.courant.sd.app.canvas.Styles;
  */
 public class FormContext {
 
-    public ModelCanvas canvas;
-    public ModelEditor editor;
-    public GridPane grid;
+    private ModelCanvas canvas;
+    private ModelEditor editor;
+    private GridPane grid;
     private String elementName;
+    private boolean updatingFields;
+    private Runnable onFormRebuildRequested;
+    private Runnable onOpenExpressionHelp;
+
+    public ModelCanvas getCanvas() {
+        return canvas;
+    }
+
+    public void setCanvas(ModelCanvas canvas) {
+        this.canvas = canvas;
+    }
+
+    public ModelEditor getEditor() {
+        return editor;
+    }
+
+    public void setEditor(ModelEditor editor) {
+        this.editor = editor;
+    }
+
+    public GridPane getGrid() {
+        return grid;
+    }
+
+    public void setGrid(GridPane grid) {
+        this.grid = grid;
+    }
 
     public String getElementName() {
         return elementName;
@@ -52,9 +79,32 @@ public class FormContext {
     public void setElementName(String elementName) {
         this.elementName = elementName;
     }
-    public boolean updatingFields;
-    public Runnable onFormRebuildRequested;
-    public Runnable onOpenExpressionHelp;
+
+    public boolean isUpdatingFields() {
+        return updatingFields;
+    }
+
+    /**
+     * Executes the given action with the reentrancy guard active.
+     * Sets {@code updatingFields} to {@code true} before running the action and
+     * guarantees it is reset to {@code false} afterwards, even if the action throws.
+     */
+    public void withUpdate(Runnable action) {
+        updatingFields = true;
+        try {
+            action.run();
+        } finally {
+            updatingFields = false;
+        }
+    }
+
+    public void setOnFormRebuildRequested(Runnable onFormRebuildRequested) {
+        this.onFormRebuildRequested = onFormRebuildRequested;
+    }
+
+    public void setOnOpenExpressionHelp(Runnable onOpenExpressionHelp) {
+        this.onOpenExpressionHelp = onOpenExpressionHelp;
+    }
 
     /** Cached registry for dimensional analysis — avoids rebuilding on every keystroke. */
     private final UnitRegistry unitRegistry = new UnitRegistry();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/LookupForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/LookupForm.java
@@ -56,7 +56,7 @@ public class LookupForm implements ElementForm {
 
     @Override
     public int build(int startRow) {
-        Optional<LookupTableDef> lookupOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        Optional<LookupTableDef> lookupOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
         if (lookupOpt.isEmpty()) {
             ctx.addReadOnlyRow(startRow++, "Name", ctx.getElementName());
             return startRow;
@@ -91,14 +91,14 @@ public class LookupForm implements ElementForm {
         interpBox.setValue(lookup.interpolation());
         interpBox.setMaxWidth(Double.MAX_VALUE);
         interpBox.setOnAction(e -> {
-            if (!ctx.updatingFields) {
+            if (!ctx.isUpdatingFields()) {
                 String newInterp = interpBox.getValue();
-                ctx.editor.getLookupTableByName(ctx.getElementName()).ifPresent(lt -> {
+                ctx.getEditor().getLookupTableByName(ctx.getElementName()).ifPresent(lt -> {
                     if (!Objects.equals(newInterp, lt.interpolation())) {
                         LookupTableDef updated = new LookupTableDef(
                                 ctx.getElementName(), lt.comment(),
                                 lt.xValues(), lt.yValues(), newInterp, lt.unit());
-                        ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
+                        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupTable(ctx.getElementName(), updated));
                         replaceChart(lt.xValues(), lt.yValues(), newInterp);
                     }
                 });
@@ -137,13 +137,13 @@ public class LookupForm implements ElementForm {
             Runnable commitRow = () -> commitDataPoint(xField, yField, index);
             xField.setOnAction(e -> commitRow.run());
             xField.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
-                if (!isFocused && !ctx.updatingFields) {
+                if (!isFocused && !ctx.isUpdatingFields()) {
                     commitRow.run();
                 }
             });
             yField.setOnAction(e -> commitRow.run());
             yField.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
-                if (!isFocused && !ctx.updatingFields) {
+                if (!isFocused && !ctx.isUpdatingFields()) {
                     commitRow.run();
                 }
             });
@@ -152,13 +152,13 @@ public class LookupForm implements ElementForm {
             tableGrid.add(yField, 1, i + 1);
         }
 
-        ctx.grid.add(tableGrid, 0, row, 2, 1);
+        ctx.getGrid().add(tableGrid, 0, row, 2, 1);
         row++;
 
         // Inline interactive chart
         chartRow = row;
         chart = buildChart(xs, ys, lookup.interpolation());
-        ctx.grid.add(chart, 0, row, 2, 1);
+        ctx.getGrid().add(chart, 0, row, 2, 1);
         row++;
 
         // Add/remove row buttons
@@ -172,7 +172,7 @@ public class LookupForm implements ElementForm {
         removeRowBtn.setOnAction(e -> removeRow());
 
         rowButtons.getChildren().addAll(addRowBtn, removeRowBtn);
-        ctx.grid.add(rowButtons, 0, row, 2, 1);
+        ctx.getGrid().add(rowButtons, 0, row, 2, 1);
         row++;
 
         return row;
@@ -184,9 +184,9 @@ public class LookupForm implements ElementForm {
     }
 
     private void replaceChart(double[] xs, double[] ys, String interpolation) {
-        ctx.grid.getChildren().remove(chart);
+        ctx.getGrid().getChildren().remove(chart);
         chart = buildChart(xs, ys, interpolation);
-        ctx.grid.add(chart, 0, chartRow, 2, 1);
+        ctx.getGrid().add(chart, 0, chartRow, 2, 1);
     }
 
     private static final int SPLINE_INTERPOLATION_POINTS = 100;
@@ -329,7 +329,7 @@ public class LookupForm implements ElementForm {
         deleteItem.setOnAction(e -> deletePointByIndex(pointIndex));
         deleteMenu.getItems().add(deleteItem);
         node.setOnContextMenuRequested(event -> {
-            Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+            Optional<LookupTableDef> ltOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
             if (ltOpt.isPresent() && ltOpt.get().xValues().length > MIN_POINTS) {
                 deleteMenu.show(node, event.getScreenX(), event.getScreenY());
             }
@@ -338,7 +338,7 @@ public class LookupForm implements ElementForm {
     }
 
     private double[] getNeighborBounds(int pointIndex) {
-        Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        Optional<LookupTableDef> ltOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
         if (ltOpt.isEmpty()) {
             return new double[]{Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY};
         }
@@ -398,7 +398,7 @@ public class LookupForm implements ElementForm {
     }
 
     public void addPointAtPosition(double x, double y) {
-        Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        Optional<LookupTableDef> ltOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
         if (ltOpt.isEmpty()) {
             return;
         }
@@ -425,11 +425,11 @@ public class LookupForm implements ElementForm {
 
         LookupTableDef updated = new LookupTableDef(
                 ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation(), lt.unit());
-        ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupTable(ctx.getElementName(), updated));
     }
 
     public void deletePointByIndex(int index) {
-        Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        Optional<LookupTableDef> ltOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
         if (ltOpt.isEmpty() || ltOpt.get().xValues().length <= MIN_POINTS) {
             return;
         }
@@ -447,11 +447,11 @@ public class LookupForm implements ElementForm {
         System.arraycopy(oldY, index + 1, newY, index, oldY.length - index - 1);
         LookupTableDef updated = new LookupTableDef(
                 ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation(), lt.unit());
-        ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupTable(ctx.getElementName(), updated));
     }
 
     private void commitChartDrag(int index, double newX, double newY) {
-        Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        Optional<LookupTableDef> ltOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
         if (ltOpt.isEmpty()) {
             return;
         }
@@ -476,7 +476,7 @@ public class LookupForm implements ElementForm {
         }
         LookupTableDef updated = new LookupTableDef(
                 ctx.getElementName(), lt.comment(), newXs, newYs, lt.interpolation(), lt.unit());
-        ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupTable(ctx.getElementName(), updated));
     }
 
     public static String formatPointTooltip(double x, double y) {
@@ -486,15 +486,15 @@ public class LookupForm implements ElementForm {
     private void commitComment(TextArea area) {
         String text = area.getText().trim();
         String comment = text.isEmpty() ? null : text;
-        Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        Optional<LookupTableDef> ltOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
         if (ltOpt.isEmpty() || Objects.equals(comment, ltOpt.get().comment())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setLookupComment(ctx.getElementName(), comment));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupComment(ctx.getElementName(), comment));
     }
 
     private void commitDataPoint(TextField xField, TextField yField, int index) {
-        Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        Optional<LookupTableDef> ltOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
         if (ltOpt.isEmpty()) {
             return;
         }
@@ -525,7 +525,7 @@ public class LookupForm implements ElementForm {
             }
             LookupTableDef updated = new LookupTableDef(
                     ctx.getElementName(), lt.comment(), newXs, newYs, lt.interpolation(), lt.unit());
-            ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
+            ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupTable(ctx.getElementName(), updated));
         } catch (NumberFormatException ignored) {
             xField.setText(ElementRenderer.formatValue(lt.xValues()[index]));
             yField.setText(ElementRenderer.formatValue(lt.yValues()[index]));
@@ -535,7 +535,7 @@ public class LookupForm implements ElementForm {
     }
 
     private void addRow() {
-        Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        Optional<LookupTableDef> ltOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
         if (ltOpt.isEmpty()) {
             return;
         }
@@ -553,11 +553,11 @@ public class LookupForm implements ElementForm {
         newY[oldY.length] = oldY[oldY.length - 1];
         LookupTableDef updated = new LookupTableDef(
                 ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation(), lt.unit());
-        ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupTable(ctx.getElementName(), updated));
     }
 
     private void removeRow() {
-        Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        Optional<LookupTableDef> ltOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
         if (ltOpt.isEmpty() || ltOpt.get().xValues().length <= MIN_POINTS) {
             return;
         }
@@ -570,16 +570,16 @@ public class LookupForm implements ElementForm {
         System.arraycopy(oldY, 0, newY, 0, newY.length);
         LookupTableDef updated = new LookupTableDef(
                 ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation(), lt.unit());
-        ctx.canvas.applyMutation(() -> ctx.editor.setLookupTable(ctx.getElementName(), updated));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupTable(ctx.getElementName(), updated));
     }
 
     private void commitUnit(ComboBox<String> box) {
         String unit = box.getValue() != null ? box.getValue().trim() : "";
         String normalizedUnit = unit.isEmpty() ? null : unit;
-        Optional<LookupTableDef> ltOpt = ctx.editor.getLookupTableByName(ctx.getElementName());
+        Optional<LookupTableDef> ltOpt = ctx.getEditor().getLookupTableByName(ctx.getElementName());
         if (ltOpt.isPresent() && Objects.equals(normalizedUnit, ltOpt.get().unit())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setLookupUnit(ctx.getElementName(), normalizedUnit));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupUnit(ctx.getElementName(), normalizedUnit));
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/StockForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/StockForm.java
@@ -32,7 +32,7 @@ public class StockForm implements ElementForm {
 
     @Override
     public int build(int startRow) {
-        Optional<StockDef> stockOpt = ctx.editor.getStockByName(ctx.getElementName());
+        Optional<StockDef> stockOpt = ctx.getEditor().getStockByName(ctx.getElementName());
         if (stockOpt.isEmpty()) {
             ctx.addReadOnlyRow(startRow++, "Name", ctx.getElementName());
             return startRow;
@@ -70,7 +70,7 @@ public class StockForm implements ElementForm {
         policyBox.setValue(policyDisplayValue(stock.negativeValuePolicy()));
         policyBox.setMaxWidth(Double.MAX_VALUE);
         policyBox.setOnAction(e -> {
-            if (!ctx.updatingFields) {
+            if (!ctx.isUpdatingFields()) {
                 commitPolicy();
             }
         });
@@ -85,7 +85,7 @@ public class StockForm implements ElementForm {
 
     @Override
     public void updateValues() {
-        Optional<StockDef> stockOpt = ctx.editor.getStockByName(ctx.getElementName());
+        Optional<StockDef> stockOpt = ctx.getEditor().getStockByName(ctx.getElementName());
         if (stockOpt.isEmpty() || nameField == null) {
             return;
         }
@@ -101,13 +101,13 @@ public class StockForm implements ElementForm {
     private void commitInitialValue(TextField field) {
         try {
             double value = Double.parseDouble(field.getText().trim());
-            Optional<StockDef> stockOpt = ctx.editor.getStockByName(ctx.getElementName());
+            Optional<StockDef> stockOpt = ctx.getEditor().getStockByName(ctx.getElementName());
             if (stockOpt.isEmpty() || stockOpt.get().initialValue() == value) {
                 return;
             }
-            ctx.canvas.applyMutation(() -> ctx.editor.setStockInitialValue(ctx.getElementName(), value));
+            ctx.getCanvas().applyMutation(() -> ctx.getEditor().setStockInitialValue(ctx.getElementName(), value));
         } catch (NumberFormatException ignored) {
-            ctx.editor.getStockByName(ctx.getElementName())
+            ctx.getEditor().getStockByName(ctx.getElementName())
                     .ifPresent(stock -> field.setText(ElementRenderer.formatValue(stock.initialValue())));
             ctx.flashInvalidInput(field);
         }
@@ -115,32 +115,32 @@ public class StockForm implements ElementForm {
 
     private void commitUnit(ComboBox<String> box) {
         String unit = box.getValue() != null ? box.getValue().trim() : "";
-        Optional<StockDef> stockOpt = ctx.editor.getStockByName(ctx.getElementName());
+        Optional<StockDef> stockOpt = ctx.getEditor().getStockByName(ctx.getElementName());
         if (stockOpt.isPresent() && unit.equals(stockOpt.get().unit())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setStockUnit(ctx.getElementName(), unit));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setStockUnit(ctx.getElementName(), unit));
     }
 
     private void commitPolicy() {
         String policyValue = "Allow".equals(policyBox.getValue())
                 ? "ALLOW" : "CLAMP_TO_ZERO";
-        Optional<StockDef> stockOpt = ctx.editor.getStockByName(ctx.getElementName());
+        Optional<StockDef> stockOpt = ctx.getEditor().getStockByName(ctx.getElementName());
         String currentPolicy = stockOpt.map(StockDef::negativeValuePolicy).orElse("CLAMP_TO_ZERO");
         if (stockOpt.isPresent() && Objects.equals(policyValue, currentPolicy)) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setStockNegativeValuePolicy(ctx.getElementName(), policyValue));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setStockNegativeValuePolicy(ctx.getElementName(), policyValue));
     }
 
     private void commitComment(TextArea area) {
         String text = area.getText().trim();
         String comment = text.isEmpty() ? null : text;
-        Optional<StockDef> stockOpt = ctx.editor.getStockByName(ctx.getElementName());
+        Optional<StockDef> stockOpt = ctx.getEditor().getStockByName(ctx.getElementName());
         if (stockOpt.isEmpty() || Objects.equals(comment, stockOpt.get().comment())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setStockComment(ctx.getElementName(), comment));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setStockComment(ctx.getElementName(), comment));
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/VariableForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/VariableForm.java
@@ -32,7 +32,7 @@ public class VariableForm implements ElementForm {
 
     @Override
     public int build(int startRow) {
-        Optional<VariableDef> varOpt = ctx.editor.getVariableByName(ctx.getElementName());
+        Optional<VariableDef> varOpt = ctx.getEditor().getVariableByName(ctx.getElementName());
         if (varOpt.isEmpty()) {
             ctx.addReadOnlyRow(startRow++, "Name", ctx.getElementName());
             return startRow;
@@ -56,7 +56,7 @@ public class VariableForm implements ElementForm {
 
         equationField = ctx.createEquationField(v.equation());
         ctx.addEquationCommitHandlers(equationField, this::commitEquation);
-        EquationAutoComplete.attach(equationField, ctx.editor, ctx.getElementName());
+        EquationAutoComplete.attach(equationField, ctx.getEditor(), ctx.getElementName());
         ctx.addFieldRow(row++, "Equation", ctx.wrapWithHelpButton(equationField),
                 "A formula computed each time step from other model elements");
         ctx.attachEquationValidation(equationField, row++);
@@ -71,7 +71,7 @@ public class VariableForm implements ElementForm {
 
     @Override
     public void updateValues() {
-        Optional<VariableDef> varOpt = ctx.editor.getVariableByName(ctx.getElementName());
+        Optional<VariableDef> varOpt = ctx.getEditor().getVariableByName(ctx.getElementName());
         if (varOpt.isEmpty() || nameField == null) {
             return;
         }
@@ -90,33 +90,33 @@ public class VariableForm implements ElementForm {
     private void commitComment(TextArea area) {
         String text = area.getText().trim();
         String comment = text.isEmpty() ? null : text;
-        Optional<VariableDef> varOpt = ctx.editor.getVariableByName(ctx.getElementName());
+        Optional<VariableDef> varOpt = ctx.getEditor().getVariableByName(ctx.getElementName());
         if (varOpt.isEmpty() || Objects.equals(comment, varOpt.get().comment())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setVariableComment(ctx.getElementName(), comment));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setVariableComment(ctx.getElementName(), comment));
     }
 
     private void commitEquation(EquationField field) {
         String equation = field.getText().trim();
         if (equation.isEmpty()) {
-            ctx.editor.getVariableByName(ctx.getElementName())
+            ctx.getEditor().getVariableByName(ctx.getElementName())
                     .ifPresent(v -> field.setText(v.equation()));
             return;
         }
-        Optional<VariableDef> varOpt = ctx.editor.getVariableByName(ctx.getElementName());
+        Optional<VariableDef> varOpt = ctx.getEditor().getVariableByName(ctx.getElementName());
         if (varOpt.isPresent() && equation.equals(varOpt.get().equation())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setVariableEquation(ctx.getElementName(), equation));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setVariableEquation(ctx.getElementName(), equation));
     }
 
     private void commitUnit(ComboBox<String> box) {
         String unit = box.getValue() != null ? box.getValue().trim() : "";
-        Optional<VariableDef> varOpt = ctx.editor.getVariableByName(ctx.getElementName());
+        Optional<VariableDef> varOpt = ctx.getEditor().getVariableByName(ctx.getElementName());
         if (varOpt.isPresent() && unit.equals(varOpt.get().unit())) {
             return;
         }
-        ctx.canvas.applyMutation(() -> ctx.editor.setVariableUnit(ctx.getElementName(), unit));
+        ctx.getCanvas().applyMutation(() -> ctx.getEditor().setVariableUnit(ctx.getElementName(), unit));
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/forms/LookupFormTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/forms/LookupFormTest.java
@@ -44,11 +44,10 @@ class LookupFormTest {
         };
 
         FormContext ctx = new FormContext();
-        ctx.editor = editor;
-        ctx.canvas = canvas;
-        ctx.grid = new GridPane();
+        ctx.setEditor(editor);
+        ctx.setCanvas(canvas);
+        ctx.setGrid(new GridPane());
         ctx.setElementName("Lookup 1");
-        ctx.updatingFields = false;
 
         form = new LookupForm(ctx);
 


### PR DESCRIPTION
## Summary
- Makes all public mutable fields in FormContext private, adds getters/setters
- Adds `withUpdate(Runnable)` method to guarantee the reentrancy guard (`updatingFields`) is always properly reset
- Updates all callers across form classes and PropertiesPanel

## Test plan
- [x] All existing tests pass (full reactor)
- [x] SpotBugs clean

Closes #792