### PR TITLE
Add depth limit to XmileExporter writeModuleModels recursion

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
@@ -49,6 +49,8 @@ import java.util.StringJoiner;
  */
 public final class XmileExporter {
 
+    private static final int MAX_MODULE_DEPTH = 50;
+
     private XmileExporter() {
     }
 
@@ -102,7 +104,7 @@ public final class XmileExporter {
 
         // Write named <model> elements for module definitions (before the main model)
         Set<String> writtenModels = new LinkedHashSet<>();
-        writeModuleModels(doc, root, def, writtenModels);
+        writeModuleModels(doc, root, def, writtenModels, 0);
 
         // Main <model>
         Element modelElem = doc.createElementNS(
@@ -200,7 +202,12 @@ public final class XmileExporter {
      */
     private static void writeModuleModels(Document doc, Element root,
                                            ModelDefinition def,
-                                           Set<String> writtenModels) {
+                                           Set<String> writtenModels,
+                                           int depth) {
+        if (depth > MAX_MODULE_DEPTH) {
+            throw new IllegalStateException(
+                    "Module nesting depth exceeds maximum of " + MAX_MODULE_DEPTH);
+        }
         for (ModuleInstanceDef mod : def.modules()) {
             String modelName = mod.definition().name();
             if (writtenModels.contains(modelName)) {
@@ -209,7 +216,7 @@ public final class XmileExporter {
             writtenModels.add(modelName);
 
             // Recurse first so nested module definitions appear before their parents
-            writeModuleModels(doc, root, mod.definition(), writtenModels);
+            writeModuleModels(doc, root, mod.definition(), writtenModels, depth + 1);
 
             Element modelElem = doc.createElementNS(
                     XmileConstants.NAMESPACE_URI, XmileConstants.MODEL);

--- a/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileExporterTest.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("XmileExporter")
 class XmileExporterTest {
@@ -315,6 +316,28 @@ class XmileExporterTest {
             assertThat(xml).contains("name=\"InnerModule\"");
             assertThat(xml).contains("<module");
             assertThat(xml).contains("<connect");
+        }
+
+        @Test
+        void shouldThrowWhenModuleNestingExceedsDepthLimit() {
+            // Build a chain of 52 nested modules (exceeds limit of 50)
+            ModelDefinition current = new ModelDefinitionBuilder()
+                    .name("Leaf")
+                    .constant("x", 1, null)
+                    .build();
+            for (int i = 51; i >= 0; i--) {
+                current = new ModelDefinitionBuilder()
+                        .name("Level_" + i)
+                        .defaultSimulation("Day", 10, "Day")
+                        .module(new ModuleInstanceDef("mod_" + (i + 1), current,
+                                Map.of(), Map.of()))
+                        .build();
+            }
+
+            ModelDefinition root = current;
+            assertThatThrownBy(() -> XmileExporter.toXmile(root))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Module nesting depth exceeds maximum of 50");
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Adds `MAX_MODULE_DEPTH = 50` guard to `XmileExporter.writeModuleModels()` to prevent `StackOverflowError` on deeply nested module structures
- Consistent with the existing depth limit in `ModelDefinitionSerializer`
- Adds test verifying the depth limit is enforced

Closes #788