### PR TITLE
Remove System.exit calls from BatchImportCli.main

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
@@ -40,21 +40,18 @@ public class BatchImportCli {
     private static final long MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
 
     public static void main(String[] args) {
+        System.exit(new BatchImportCli().run(args));
+    }
+
+    int run(String[] args) {
+        CliArgs parsed;
         try {
-            int exitCode = new BatchImportCli().run(args);
-            System.exit(exitCode);
+            parsed = parseArgs(args);
         } catch (IllegalArgumentException e) {
             System.err.println(e.getMessage());
             printUsage();
-            System.exit(1);
-        } catch (Exception e) {
-            System.err.println("Error: " + e.getMessage());
-            System.exit(1);
+            return 1;
         }
-    }
-
-    int run(String[] args) throws IOException {
-        CliArgs parsed = parseArgs(args);
 
         if (parsed.helpRequested) {
             printUsage();
@@ -66,7 +63,13 @@ public class BatchImportCli {
             return 1;
         }
 
-        List<ManifestEntry> entries = readManifest(Path.of(parsed.manifestFile));
+        List<ManifestEntry> entries;
+        try {
+            entries = readManifest(Path.of(parsed.manifestFile));
+        } catch (IOException e) {
+            System.err.println("Error reading manifest: " + e.getMessage());
+            return 1;
+        }
         log.info("Loaded {} manifest entries", entries.size());
 
         ImportPipeline pipeline = new ImportPipeline();

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/BatchImportCliTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/BatchImportCliTest.java
@@ -157,10 +157,24 @@ class BatchImportCliTest {
         }
 
         @Test
-        void shouldReturnZeroForHelpViaRun() throws IOException {
+        void shouldReturnZeroForHelpViaRun() {
             BatchImportCli cli = new BatchImportCli();
             int exitCode = cli.run(new String[]{"--help"});
             assertThat(exitCode).isZero();
+        }
+
+        @Test
+        void shouldReturnOneForUnknownOptionViaRun() {
+            BatchImportCli cli = new BatchImportCli();
+            int exitCode = cli.run(new String[]{"--bogus"});
+            assertThat(exitCode).isEqualTo(1);
+        }
+
+        @Test
+        void shouldReturnOneForMissingManifest() {
+            BatchImportCli cli = new BatchImportCli();
+            int exitCode = cli.run(new String[]{"--manifest", "nonexistent.json"});
+            assertThat(exitCode).isEqualTo(1);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Moves exception handling from `main()` into `run()` so it always returns an exit code
- `main()` becomes `System.exit(new BatchImportCli().run(args))` - a one-liner
- Tests and embedders can call `run()` directly without JVM termination

## Test plan
- [x] Added tests for unknown option and missing manifest via `run()`
- [x] All 129 courant-tools tests pass
- [x] SpotBugs clean

Closes #767