### PR TITLE
Clamp Trend and Forecast to prevent extreme values near zero

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/Forecast.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Forecast.java
@@ -100,8 +100,11 @@ public class Forecast implements Formula, Resettable {
             for (int d = 0; d < delta; d++) {
                 lastInputVal = input.getAsDouble();
                 averageInput += (lastInputVal - averageInput) / averagingTime;
-                if (averageInput != 0) {
-                    trend = (lastInputVal - averageInput) / (averageInput * averagingTime);
+                double denom = averageInput * averagingTime;
+                if (Math.abs(denom) > 1e-15) {
+                    trend = (lastInputVal - averageInput) / denom;
+                    // Clamp to prevent extreme values when averageInput is near zero
+                    trend = Math.max(-10, Math.min(10, trend));
                 } else {
                     trend = 0;
                 }

--- a/courant-engine/src/main/java/systems/courant/sd/model/Trend.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Trend.java
@@ -100,8 +100,11 @@ public class Trend implements Formula, Resettable {
             for (int d = 0; d < delta; d++) {
                 double inputVal = input.getAsDouble();
                 averageInput += (inputVal - averageInput) / averagingTime;
-                if (averageInput != 0) {
-                    trend = (inputVal - averageInput) / (averageInput * averagingTime);
+                double denom = averageInput * averagingTime;
+                if (Math.abs(denom) > 1e-15) {
+                    trend = (inputVal - averageInput) / denom;
+                    // Clamp to prevent extreme values when averageInput is near zero
+                    trend = Math.max(-10, Math.min(10, trend));
                 } else {
                     trend = 0;
                 }

--- a/courant-engine/src/test/java/systems/courant/sd/model/ForecastTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/ForecastTest.java
@@ -77,4 +77,23 @@ class ForecastTest {
         assertEquals(true, val > 110,
                 "Forecast should extrapolate above current input when trend is positive");
     }
+
+    @Test
+    void shouldNotProduceExtremeValuesWhenAverageInputNearZero() {
+        int[] step = {0};
+        double[] inputVal = {0.01};
+        Forecast forecast = Forecast.of(() -> inputVal[0], 5, 3, 0, () -> step[0]);
+        forecast.getCurrentValue(); // initialize
+
+        for (int i = 1; i <= 20; i++) {
+            step[0] = i;
+            inputVal[0] = 0.01 * Math.sin(i * 0.5);
+            double val = forecast.getCurrentValue();
+            assertEquals(false, Double.isNaN(val), "Forecast should not be NaN at step " + i);
+            assertEquals(false, Double.isInfinite(val),
+                    "Forecast should not be Infinite at step " + i);
+            assertEquals(true, Math.abs(val) < 100,
+                    "Forecast should not be extreme at step " + i + ", was " + val);
+        }
+    }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/model/TrendTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/TrendTest.java
@@ -60,4 +60,27 @@ class TrendTest {
         assertThrows(IllegalArgumentException.class, () ->
                 Trend.of(() -> 100, -1, 0, () -> 0));
     }
+
+    @Test
+    void shouldNotProduceExtremeValuesWhenAverageInputNearZero() {
+        int[] step = {0};
+        // Input that oscillates around zero: starts at a small positive value
+        // and crosses through zero
+        double[] inputVal = {0.01};
+        Trend trend = Trend.of(() -> inputVal[0], 5, 0, () -> step[0]);
+        trend.getCurrentValue(); // initialize
+
+        // Drive input to near-zero
+        for (int i = 1; i <= 20; i++) {
+            step[0] = i;
+            inputVal[0] = 0.01 * Math.sin(i * 0.5); // crosses zero
+            double trendVal = trend.getCurrentValue();
+            // Should never produce extreme values (NaN, Infinity, or very large)
+            assertEquals(false, Double.isNaN(trendVal), "Trend should not be NaN at step " + i);
+            assertEquals(false, Double.isInfinite(trendVal),
+                    "Trend should not be Infinite at step " + i);
+            assertEquals(true, Math.abs(trendVal) < 100,
+                    "Trend should not be extreme at step " + i + ", was " + trendVal);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Added trend clamping to [-10, +10] in both `Trend.java` and `Forecast.java`
- Falls back to trend=0 when `averageInput * averagingTime` is negligible (< 1e-15)
- Prevents extreme values and feedback loop destabilization when input oscillates through zero

## Test plan
- [x] New test: Trend does not produce NaN, Infinity, or extreme values with zero-crossing input
- [x] New test: Forecast does not produce extreme values with zero-crossing input
- [x] Existing Trend and Forecast tests still pass
- [x] SpotBugs clean

Closes #707