### PR TITLE
Make CanvasState.drawOrderCache volatile for thread safety

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
@@ -38,7 +38,7 @@ public class CanvasState {
     private final Map<String, ElementType> types = new LinkedHashMap<>();
     private final Set<String> selection = new LinkedHashSet<>();
     private final SequencedSet<String> drawOrder = new LinkedHashSet<>();
-    private List<String> drawOrderCache;
+    private volatile List<String> drawOrderCache;
     private String viewName = DEFAULT_VIEW_NAME;
 
     /**


### PR DESCRIPTION
## Summary
- Added `volatile` to `drawOrderCache` field in CanvasState to prevent partially-constructed list references being visible to non-FX threads
- Existing lazy-init pattern with local read is correct for volatile single-check

## Test plan
- [x] Full reactor build and test pass
- [x] SpotBugs clean

Closes #790