### PR TITLE
Handle quoted variable names in VensimExporter denormalizeNamesInExpr

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -666,11 +666,24 @@ public final class VensimExporter {
         // Replace underscores in identifiers with spaces.
         // An identifier is a sequence of word characters that contains at least one underscore
         // and is not purely numeric.
+        // Quoted references ("name") are treated as atomic units and denormalized whole.
         StringBuilder result = new StringBuilder();
         int i = 0;
         while (i < expr.length()) {
             char c = expr.charAt(i);
-            if (Character.isLetter(c) || c == '_') {
+            if (c == '"') {
+                // Quoted name — read until closing quote and denormalize as a single unit
+                int closeQuote = expr.indexOf('"', i + 1);
+                if (closeQuote < 0) {
+                    // No closing quote — append remainder verbatim
+                    result.append(expr, i, expr.length());
+                    break;
+                }
+                String quotedName = expr.substring(i + 1, closeQuote);
+                String denormed = denormalizeName(quotedName);
+                result.append('"').append(denormed).append('"');
+                i = closeQuote + 1;
+            } else if (Character.isLetter(c) || c == '_') {
                 // Read the full identifier token
                 int start = i;
                 while (i < expr.length() && (Character.isLetterOrDigit(expr.charAt(i))

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
@@ -278,6 +278,24 @@ class VensimExporterTest {
             assertThat(VensimExporter.toVensimExpr("_2nd_Batch * 2"))
                     .isEqualTo("2nd Batch * 2");
         }
+
+        @Test
+        void shouldDenormalizeQuotedVariableNamesAsAtomicUnit() {
+            assertThat(VensimExporter.toVensimExpr("\"my_var\" + 5"))
+                    .isEqualTo("\"my var\" + 5");
+        }
+
+        @Test
+        void shouldDenormalizeQuotedDigitPrefixedName() {
+            assertThat(VensimExporter.toVensimExpr("\"_2nd_Batch\" * x"))
+                    .isEqualTo("\"2nd Batch\" * x");
+        }
+
+        @Test
+        void shouldHandleUnclosedQuoteGracefully() {
+            assertThat(VensimExporter.toVensimExpr("\"unclosed + x"))
+                    .isEqualTo("\"unclosed + x");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Treats quoted references (`"my_var"`) as atomic units in `denormalizeNamesInExpr()`
- The entire quoted name is denormalized as a single token rather than being split at non-letter characters
- Handles unclosed quotes gracefully by appending remainder verbatim

Closes #786