### PR TITLE
Fix clearDanglingReferences corrupting subscripted expressions

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CopyPasteController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CopyPasteController.java
@@ -390,9 +390,20 @@ public final class CopyPasteController {
                 continue;
             }
 
+            // Consume subscript brackets as part of the reference (e.g. Stock[Region])
+            // so that subscript names are not independently checked and replaced.
+            String suffix = "";
+            if (i < len && equation.charAt(i) == '[') {
+                int close = equation.indexOf(']', i);
+                if (close >= 0) {
+                    suffix = equation.substring(i, close + 1);
+                    i = close + 1;
+                }
+            }
+
             // Check if the element exists in the target editor
             if (editor.hasElement(token) || editor.hasElement(token.replace('_', ' '))) {
-                result.append(token);
+                result.append(token).append(suffix);
             } else {
                 replaced.add(token.replace('_', ' '));
                 result.append("0");

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/CopyPasteControllerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/CopyPasteControllerTest.java
@@ -293,6 +293,39 @@ class CopyPasteControllerTest {
             assertThat(cr.equation()).isEqualTo("`Population` * 0");
             assertThat(cr.replaced()).containsExactly("Growth Rate");
         }
+
+        @Test
+        void shouldPreserveSubscriptedReferencesWhenBaseExists() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Stock", 100, null)
+                    .build();
+            editor.loadFrom(def);
+
+            String result = CopyPasteController.clearDanglingReferences(
+                    "Stock[Region] * Rate", editor).equation();
+            assertThat(result).isEqualTo("Stock[Region] * 0");
+        }
+
+        @Test
+        void shouldReplaceSubscriptedReferenceWhenBaseIsMissing() {
+            String result = CopyPasteController.clearDanglingReferences(
+                    "Missing[Region] + 1", editor).equation();
+            assertThat(result).isEqualTo("0 + 1");
+        }
+
+        @Test
+        void shouldPreserveMultipleSubscriptDimensions() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Population", 100, null)
+                    .build();
+            editor.loadFrom(def);
+
+            String result = CopyPasteController.clearDanglingReferences(
+                    "Population[Region, Age]", editor).equation();
+            assertThat(result).isEqualTo("Population[Region, Age]");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Fixes `clearDanglingReferences` treating `[` and `]` as non-token characters, which split `Stock[Region]` into independent tokens and replaced subscript names with `0`
- Now consumes bracket suffixes as part of the reference and checks only the base name against the editor

## Test plan
- [x] Added test: subscripted reference preserved when base exists
- [x] Added test: subscripted reference replaced when base is missing
- [x] Added test: multi-dimension subscripts preserved
- [x] All tests pass, SpotBugs clean

Closes #768