### PR TITLE
Add PI to ExprStringifier reserved words for round-trip safety

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprStringifier.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprStringifier.java
@@ -101,7 +101,8 @@ public final class ExprStringifier {
             return true;
         }
         return name.equals("IF") || name.equals("IF_SHORT")
-                || name.equals("TIME") || name.equals("DT");
+                || name.equals("TIME") || name.equals("DT")
+                || name.equals("PI");
     }
 
     private static void appendBinaryOp(StringBuilder sb, Expr.BinaryOp bin, int contextPrecedence) {

--- a/courant-engine/src/test/java/systems/courant/sd/model/expr/ExprStringifierTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/expr/ExprStringifierTest.java
@@ -160,6 +160,19 @@ class ExprStringifierTest {
         assertThat(ExprStringifier.stringify(new Expr.Ref("IF"))).isEqualTo("`IF`");
         assertThat(ExprStringifier.stringify(new Expr.Ref("TIME"))).isEqualTo("`TIME`");
         assertThat(ExprStringifier.stringify(new Expr.Ref("DT"))).isEqualTo("`DT`");
+        assertThat(ExprStringifier.stringify(new Expr.Ref("PI"))).isEqualTo("`PI`");
+    }
+
+    @Test
+    void shouldRoundTripPIAsVariableRef() {
+        // A variable named PI should stringify with backtick quoting and
+        // re-parse as a Ref, not as the zero-arg PI function call
+        Expr ref = new Expr.Ref("PI");
+        String stringified = ExprStringifier.stringify(ref);
+        assertThat(stringified).isEqualTo("`PI`");
+        Expr reparsed = ExprParser.parse(stringified);
+        assertThat(reparsed).isInstanceOf(Expr.Ref.class);
+        assertThat(((Expr.Ref) reparsed).name()).isEqualTo("PI");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Added `PI` to the reserved words list in `ExprStringifier.needsQuoting()`
- Prevents a variable named `PI` from being re-parsed as the zero-arg PI function call

## Test plan
- [x] New test: PI variable ref stringifies with backtick quoting
- [x] New test: round-trip of PI variable ref preserves Ref semantics
- [x] SpotBugs clean

Closes #763