### PR TITLE
Use Math.rint for ROUND function

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -424,7 +424,7 @@ public class ExprCompiler {
             case "ROUND" -> {
                 requireArgs(name, args, 1);
                 DoubleSupplier a = compileExpr(args.get(0));
-                yield () -> Math.round(a.getAsDouble());
+                yield () -> Math.rint(a.getAsDouble());
             }
             case "MODULO" -> {
                 requireArgs(name, args, 2);

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
@@ -611,6 +611,23 @@ class ExprCompilerTest {
         }
 
         @Test
+        void shouldUseHalfToEvenRoundingForROUND() {
+            // Half-to-even (banker's rounding): 0.5 rounds to nearest even
+            assertThat(compiler.compile("ROUND(0.5)").getCurrentValue()).isEqualTo(0.0);
+            assertThat(compiler.compile("ROUND(1.5)").getCurrentValue()).isEqualTo(2.0);
+            assertThat(compiler.compile("ROUND(2.5)").getCurrentValue()).isEqualTo(2.0);
+            assertThat(compiler.compile("ROUND(3.5)").getCurrentValue()).isEqualTo(4.0);
+        }
+
+        @Test
+        void shouldNotClampLargeDoublesInROUND() {
+            // Values beyond Long.MAX_VALUE must not clamp
+            double huge = 1e19;
+            Formula formula = compiler.compile("ROUND(" + huge + ")");
+            assertThat(formula.getCurrentValue()).isEqualTo(huge);
+        }
+
+        @Test
         void shouldCompileMODULO() {
             Formula formula = compiler.compile("MODULO(7, 3)");
             assertThat(formula.getCurrentValue()).isCloseTo(1.0, within(1e-10));


### PR DESCRIPTION
## Summary
- Replaces `Math.round()` with `Math.rint()` in ROUND function compilation
- Fixes half-up rounding mode (should be half-to-even/banker's rounding per SD standard)
- Fixes silent clamping of values beyond Long.MAX_VALUE (~9.2e18)

## Test plan
- [x] Added half-to-even rounding test (0.5→0, 1.5→2, 2.5→2, 3.5→4)
- [x] Added large value test (1e19 not clamped)
- [x] All tests pass, SpotBugs clean

Closes #765