### PR TITLE
Stop replacing deleted element refs with 0 in equations

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationReferenceManager.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationReferenceManager.java
@@ -34,6 +34,25 @@ public final class EquationReferenceManager {
     }
 
     /**
+     * Returns the names of all elements whose equations reference the given token.
+     * Does not modify any equations.
+     */
+    public List<String> findReferencingElements(String token) {
+        List<String> result = new ArrayList<>();
+        for (FlowDef f : flows) {
+            if (f.equation() != null && containsWholeToken(f.equation(), token)) {
+                result.add(f.name());
+            }
+        }
+        for (VariableDef a : variables) {
+            if (a.equation() != null && containsWholeToken(a.equation(), token)) {
+                result.add(a.name());
+            }
+        }
+        return result;
+    }
+
+    /**
      * Replaces all occurrences of {@code oldToken} with {@code newToken} in every
      * flow and variable equation, respecting word boundaries.
      *

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
@@ -430,11 +430,13 @@ public class ModelEditor {
         // Remove causal links referencing the deleted element
         causalLinks.removeIf(link -> link.from().equals(name) || link.to().equals(name));
 
-        // Clean equation references: replace deleted element's token with "0"
+        // Fire equationChanged for any equations that still reference the deleted element.
+        // The dangling reference will be flagged by validation rather than silently replaced
+        // with "0", which is dangerous in multiplicative/divisive contexts.
         String deletedToken = name.replace(' ', '_');
-        List<String> modifiedElements = equationRefManager.updateEquationReferences(deletedToken, "0");
-        for (String modified : modifiedElements) {
-            fireEquationChanged(modified);
+        List<String> affectedElements = equationRefManager.findReferencingElements(deletedToken);
+        for (String affected : affectedElements) {
+            fireEquationChanged(affected);
         }
 
         fireElementRemoved(name);

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/EquationReferenceManagerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/EquationReferenceManagerTest.java
@@ -261,6 +261,41 @@ class EquationReferenceManagerTest {
     }
 
     @Nested
+    @DisplayName("findReferencingElements")
+    class FindReferencingElements {
+
+        @Test
+        void shouldFindFlowsReferencingToken() {
+            flows.add(new FlowDef("Drain", "Rate * Pop", "Day", null, null));
+            flows.add(new FlowDef("Other", "100", "Day", null, null));
+            List<String> result = manager.findReferencingElements("Rate");
+            assertThat(result).containsExactly("Drain");
+        }
+
+        @Test
+        void shouldFindVariablesReferencingToken() {
+            variables.add(new VariableDef("Ratio", "Pop / Total", "units"));
+            variables.add(new VariableDef("Const", "42", "units"));
+            List<String> result = manager.findReferencingElements("Total");
+            assertThat(result).containsExactly("Ratio");
+        }
+
+        @Test
+        void shouldReturnEmptyWhenNoReferences() {
+            flows.add(new FlowDef("Drain", "Pop * 5", "Day", null, null));
+            List<String> result = manager.findReferencingElements("Rate");
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldNotMatchSubstrings() {
+            flows.add(new FlowDef("Drain", "Birth_Rate * Pop", "Day", null, null));
+            List<String> result = manager.findReferencingElements("Rate");
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
     @DisplayName("containsWholeToken (static)")
     class ContainsWholeToken {
 

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelEditorTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelEditorTest.java
@@ -306,7 +306,7 @@ class ModelEditorTest {
         }
 
         @Test
-        void shouldCleanEquationReferencesWhenConstantDeleted() {
+        void shouldPreserveEquationReferencesWhenConstantDeleted() {
             ModelDefinition def = new ModelDefinitionBuilder()
                     .name("Test")
                     .stock("S", 100, "u")
@@ -318,11 +318,12 @@ class ModelEditorTest {
             editor.removeElement("Rate");
 
             FlowDef flow = editor.getFlows().get(0);
-            assertThat(flow.equation()).isEqualTo("S * 0");
+            // Equation retains dangling reference so validation can flag it
+            assertThat(flow.equation()).isEqualTo("S * Rate");
         }
 
         @Test
-        void shouldCleanEquationReferencesWhenStockDeleted() {
+        void shouldPreserveEquationReferencesWhenStockDeleted() {
             ModelDefinition def = new ModelDefinitionBuilder()
                     .name("Test")
                     .stock("Population", 1000, "people")
@@ -334,11 +335,11 @@ class ModelEditorTest {
             editor.removeElement("Population");
 
             FlowDef flow = editor.getFlows().get(0);
-            assertThat(flow.equation()).isEqualTo("0 * k");
+            assertThat(flow.equation()).isEqualTo("Population * k");
         }
 
         @Test
-        void shouldCleanAuxEquationWhenReferencedElementDeleted() {
+        void shouldPreserveAuxEquationWhenReferencedElementDeleted() {
             ModelDefinition def = new ModelDefinitionBuilder()
                     .name("Test")
                     .stock("S", 100, "u")
@@ -350,11 +351,11 @@ class ModelEditorTest {
             editor.removeElement("k");
 
             VariableDef v = editor.getVariables().get(0);
-            assertThat(v.equation()).isEqualTo("S * 0");
+            assertThat(v.equation()).isEqualTo("S * k");
         }
 
         @Test
-        void shouldCleanFlowEquationWhenReferencedAuxDeleted() {
+        void shouldPreserveFlowEquationWhenReferencedAuxDeleted() {
             ModelDefinition def = new ModelDefinitionBuilder()
                     .name("Test")
                     .stock("S", 100, "u")
@@ -366,11 +367,11 @@ class ModelEditorTest {
             editor.removeElement("Calc");
 
             FlowDef flow = editor.getFlows().get(0);
-            assertThat(flow.equation()).isEqualTo("0 + 1");
+            assertThat(flow.equation()).isEqualTo("Calc + 1");
         }
 
         @Test
-        void shouldFireEquationChangedForModifiedEquations() {
+        void shouldFireEquationChangedForAffectedEquations() {
             ModelDefinition def = new ModelDefinitionBuilder()
                     .name("Test")
                     .stock("S", 100, "u")


### PR DESCRIPTION
## Summary
- Removes the dangerous behavior of replacing deleted element tokens with `"0"` in equations, which silently zeroed products (`A * B` → `A * 0`) and introduced division-by-zero (`A / B` → `A / 0`)
- Dangling references are now preserved so the equation validator flags them as unresolved, forcing explicit user action
- Adds `findReferencingElements` to `EquationReferenceManager` for non-mutating reference lookup

## Test plan
- [x] Updated ModelEditorTest to verify equations are preserved with dangling references
- [x] Added tests for `findReferencingElements`
- [x] All tests pass, SpotBugs clean

Closes #789