### PR TITLE
Defer single-equals replacement until after bracket translation

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
@@ -224,10 +224,6 @@ public final class VensimExprTranslator {
         // 4a. Not-equal operator: <> → !=
         expr = NOT_EQUAL_PATTERN.matcher(expr).replaceAll("!=");
 
-        // 4b. Single = (equality) → == (Vensim uses = for both assignment and comparison;
-        // by this point we're processing the RHS, so any remaining = is equality)
-        expr = expr.replaceAll("(?<![<>=!])=(?!=)", "==");
-
         // 5. XIDZ and ZIDZ
         expr = translateXidz(expr, warnings);
         expr = translateZidz(expr, warnings);
@@ -293,6 +289,10 @@ public final class VensimExprTranslator {
 
         // 11. Translate subscript bracket notation: name[label] → name_label
         expr = translateSubscriptBrackets(expr);
+
+        // 11a. Single = (equality) → == (deferred until after bracket translation so
+        // that any = inside subscript brackets is not incorrectly doubled)
+        expr = expr.replaceAll("(?<![<>=!])=(?!=)", "==");
 
         // 12. Rewrite lookupName(arg) → LOOKUP(lookupName, arg)
         expr = rewriteLookupCalls(expr, lookupNames);

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExprTranslatorTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExprTranslatorTest.java
@@ -788,6 +788,17 @@ class VensimExprTranslatorTest {
             assertThat(result.expression()).contains("scenario == 0");
             assertThat(result.expression()).contains("scenario == 1");
         }
+
+        @Test
+        void shouldNotCorruptEqualityAfterSubscriptBracketTranslation() {
+            // Equality replacement must happen after subscript brackets are removed,
+            // so any = inside brackets won't be doubled
+            var result = VensimExprTranslator.translate(
+                    "IF THEN ELSE(x[Region] = 0, 1, 0)", "var", EMPTY_NAMES);
+            assertThat(result.expression()).contains("== 0");
+            // Should not contain === (tripled equals from double replacement)
+            assertThat(result.expression()).doesNotContain("===");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Moved `=` to `==` conversion from step 4b to after step 11 (subscript bracket translation)
- Prevents any `=` inside subscript brackets from being incorrectly doubled

## Test plan
- [x] New test for equality after subscript bracket context
- [x] All 139 VensimExprTranslator tests pass
- [x] SpotBugs clean

Closes #769