### PR TITLE
Reset ExprCompiler warned flags between simulation re-runs

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -56,6 +56,15 @@ public class ExprCompiler {
     }
 
     /**
+     * Creates a warned flag array and registers a resettable that clears it between runs.
+     */
+    private boolean[] newWarnedFlag() {
+        boolean[] warned = {false};
+        resettables.add(() -> warned[0] = false);
+        return warned;
+    }
+
+    /**
      * Compiles an expression string into a Formula.
      *
      * @param equation the expression string to parse and compile
@@ -104,7 +113,7 @@ public class ExprCompiler {
             case SUB -> () -> left.getAsDouble() - right.getAsDouble();
             case MUL -> () -> left.getAsDouble() * right.getAsDouble();
             case DIV -> {
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double divisor = right.getAsDouble();
                     if (divisor == 0) {
@@ -118,7 +127,7 @@ public class ExprCompiler {
                 };
             }
             case MOD -> {
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double divisor = right.getAsDouble();
                     if (divisor == 0) {
@@ -132,7 +141,7 @@ public class ExprCompiler {
                 };
             }
             case POW -> {
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double result = Math.pow(left.getAsDouble(), right.getAsDouble());
                     if (Double.isNaN(result) || Double.isInfinite(result)) {
@@ -265,7 +274,7 @@ public class ExprCompiler {
             case "SQRT" -> {
                 requireArgs(name, args, 1);
                 DoubleSupplier a = compileExpr(args.get(0));
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double v = a.getAsDouble();
                     if (v < 0) {
@@ -281,7 +290,7 @@ public class ExprCompiler {
             case "LN" -> {
                 requireArgs(name, args, 1);
                 DoubleSupplier a = compileExpr(args.get(0));
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double v = a.getAsDouble();
                     if (v <= 0) {
@@ -297,7 +306,7 @@ public class ExprCompiler {
             case "EXP" -> {
                 requireArgs(name, args, 1);
                 DoubleSupplier a = compileExpr(args.get(0));
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double result = Math.exp(a.getAsDouble());
                     if (Double.isInfinite(result)) {
@@ -314,7 +323,7 @@ public class ExprCompiler {
                 if (args.size() == 2) {
                     DoubleSupplier a = compileExpr(args.get(0));
                     DoubleSupplier base = compileExpr(args.get(1));
-                    boolean[] warned = {false};
+                    boolean[] warned = newWarnedFlag();
                     yield () -> {
                         double v = a.getAsDouble();
                         double b = base.getAsDouble();
@@ -330,7 +339,7 @@ public class ExprCompiler {
                 }
                 requireArgs(name, args, 1);
                 DoubleSupplier a = compileExpr(args.get(0));
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double v = a.getAsDouble();
                     if (v <= 0) {
@@ -361,7 +370,7 @@ public class ExprCompiler {
             case "ARCSIN" -> {
                 requireArgs(name, args, 1);
                 DoubleSupplier a = compileExpr(args.get(0));
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double v = a.getAsDouble();
                     if (v < -1 || v > 1) {
@@ -377,7 +386,7 @@ public class ExprCompiler {
             case "ARCCOS" -> {
                 requireArgs(name, args, 1);
                 DoubleSupplier a = compileExpr(args.get(0));
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double v = a.getAsDouble();
                     if (v < -1 || v > 1) {
@@ -421,7 +430,7 @@ public class ExprCompiler {
                 requireArgs(name, args, 2);
                 DoubleSupplier a = compileExpr(args.get(0));
                 DoubleSupplier b = compileExpr(args.get(1));
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double divisor = b.getAsDouble();
                     if (divisor == 0) {
@@ -438,7 +447,7 @@ public class ExprCompiler {
                 requireArgs(name, args, 2);
                 DoubleSupplier a = compileExpr(args.get(0));
                 DoubleSupplier b = compileExpr(args.get(1));
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double quantum = b.getAsDouble();
                     if (quantum == 0) {
@@ -455,7 +464,7 @@ public class ExprCompiler {
                 requireArgs(name, args, 2);
                 DoubleSupplier a = compileExpr(args.get(0));
                 DoubleSupplier b = compileExpr(args.get(1));
-                boolean[] warned = {false};
+                boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double result = Math.pow(a.getAsDouble(), b.getAsDouble());
                     if (Double.isNaN(result) || Double.isInfinite(result)) {

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
@@ -1369,4 +1369,30 @@ class ExprCompilerTest {
             assertThat(((Expr.Conditional) ifShortExpr).shortCircuit()).isTrue();
         }
     }
+
+    @Nested
+    @DisplayName("Warned flag reset")
+    class WarnedFlagReset {
+
+        @Test
+        @DisplayName("should register resettables for warned flags in division by zero")
+        void shouldResetWarnedFlagsOnReset() {
+            context.addLiteralConstant("zero", 0);
+            Formula formula = compiler.compile("Population / zero");
+
+            // First evaluation triggers warning and returns NaN
+            assertThat(formula.getCurrentValue()).isNaN();
+
+            // Resettables should have been registered
+            assertThat(resettables).isNotEmpty();
+
+            // Reset all resettables (simulating model reset between runs)
+            resettables.forEach(Resettable::reset);
+
+            // After reset, the warned flag should be cleared so warning can fire again
+            // The formula should still return NaN (the behavior is the same,
+            // but the warning log would fire again on a real run)
+            assertThat(formula.getCurrentValue()).isNaN();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- All 13 `boolean[] warned` flag arrays in ExprCompiler are now registered as `Resettable` via a `newWarnedFlag()` helper
- Flags get cleared on model reset, allowing warnings to fire again on subsequent simulation runs

## Test plan
- [x] New test verifying resettables are registered for warned flags
- [x] All 144 ExprCompiler tests pass
- [x] SpotBugs clean

Closes #770