### PR TITLE
Don't enter macro mode when macro header is malformed

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/MdlParser.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/MdlParser.java
@@ -256,6 +256,10 @@ public final class MdlParser {
                         }
                     }
                 } else {
+                    logger.warn("Malformed :MACRO: header — ignoring: {}",
+                            macroHeaderLine.strip());
+                    inMacro = false;
+                    macroBody = null;
                     macroName = null;
                     macroParams = null;
                 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/MdlParserTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/MdlParserTest.java
@@ -413,6 +413,33 @@ class MdlParserTest {
             assertThat(result.equations().get(1).name()).isEqualTo("y");
             assertThat(result.equations().get(2).name()).isEqualTo("z");
         }
+
+        @Test
+        void shouldNotLoseEquationsWhenMacroHeaderIsMalformed() {
+            String content = """
+                    x = 1
+                    \t~\t
+                    \t~\t
+                    \t|
+                    :MACRO: InvalidMacroNoParentheses
+                    eq1 = 5
+                    \t~\t
+                    \t~\t
+                    \t|
+                    :END OF MACRO:
+                    y = 2
+                    \t~\t
+                    \t~\t
+                    \t|
+                    """;
+            MdlParser.ParsedMdl result = MdlParser.parse(content);
+            // Malformed macro should not consume equations; eq1 and y should be present
+            List<String> names = result.equations().stream()
+                    .map(MdlEquation::name)
+                    .toList();
+            assertThat(names).contains("x", "eq1", "y");
+            assertThat(result.macros()).isEmpty();
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- When a `:MACRO:` header doesn't match the expected `NAME(params)` pattern, the parser now stays in normal mode and logs a warning
- Prevents subsequent equations from being silently discarded into a macro body that can never be finalized

## Test plan
- [x] New test: malformed macro header preserves all equations
- [x] All existing MdlParser tests pass
- [x] SpotBugs clean

Closes #746