### PR TITLE
Canvas visual polish: auto-sizing, amber polarity, bolder badges (#751)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
@@ -61,6 +61,12 @@ public class CanvasState {
             } else if (ep.type() == ElementType.CLD_VARIABLE) {
                 double w = LayoutMetrics.cldVarWidthForName(ep.name());
                 sizes.put(ep.name(), new Size(w, LayoutMetrics.CLD_VAR_HEIGHT));
+            } else if (ep.type() == ElementType.AUX) {
+                double w = LayoutMetrics.auxWidthForName(ep.name());
+                sizes.put(ep.name(), new Size(w, LayoutMetrics.AUX_HEIGHT));
+            } else if (ep.type() == ElementType.LOOKUP) {
+                double w = LayoutMetrics.lookupWidthForName(ep.name());
+                sizes.put(ep.name(), new Size(w, LayoutMetrics.LOOKUP_HEIGHT));
             }
             drawOrder.add(ep.name());
         }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ColorPalette.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ColorPalette.java
@@ -23,14 +23,14 @@ public final class ColorPalette {
     public static final Color BACKGROUND = Color.web("#F8F9FA");
     public static final Color TEXT = Color.web("#2C3E50");
     public static final Color TEXT_SECONDARY = Color.web("#7F8C8D");
-    public static final Color CLOUD = Color.web("#BDC3C7");
+    public static final Color CLOUD = Color.web("#95A5A6");
 
     // CLD (Causal Loop Diagram) colors
     public static final Color CLD_VAR_BORDER = Color.web("#7F8C8D");
     public static final Color CAUSAL_LINK = Color.web("#2C3E50");
     public static final Color CAUSAL_POSITIVE = Color.web("#27AE60");
     public static final Color CAUSAL_NEGATIVE = Color.web("#E74C3C");
-    public static final Color CAUSAL_UNKNOWN = Color.web("#BDC3C7");
+    public static final Color CAUSAL_UNKNOWN = Color.web("#F39C12");
 
     public static final Color HOVER = Color.web("#4A90D9", 0.4);
     public static final Color SELECTION = Color.web("#4A90D9", 0.8);
@@ -67,6 +67,9 @@ public final class ColorPalette {
     public static final Color COMMENT_BORDER = Color.web("#95A5A6", 0.7);
     public static final Color COMMENT_TEXT = Color.web("#5D6D7E");
     public static final Color COMMENT_ACCENT = Color.web("#95A5A6", 0.7);
+
+    /** Darker gray for badge text (value/fx/Table/Module), distinct from TEXT_SECONDARY. */
+    public static final Color BADGE_TEXT = Color.web("#5D6D7E");
 
     // Delay indicator badge
     public static final Color DELAY_BADGE = Color.web("#8E44AD");

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/LayoutMetrics.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/LayoutMetrics.java
@@ -58,6 +58,9 @@ public final class LayoutMetrics {
     public static final double CAUSAL_ARROWHEAD_LENGTH = 10;
     public static final double CAUSAL_ARROWHEAD_WIDTH = 7;
     public static final Font CAUSAL_POLARITY_FONT = Font.font("System", FontWeight.BOLD, 12);
+    /** Larger font for the "?" glyph on UNKNOWN polarity links. */
+    public static final double CAUSAL_UNKNOWN_FONT_SIZE = 16;
+    public static final Font CAUSAL_UNKNOWN_FONT = Font.font("System", FontWeight.BOLD, CAUSAL_UNKNOWN_FONT_SIZE);
 
     // Module dimensions
     public static final double MODULE_WIDTH = 120;
@@ -85,9 +88,10 @@ public final class LayoutMetrics {
     public static final double INFO_ARROWHEAD_WIDTH = 6;
 
     // Cloud symbol
-    public static final double CLOUD_RADIUS = 12;
-    public static final double CLOUD_OFFSET = 80;
-    public static final double CLOUD_LINE_WIDTH = 1.5;
+    public static final double CLOUD_RADIUS = 16;
+    public static final double CLOUD_OFFSET = 84;
+    public static final double CLOUD_LINE_WIDTH = 2.5;
+    public static final Font CLOUD_SYMBOL_FONT = Font.font("System", FontWeight.NORMAL, 14);
 
     // Text positioning offsets
     /** Gap below flow diamond to name label. */
@@ -107,7 +111,7 @@ public final class LayoutMetrics {
     public static final double STOCK_NAME_FONT_SIZE = 13;
     public static final double AUX_NAME_FONT_SIZE = 12;
     public static final double MODULE_NAME_FONT_SIZE = 13;
-    public static final double BADGE_FONT_SIZE = 9;
+    public static final double BADGE_FONT_SIZE = 10;
     public static final double FLOW_NAME_FONT_SIZE = 11;
     public static final double LOOKUP_NAME_FONT_SIZE = 11;
     public static final double COMMENT_TEXT_FONT_SIZE = 11;
@@ -124,8 +128,21 @@ public final class LayoutMetrics {
     public static final Font STOCK_NAME_FONT = Font.font("System", FontWeight.BOLD, STOCK_NAME_FONT_SIZE);
     public static final Font AUX_NAME_FONT = Font.font("System", FontWeight.NORMAL, AUX_NAME_FONT_SIZE);
     public static final Font MODULE_NAME_FONT = Font.font("System", FontWeight.BOLD, MODULE_NAME_FONT_SIZE);
-    public static final Font BADGE_FONT = Font.font("System", FontWeight.NORMAL, BADGE_FONT_SIZE);
+    public static final Font BADGE_FONT = Font.font("System", FontWeight.BOLD, BADGE_FONT_SIZE);
     public static final Font FLOW_NAME_FONT = Font.font("System", FontWeight.NORMAL, FLOW_NAME_FONT_SIZE);
+
+    /** Font for the unit badge on stocks (centered below name). */
+    public static final double UNIT_BADGE_FONT_SIZE = 10;
+    public static final Font UNIT_BADGE_FONT = Font.font("System", FontWeight.NORMAL, UNIT_BADGE_FONT_SIZE);
+
+    /** Maximum auto-computed width for AUX variables (2x default). */
+    public static final double AUX_MAX_AUTO_WIDTH = 200;
+    /** Maximum auto-computed width for LOOKUP elements (2x default). */
+    public static final double LOOKUP_MAX_AUTO_WIDTH = 200;
+    /** Horizontal padding around text for AUX variable auto-sizing. */
+    public static final double AUX_TEXT_PADDING = 24;
+    /** Horizontal padding around text for LOOKUP auto-sizing. */
+    public static final double LOOKUP_TEXT_PADDING = 20;
 
     /**
      * Returns the width for a given element type.
@@ -218,5 +235,31 @@ public final class LayoutMetrics {
         text.setFont(AUX_NAME_FONT);
         double textWidth = text.getLayoutBounds().getWidth();
         return Math.max(minWidthFor(ElementType.CLD_VARIABLE), textWidth + CLD_VAR_TEXT_PADDING);
+    }
+
+    /**
+     * Computes the width for an AUX variable based on its text label.
+     * Returns the measured text width plus padding, clamped to
+     * [{@link #minWidthFor(ElementType) minWidth}, {@link #AUX_MAX_AUTO_WIDTH}].
+     */
+    public static double auxWidthForName(String name) {
+        Text text = new Text(name);
+        text.setFont(AUX_NAME_FONT);
+        double textWidth = text.getLayoutBounds().getWidth();
+        return Math.max(minWidthFor(ElementType.AUX),
+                Math.min(textWidth + AUX_TEXT_PADDING, AUX_MAX_AUTO_WIDTH));
+    }
+
+    /**
+     * Computes the width for a LOOKUP element based on its text label.
+     * Returns the measured text width plus padding, clamped to
+     * [{@link #minWidthFor(ElementType) minWidth}, {@link #LOOKUP_MAX_AUTO_WIDTH}].
+     */
+    public static double lookupWidthForName(String name) {
+        Text text = new Text(name);
+        text.setFont(LOOKUP_NAME_FONT);
+        double textWidth = text.getLayoutBounds().getWidth();
+        return Math.max(minWidthFor(ElementType.LOOKUP),
+                Math.min(textWidth + LOOKUP_TEXT_PADDING, LOOKUP_MAX_AUTO_WIDTH));
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/LoopNavigatorBar.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/LoopNavigatorBar.java
@@ -203,8 +203,18 @@ public class LoopNavigatorBar extends HBox {
      */
     public void update(FeedbackAnalysis analysis, int activeIndex,
                        LoopType typeFilter, int filteredCount) {
-        if (analysis == null || analysis.loopCount() == 0) {
-            loopLabel.setText("No loops detected");
+        if (analysis == null) {
+            loopLabel.setText("Loop analysis not available");
+            loopLabel.setTooltip(null);
+            prevButton.setDisable(true);
+            nextButton.setDisable(true);
+            allButton.setDisable(true);
+            filterRBtn.setDisable(true);
+            filterBBtn.setDisable(true);
+            return;
+        }
+        if (analysis.loopCount() == 0) {
+            loopLabel.setText("No feedback loops found");
             loopLabel.setTooltip(null);
             prevButton.setDisable(true);
             nextButton.setDisable(true);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
@@ -425,13 +425,13 @@ public final class SvgExporter {
                 "font-family=\"sans-serif\" font-size=\"%.0f\" font-weight=\"bold\" fill=\"%s\">%s</text>%n",
                 cx, cy, LayoutMetrics.STOCK_NAME_FONT_SIZE, svgColor(ColorPalette.TEXT), escapeXml(stockLabel));
 
-        // Unit badge
+        // Unit badge centered below name
         if (unit != null && !unit.isBlank()) {
             w.printf(Locale.US,
-                    "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"end\" dominant-baseline=\"auto\" " +
-                    "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
-                    x + width - 6, y + height - 4,
-                    LayoutMetrics.BADGE_FONT_SIZE, svgColor(ColorPalette.TEXT_SECONDARY), escapeXml(unit));
+                    "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"middle\" dominant-baseline=\"auto\" " +
+                    "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">[%s]</text>%n",
+                    cx, y + height - 3,
+                    LayoutMetrics.UNIT_BADGE_FONT_SIZE, svgColor(ColorPalette.BADGE_TEXT), escapeXml(unit));
         }
     }
 
@@ -486,15 +486,12 @@ public final class SvgExporter {
         }
         w.printf(Locale.US,
                 "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"start\" dominant-baseline=\"hanging\" " +
-                "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
-                x + 5, y + 3, LayoutMetrics.BADGE_FONT_SIZE, svgColor(ColorPalette.TEXT_SECONDARY), escapeXml(badge));
+                "font-family=\"sans-serif\" font-size=\"%.0f\" font-weight=\"bold\" fill=\"%s\">%s</text>%n",
+                x + 5, y + 3, LayoutMetrics.BADGE_FONT_SIZE, svgColor(ColorPalette.BADGE_TEXT), escapeXml(badge));
 
-        // Name centered (truncated to fit)
-        String auxLabel = ElementRenderer.truncate(name, LayoutMetrics.AUX_NAME_FONT, width - 20);
-        w.printf(Locale.US,
-                "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"middle\" dominant-baseline=\"central\" " +
-                "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
-                cx, cy, LayoutMetrics.AUX_NAME_FONT_SIZE, svgColor(ColorPalette.TEXT), escapeXml(auxLabel));
+        // Name centered — wrap to two lines if needed
+        writeSvgWrappedName(w, name, LayoutMetrics.AUX_NAME_FONT, LayoutMetrics.AUX_NAME_FONT_SIZE,
+                cx, cy, width, 20);
     }
 
     private static void writeModule(PrintWriter w, String name,
@@ -519,9 +516,9 @@ public final class SvgExporter {
         // Module badge
         w.printf(Locale.US,
                 "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"start\" dominant-baseline=\"hanging\" " +
-                "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
+                "font-family=\"sans-serif\" font-size=\"%.0f\" font-weight=\"bold\" fill=\"%s\">%s</text>%n",
                 x + 5, y + 3, LayoutMetrics.BADGE_FONT_SIZE,
-                svgColor(ColorPalette.TEXT_SECONDARY), ElementRenderer.BADGE_MODULE);
+                svgColor(ColorPalette.BADGE_TEXT), ElementRenderer.BADGE_MODULE);
 
         // Name centered (truncated to fit)
         String modLabel = ElementRenderer.truncate(name, LayoutMetrics.MODULE_NAME_FONT, width - 12);
@@ -546,17 +543,13 @@ public final class SvgExporter {
         // Table badge
         w.printf(Locale.US,
                 "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"start\" dominant-baseline=\"hanging\" " +
-                "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
+                "font-family=\"sans-serif\" font-size=\"%.0f\" font-weight=\"bold\" fill=\"%s\">%s</text>%n",
                 x + 4, y + 3, LayoutMetrics.BADGE_FONT_SIZE,
-                svgColor(ColorPalette.TEXT_SECONDARY), ElementRenderer.BADGE_LOOKUP);
+                svgColor(ColorPalette.BADGE_TEXT), ElementRenderer.BADGE_LOOKUP);
 
-        // Name centered vertically (truncated to fit)
-        String lookupLabel = ElementRenderer.truncate(name, LayoutMetrics.LOOKUP_NAME_FONT, width - 16);
-        w.printf(Locale.US,
-                "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"middle\" dominant-baseline=\"central\" " +
-                "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
-                cx, cy,
-                LayoutMetrics.LOOKUP_NAME_FONT_SIZE, svgColor(ColorPalette.TEXT), escapeXml(lookupLabel));
+        // Name centered vertically — wrap to two lines if needed
+        writeSvgWrappedName(w, name, LayoutMetrics.LOOKUP_NAME_FONT, LayoutMetrics.LOOKUP_NAME_FONT_SIZE,
+                cx, cy, width, 16);
     }
 
     private static void writeCldVariable(PrintWriter w, String name,
@@ -612,19 +605,23 @@ public final class SvgExporter {
                 double halfH = LayoutMetrics.effectiveHeight(state, link.from()) / 2;
                 double[] lp = CausalLinkGeometry.selfLoopPoints(fromX, fromY, halfW, halfH);
 
+                boolean isUnknown = link.polarity() == CausalLinkDef.Polarity.UNKNOWN;
+                Color selfLinkColor = isUnknown ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
+                String dashAttr = isUnknown ? " stroke-dasharray=\"4 3\"" : "";
+
                 // Cubic Bézier path
                 w.printf(Locale.US,
                         "  <path d=\"M %.2f %.2f C %.2f %.2f, %.2f %.2f, %.2f %.2f\" " +
-                        "fill=\"none\" stroke=\"%s\" stroke-width=\"%.1f\"/>%n",
+                        "fill=\"none\" stroke=\"%s\" stroke-width=\"%.1f\"%s/>%n",
                         lp[0], lp[1], lp[2], lp[3], lp[4], lp[5], lp[6], lp[7],
-                        svgColor(ColorPalette.CAUSAL_LINK), LayoutMetrics.CAUSAL_LINK_WIDTH);
+                        svgColor(selfLinkColor), LayoutMetrics.CAUSAL_LINK_WIDTH, dashAttr);
 
                 // Arrowhead at end
                 double[] tan = CausalLinkGeometry.tangentCubic(
                         lp[0], lp[1], lp[2], lp[3], lp[4], lp[5], lp[6], lp[7], 1.0);
                 writeArrowheadFromTangent(w, lp[6], lp[7], tan[0], tan[1],
                         LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH, LayoutMetrics.CAUSAL_ARROWHEAD_WIDTH,
-                        ColorPalette.CAUSAL_LINK);
+                        selfLinkColor);
 
                 // Polarity label at top of loop
                 double[] midPt = CausalLinkGeometry.evaluateCubic(
@@ -642,19 +639,23 @@ public final class SvgExporter {
             FlowGeometry.Point2D cf = FlowGeometry.clipToElement(state, link.from(), cp.x(), cp.y());
             FlowGeometry.Point2D ct = FlowGeometry.clipToElement(state, link.to(), cp.x(), cp.y());
 
+            boolean isUnknown = link.polarity() == CausalLinkDef.Polarity.UNKNOWN;
+            Color curLinkColor = isUnknown ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
+            String dashAttr = isUnknown ? " stroke-dasharray=\"4 3\"" : "";
+
             // Quadratic Bézier path
             w.printf(Locale.US,
                     "  <path d=\"M %.2f %.2f Q %.2f %.2f, %.2f %.2f\" " +
-                    "fill=\"none\" stroke=\"%s\" stroke-width=\"%.1f\"/>%n",
+                    "fill=\"none\" stroke=\"%s\" stroke-width=\"%.1f\"%s/>%n",
                     cf.x(), cf.y(), cp.x(), cp.y(), ct.x(), ct.y(),
-                    svgColor(ColorPalette.CAUSAL_LINK), LayoutMetrics.CAUSAL_LINK_WIDTH);
+                    svgColor(curLinkColor), LayoutMetrics.CAUSAL_LINK_WIDTH, dashAttr);
 
             // Arrowhead oriented along curve tangent at endpoint
             double[] tan = CausalLinkGeometry.tangent(
                     cf.x(), cf.y(), cp.x(), cp.y(), ct.x(), ct.y(), 1.0);
             writeArrowheadFromTangent(w, ct.x(), ct.y(), tan[0], tan[1],
                     LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH, LayoutMetrics.CAUSAL_ARROWHEAD_WIDTH,
-                    ColorPalette.CAUSAL_LINK);
+                    curLinkColor);
 
             // Polarity label at t=0.8 on the curve, offset perpendicular
             double dx = ct.x() - cf.x();
@@ -685,11 +686,13 @@ public final class SvgExporter {
             case NEGATIVE -> ColorPalette.CAUSAL_NEGATIVE;
             case UNKNOWN -> ColorPalette.CAUSAL_UNKNOWN;
         };
+        double fontSize = polarity == CausalLinkDef.Polarity.UNKNOWN
+                ? LayoutMetrics.CAUSAL_UNKNOWN_FONT_SIZE : LayoutMetrics.CAUSAL_POLARITY_FONT_SIZE;
         w.printf(Locale.US,
                 "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"middle\" " +
                 "dominant-baseline=\"central\" font-weight=\"bold\" font-size=\"%.0f\" " +
                 "fill=\"%s\">%s</text>%n",
-                x, y, LayoutMetrics.CAUSAL_POLARITY_FONT_SIZE, svgColor(labelColor), escapeXml(polarity.symbol()));
+                x, y, fontSize, svgColor(labelColor), escapeXml(polarity.symbol()));
     }
 
     private static void writeArrowheadFromTangent(PrintWriter w,
@@ -756,6 +759,45 @@ public final class SvgExporter {
 
     // --- Shared helpers ---
 
+    /**
+     * Writes a name label as SVG, wrapping to two lines with {@code <tspan>} elements if needed.
+     */
+    private static void writeSvgWrappedName(PrintWriter w, String name,
+                                            javafx.scene.text.Font font, double fontSize,
+                                            double cx, double cy, double width, double padding) {
+        double maxWidth = width - padding;
+        javafx.scene.text.Text measure = new javafx.scene.text.Text(name);
+        measure.setFont(font);
+        if (measure.getLayoutBounds().getWidth() <= maxWidth) {
+            // Single line
+            w.printf(Locale.US,
+                    "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"middle\" dominant-baseline=\"central\" " +
+                    "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
+                    cx, cy, fontSize, svgColor(ColorPalette.TEXT), escapeXml(name));
+        } else {
+            // Wrap to lines, show at most 2
+            java.util.List<String> lines = ElementRenderer.wrapText(name, font, maxWidth);
+            int lineCount = Math.min(lines.size(), 2);
+            double lineHeight = ElementRenderer.measureLineHeight(font);
+            double startY = cy - (lineCount - 1) * lineHeight / 2;
+
+            w.printf(Locale.US,
+                    "  <text x=\"%.2f\" text-anchor=\"middle\" " +
+                    "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%n",
+                    cx, fontSize, svgColor(ColorPalette.TEXT));
+            for (int i = 0; i < lineCount; i++) {
+                String line = lines.get(i);
+                if (i == 1 && lines.size() > 2) {
+                    line = ElementRenderer.truncate(line, font, maxWidth);
+                }
+                w.printf(Locale.US,
+                        "    <tspan x=\"%.2f\" y=\"%.2f\" dominant-baseline=\"central\">%s</tspan>%n",
+                        cx, startY + i * lineHeight, escapeXml(line));
+            }
+            w.println("  </text>");
+        }
+    }
+
     private static void writeCloud(PrintWriter w, double cx, double cy) {
         double r = LayoutMetrics.CLOUD_RADIUS;
         w.printf(Locale.US,
@@ -764,8 +806,8 @@ public final class SvgExporter {
                 cx, cy, r, svgColor(ColorPalette.CLOUD), LayoutMetrics.CLOUD_LINE_WIDTH);
         w.printf(Locale.US,
                 "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"middle\" dominant-baseline=\"central\" " +
-                "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">~</text>%n",
-                cx, cy, LayoutMetrics.BADGE_FONT_SIZE, svgColor(ColorPalette.CLOUD));
+                "font-family=\"sans-serif\" font-size=\"14\" fill=\"%s\">~</text>%n",
+                cx, cy, svgColor(ColorPalette.CLOUD));
     }
 
     private static void writeArrowhead(PrintWriter w, double fromX, double fromY,

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/SelectionController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/SelectionController.java
@@ -75,6 +75,12 @@ public final class SelectionController {
         if (type == ElementType.CLD_VARIABLE) {
             double w = LayoutMetrics.cldVarWidthForName(name);
             canvasState.setSize(name, w, LayoutMetrics.CLD_VAR_HEIGHT);
+        } else if (type == ElementType.AUX) {
+            double w = LayoutMetrics.auxWidthForName(name);
+            canvasState.setSize(name, w, LayoutMetrics.AUX_HEIGHT);
+        } else if (type == ElementType.LOOKUP) {
+            double w = LayoutMetrics.lookupWidthForName(name);
+            canvasState.setSize(name, w, LayoutMetrics.LOOKUP_HEIGHT);
         }
         canvasState.clearSelection();
         canvasState.select(name);
@@ -188,9 +194,16 @@ public final class SelectionController {
             return false;
         }
         canvasState.renameElement(oldName, newName);
-        if (canvasState.getType(newName).orElse(null) == ElementType.CLD_VARIABLE) {
+        ElementType renamedType = canvasState.getType(newName).orElse(null);
+        if (renamedType == ElementType.CLD_VARIABLE) {
             double w = LayoutMetrics.cldVarWidthForName(newName);
             canvasState.setSize(newName, w, LayoutMetrics.CLD_VAR_HEIGHT);
+        } else if (renamedType == ElementType.AUX) {
+            double w = LayoutMetrics.auxWidthForName(newName);
+            canvasState.setSize(newName, w, LayoutMetrics.AUX_HEIGHT);
+        } else if (renamedType == ElementType.LOOKUP) {
+            double w = LayoutMetrics.lookupWidthForName(newName);
+            canvasState.setSize(newName, w, LayoutMetrics.LOOKUP_HEIGHT);
         }
         return true;
     }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ConnectionRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ConnectionRenderer.java
@@ -5,6 +5,7 @@ import systems.courant.sd.model.def.CausalLinkDef;
 import javafx.geometry.VPos;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
 import systems.courant.sd.app.canvas.CausalLinkGeometry;
 import systems.courant.sd.app.canvas.ColorPalette;
@@ -162,9 +163,15 @@ public final class ConnectionRenderer {
         double stopT = ah[4];
 
         // Draw the curved line, stopping at the arrowhead base
-        gc.setStroke(ColorPalette.CAUSAL_LINK);
+        Color linkColor = polarity == CausalLinkDef.Polarity.UNKNOWN
+                ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
+        gc.setStroke(linkColor);
         gc.setLineWidth(LayoutMetrics.CAUSAL_LINK_WIDTH);
-        gc.setLineDashes();
+        if (polarity == CausalLinkDef.Polarity.UNKNOWN) {
+            gc.setLineDashes(4, 3);
+        } else {
+            gc.setLineDashes();
+        }
 
         gc.beginPath();
         gc.moveTo(fromX, fromY);
@@ -176,11 +183,12 @@ public final class ConnectionRenderer {
             gc.lineTo(pt[0], pt[1]);
         }
         gc.stroke();
+        gc.setLineDashes();
 
         // Arrowhead oriented along the curve tangent at the tip
         drawArrowheadFromTangent(gc, tipX, tipY, tanX, tanY,
                 LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH, LayoutMetrics.CAUSAL_ARROWHEAD_WIDTH,
-                ColorPalette.CAUSAL_LINK);
+                linkColor);
 
         // Polarity label near the arrowhead, offset perpendicular to the curve tangent
         double dx = toX - fromX;
@@ -205,8 +213,10 @@ public final class ConnectionRenderer {
                 double labelX = labelPt[0] + perpX * perpOffset;
                 double labelY = labelPt[1] + perpY * perpOffset;
 
+                Font labelFont = polarity == CausalLinkDef.Polarity.UNKNOWN
+                        ? LayoutMetrics.CAUSAL_UNKNOWN_FONT : LayoutMetrics.CAUSAL_POLARITY_FONT;
                 gc.setFill(labelColor);
-                gc.setFont(LayoutMetrics.CAUSAL_POLARITY_FONT);
+                gc.setFont(labelFont);
                 gc.setTextAlign(TextAlignment.CENTER);
                 gc.setTextBaseline(VPos.CENTER);
                 gc.fillText(polarity.symbol(), labelX, labelY);
@@ -230,9 +240,15 @@ public final class ConnectionRenderer {
         double endY = loopPts[7];
 
         // Draw curve
-        gc.setStroke(ColorPalette.CAUSAL_LINK);
+        Color linkColor = polarity == CausalLinkDef.Polarity.UNKNOWN
+                ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
+        gc.setStroke(linkColor);
         gc.setLineWidth(LayoutMetrics.CAUSAL_LINK_WIDTH);
-        gc.setLineDashes();
+        if (polarity == CausalLinkDef.Polarity.UNKNOWN) {
+            gc.setLineDashes(4, 3);
+        } else {
+            gc.setLineDashes();
+        }
 
         int segments = 30;
         gc.beginPath();
@@ -246,13 +262,14 @@ public final class ConnectionRenderer {
             gc.lineTo(pt[0], pt[1]);
         }
         gc.stroke();
+        gc.setLineDashes();
 
         // Arrowhead at the end
         double[] tan = CausalLinkGeometry.tangentCubic(
                 startX, startY, cp1X, cp1Y, cp2X, cp2Y, endX, endY, 1.0);
         drawArrowheadFromTangent(gc, endX, endY, tan[0], tan[1],
                 LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH, LayoutMetrics.CAUSAL_ARROWHEAD_WIDTH,
-                ColorPalette.CAUSAL_LINK);
+                linkColor);
 
         // Polarity label at the top of the loop
         double[] midPt = CausalLinkGeometry.evaluateCubic(
@@ -262,8 +279,10 @@ public final class ConnectionRenderer {
             case NEGATIVE -> ColorPalette.CAUSAL_NEGATIVE;
             case UNKNOWN -> ColorPalette.CAUSAL_UNKNOWN;
         };
+        Font labelFont = polarity == CausalLinkDef.Polarity.UNKNOWN
+                ? LayoutMetrics.CAUSAL_UNKNOWN_FONT : LayoutMetrics.CAUSAL_POLARITY_FONT;
         gc.setFill(labelColor);
-        gc.setFont(LayoutMetrics.CAUSAL_POLARITY_FONT);
+        gc.setFont(labelFont);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
         gc.fillText(polarity.symbol(), midPt[0], midPt[1] - 10);
@@ -342,9 +361,9 @@ public final class ConnectionRenderer {
         gc.setLineDashes();
         gc.strokeOval(cx - r, cy - r, r * 2, r * 2);
 
-        // Draw a small "~" inside to distinguish from a plain circle
+        // Draw a "~" inside to distinguish from a plain circle
         gc.setFill(ColorPalette.CLOUD);
-        gc.setFont(LayoutMetrics.BADGE_FONT);
+        gc.setFont(LayoutMetrics.CLOUD_SYMBOL_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
         gc.fillText("~", cx, cy);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
@@ -56,13 +56,13 @@ public final class ElementRenderer {
         gc.fillText(truncate(name, LayoutMetrics.STOCK_NAME_FONT, width - 12),
                 x + width / 2, y + height / 2);
 
-        // Unit badge bottom-right
+        // Unit badge centered below name
         if (unit != null && !unit.isBlank()) {
-            gc.setFill(ColorPalette.TEXT_SECONDARY);
-            gc.setFont(LayoutMetrics.BADGE_FONT);
-            gc.setTextAlign(TextAlignment.RIGHT);
+            gc.setFill(ColorPalette.BADGE_TEXT);
+            gc.setFont(LayoutMetrics.UNIT_BADGE_FONT);
+            gc.setTextAlign(TextAlignment.CENTER);
             gc.setTextBaseline(VPos.BOTTOM);
-            gc.fillText(unit, x + width - 6, y + height - 4);
+            gc.fillText("[" + unit + "]", x + width / 2, y + height - 3);
         }
     }
 
@@ -138,7 +138,7 @@ public final class ElementRenderer {
         gc.fillRoundRect(x, y, width, height, r, r);
 
         // Badge top-left: value for literals, "fx" for formulas
-        gc.setFill(ColorPalette.TEXT_SECONDARY);
+        gc.setFill(ColorPalette.BADGE_TEXT);
         gc.setFont(LayoutMetrics.BADGE_FONT);
         gc.setTextAlign(TextAlignment.LEFT);
         gc.setTextBaseline(VPos.TOP);
@@ -153,13 +153,12 @@ public final class ElementRenderer {
             gc.fillText(BADGE_FORMULA, x + 5, y + 3);
         }
 
-        // Name centered (truncated to fit)
+        // Name centered — wrap to two lines if needed
         gc.setFill(ColorPalette.TEXT);
         gc.setFont(LayoutMetrics.AUX_NAME_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
-        gc.fillText(truncate(name, LayoutMetrics.AUX_NAME_FONT, width - 20),
-                x + width / 2, y + height / 2);
+        drawWrappedName(gc, name, LayoutMetrics.AUX_NAME_FONT, x, y, width, height, 20);
 
         // Delay badge top-right
         if (hasDelay) {
@@ -191,7 +190,7 @@ public final class ElementRenderer {
         gc.strokeRoundRect(x, y, width, height, r, r);
 
         // Module badge top-left
-        gc.setFill(ColorPalette.TEXT_SECONDARY);
+        gc.setFill(ColorPalette.BADGE_TEXT);
         gc.setFont(LayoutMetrics.BADGE_FONT);
         gc.setTextAlign(TextAlignment.LEFT);
         gc.setTextBaseline(VPos.TOP);
@@ -270,19 +269,18 @@ public final class ElementRenderer {
         gc.fillRoundRect(x, y, width, height, r, r);
 
         // Table badge top-left
-        gc.setFill(ColorPalette.TEXT_SECONDARY);
+        gc.setFill(ColorPalette.BADGE_TEXT);
         gc.setFont(LayoutMetrics.BADGE_FONT);
         gc.setTextAlign(TextAlignment.LEFT);
         gc.setTextBaseline(VPos.TOP);
         gc.fillText(BADGE_LOOKUP, x + 4, y + 3);
 
-        // Name centered vertically (truncated to fit)
+        // Name centered vertically — wrap to two lines if needed
         gc.setFill(ColorPalette.TEXT);
         gc.setFont(LayoutMetrics.LOOKUP_NAME_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
-        gc.fillText(truncate(name, LayoutMetrics.LOOKUP_NAME_FONT, width - 16),
-                x + width / 2, y + height / 2);
+        drawWrappedName(gc, name, LayoutMetrics.LOOKUP_NAME_FONT, x, y, width, height, 16);
     }
 
     /** Padding inside the comment box (each side). */
@@ -443,6 +441,39 @@ public final class ElementRenderer {
     /** Thread-local Text node for width measurement — safe from any thread. */
     private static final ThreadLocal<Text> MEASURE_TEXT =
             ThreadLocal.withInitial(Text::new);
+
+    /**
+     * Draws a name centered in the element bounding box, wrapping to two lines if needed.
+     * If the name fits on one line, draws centered as usual. If it needs wrapping, draws
+     * up to 2 lines vertically centered. If more than 2 lines, truncates line 2 with ellipsis.
+     *
+     * @param padding  total horizontal padding (both sides combined)
+     */
+    private static void drawWrappedName(GraphicsContext gc, String name, Font font,
+                                        double x, double y, double width, double height,
+                                        double padding) {
+        double maxWidth = width - padding;
+        MEASURE_TEXT.get().setFont(font);
+        MEASURE_TEXT.get().setText(name);
+        if (MEASURE_TEXT.get().getLayoutBounds().getWidth() <= maxWidth) {
+            // Fits on one line
+            gc.fillText(name, x + width / 2, y + height / 2);
+        } else {
+            List<String> lines = wrapText(name, font, maxWidth);
+            double lineHeight = measureLineHeight(font);
+            int lineCount = Math.min(lines.size(), 2);
+            double totalHeight = lineCount * lineHeight;
+            double startY = y + (height - totalHeight) / 2 + lineHeight / 2;
+
+            for (int i = 0; i < lineCount; i++) {
+                String line = lines.get(i);
+                if (i == 1 && lines.size() > 2) {
+                    line = truncate(line, font, maxWidth);
+                }
+                gc.fillText(line, x + width / 2, startY + i * lineHeight);
+            }
+        }
+    }
 
     /**
      * Truncates a name to fit within the given pixel width, appending "..." if needed.

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ColorPaletteTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ColorPaletteTest.java
@@ -79,6 +79,7 @@ class ColorPaletteTest {
             assertThat(ColorPalette.BACKGROUND).isNotNull();
             assertThat(ColorPalette.TEXT).isNotNull();
             assertThat(ColorPalette.TEXT_SECONDARY).isNotNull();
+            assertThat(ColorPalette.BADGE_TEXT).isNotNull();
             assertThat(ColorPalette.CLOUD).isNotNull();
             assertThat(ColorPalette.COMMENT_BORDER).isNotNull();
             assertThat(ColorPalette.DELAY_BADGE).isNotNull();
@@ -87,6 +88,25 @@ class ColorPaletteTest {
             assertThat(ColorPalette.HOVER_FILL).isNotNull();
             assertThat(ColorPalette.COMMENT_TEXT).isNotNull();
             assertThat(ColorPalette.COMMENT_ACCENT).isNotNull();
+        }
+
+        @Test
+        @DisplayName("CAUSAL_UNKNOWN is amber (#F39C12)")
+        void causalUnknownIsAmber() {
+            assertThat(ColorPalette.CAUSAL_UNKNOWN).isEqualTo(Color.web("#F39C12"));
+        }
+
+        @Test
+        @DisplayName("BADGE_TEXT is darker than TEXT_SECONDARY")
+        void badgeTextDarkerThanSecondary() {
+            assertThat(ColorPalette.BADGE_TEXT.getBrightness())
+                    .isLessThan(ColorPalette.TEXT_SECONDARY.getBrightness());
+        }
+
+        @Test
+        @DisplayName("CLOUD is darker gray (#95A5A6)")
+        void cloudIsDarkerGray() {
+            assertThat(ColorPalette.CLOUD).isEqualTo(Color.web("#95A5A6"));
         }
 
         @Test

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/FlowEndpointCalculatorTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/FlowEndpointCalculatorTest.java
@@ -101,7 +101,7 @@ class FlowEndpointCalculatorTest {
 
             assertThat(pos).isNotNull();
             // Default: left of diamond
-            assertThat(pos.x()).isCloseTo(250 - 80, within(1.0));
+            assertThat(pos.x()).isCloseTo(250 - LayoutMetrics.CLOUD_OFFSET, within(1.0));
             assertThat(pos.y()).isCloseTo(200, within(1.0));
         }
 
@@ -116,7 +116,7 @@ class FlowEndpointCalculatorTest {
 
             assertThat(pos).isNotNull();
             // Default: right of diamond
-            assertThat(pos.x()).isCloseTo(250 + 80, within(1.0));
+            assertThat(pos.x()).isCloseTo(250 + LayoutMetrics.CLOUD_OFFSET, within(1.0));
             assertThat(pos.y()).isCloseTo(200, within(1.0));
         }
     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/HitTesterTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/HitTesterTest.java
@@ -76,14 +76,16 @@ class HitTesterTest {
 
         @Test
         void shouldHitAtEdge() {
-            // Aux is 100x55, half-width=50, half-height=27.5
-            assertThat(HitTester.hitTest(state, 150 + 50, 250)).isEqualTo("rate");
+            // Aux auto-sizes to fit name; height remains AUX_HEIGHT (55)
+            double halfW = LayoutMetrics.effectiveWidth(state, "rate") / 2;
+            assertThat(HitTester.hitTest(state, 150 + halfW, 250)).isEqualTo("rate");
             assertThat(HitTester.hitTest(state, 150, 250 + 27)).isEqualTo("rate");
         }
 
         @Test
         void shouldMissOutside() {
-            assertThat(HitTester.hitTest(state, 150 + 51, 250)).isNull();
+            double halfW = LayoutMetrics.effectiveWidth(state, "rate") / 2;
+            assertThat(HitTester.hitTest(state, 150 + halfW + 1, 250)).isNull();
             assertThat(HitTester.hitTest(state, 150, 250 + 28)).isNull();
         }
     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/LoopNavigatorBarFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/LoopNavigatorBarFxTest.java
@@ -125,17 +125,17 @@ class LoopNavigatorBarFxTest {
     }
 
     @Test
-    @DisplayName("update() with null analysis shows 'No loops detected'")
+    @DisplayName("update() with null analysis shows analysis unavailable")
     void updateWithNullAnalysis(FxRobot robot) {
         Platform.runLater(() -> bar.update(null, -1, null, 0));
         WaitForAsyncUtils.waitForFxEvents();
 
         Label label = robot.lookup("#loopNavigatorLabel").queryAs(Label.class);
-        assertThat(label.getText()).isEqualTo("No loops detected");
+        assertThat(label.getText()).isEqualTo("Loop analysis not available");
     }
 
     @Test
-    @DisplayName("update() with empty analysis shows 'No loops detected'")
+    @DisplayName("update() with empty analysis shows no loops found")
     void updateWithEmptyAnalysis(FxRobot robot) {
         FeedbackAnalysis empty = new FeedbackAnalysis(
                 Collections.emptySet(), Collections.emptyList(),
@@ -144,7 +144,7 @@ class LoopNavigatorBarFxTest {
         WaitForAsyncUtils.waitForFxEvents();
 
         Label label = robot.lookup("#loopNavigatorLabel").queryAs(Label.class);
-        assertThat(label.getText()).isEqualTo("No loops detected");
+        assertThat(label.getText()).isEqualTo("No feedback loops found");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Auto-size AUX and LOOKUP elements to fit names (up to 2x default), wrap to two lines when narrowed
- Highlight UNKNOWN polarity links with amber dashed stroke and larger "?" glyph
- Center stock unit labels below name in `[brackets]` at 10pt
- Make value/fx/Table/Module badges more prominent (10pt bold, darker color)
- Enlarge cloud symbols (radius 16, stroke 2.5, darker gray #95A5A6)
- Disambiguate loop navigator: "Loop analysis not available" vs "No feedback loops found"

Closes #751

## Test plan
- [x] `mvn clean compile` — all modules build
- [x] `mvn clean test` — all 1699 tests pass
- [x] `mvn spotbugs:check` — no findings