### PR TITLE
Add depth limit to ModelDefinitionSerializer.toJsonNode

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -80,7 +80,7 @@ public class ModelDefinitionSerializer {
      */
     public String toJson(ModelDefinition def) {
         try {
-            ObjectNode root = toJsonNode(def);
+            ObjectNode root = toJsonNode(def, 0);
             return mapper.writeValueAsString(root);
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("Failed to serialize model definition", e);
@@ -137,7 +137,11 @@ public class ModelDefinitionSerializer {
 
     // === Serialization ===
 
-    private ObjectNode toJsonNode(ModelDefinition def) {
+    private ObjectNode toJsonNode(ModelDefinition def, int depth) {
+        if (depth > MAX_MODULE_DEPTH) {
+            throw new IllegalArgumentException(
+                    "Module nesting depth exceeds maximum of " + MAX_MODULE_DEPTH);
+        }
         ObjectNode root = mapper.createObjectNode();
         root.put("name", def.name());
         if (def.comment() != null) {
@@ -160,7 +164,7 @@ public class ModelDefinitionSerializer {
             root.set("lookupTables", serializeLookupTables(def.lookupTables()));
         }
         if (!def.modules().isEmpty()) {
-            root.set("modules", serializeModules(def.modules()));
+            root.set("modules", serializeModules(def.modules(), depth));
         }
         if (!def.subscripts().isEmpty()) {
             root.set("subscripts", serializeSubscripts(def.subscripts()));
@@ -284,12 +288,12 @@ public class ModelDefinitionSerializer {
         return arr;
     }
 
-    private ArrayNode serializeModules(List<ModuleInstanceDef> modules) {
+    private ArrayNode serializeModules(List<ModuleInstanceDef> modules, int depth) {
         ArrayNode arr = mapper.createArrayNode();
         for (ModuleInstanceDef m : modules) {
             ObjectNode node = mapper.createObjectNode();
             node.put("instanceName", m.instanceName());
-            node.set("definition", toJsonNode(m.definition()));
+            node.set("definition", toJsonNode(m.definition(), depth + 1));
             if (!m.inputBindings().isEmpty()) {
                 node.set("inputBindings", mapToJson(m.inputBindings()));
             }

--- a/courant-engine/src/test/java/systems/courant/sd/io/json/ModelDefinitionSerializerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/json/ModelDefinitionSerializerTest.java
@@ -480,6 +480,27 @@ class ModelDefinitionSerializerTest {
             ModelDefinition roundTripped = serializer.fromJson(json);
             assertThat(roundTripped.stocks()).hasSize(3);
         }
+
+        @Test
+        @DisplayName("should reject serialization of deeply nested modules beyond depth limit")
+        void shouldRejectDeeplyNestedModuleSerialization() {
+            // Build a model with 55 levels of nested modules (exceeds limit of 50)
+            ModelDefinition leaf = new ModelDefinitionBuilder()
+                    .name("leaf")
+                    .variable("x", "1", null)
+                    .build();
+            ModelDefinition current = leaf;
+            for (int i = 0; i < 55; i++) {
+                current = new ModelDefinitionBuilder()
+                        .name("level" + i)
+                        .module("child", current, Map.of(), Map.of())
+                        .build();
+            }
+            ModelDefinition deepModel = current;
+            assertThatThrownBy(() -> serializer.toJson(deepModel))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("nesting depth");
+        }
     }
 
     private ModelDefinition buildSIR() {


### PR DESCRIPTION
## Summary
- Added depth counter to `toJsonNode()` that mirrors the `MAX_MODULE_DEPTH=50` limit already used in deserialization
- Prevents `StackOverflowError` when serializing pathologically nested module hierarchies

## Test plan
- [x] New test: serialization of 55-level deep nesting throws IllegalArgumentException
- [x] Existing round-trip tests pass
- [x] SpotBugs clean

Closes #787