### PR TITLE
Propagate original unit from SQRT of odd-exponent inputs

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/measure/DimensionalAnalyzer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/DimensionalAnalyzer.java
@@ -180,11 +180,13 @@ public class DimensionalAnalyzer {
                         return arg.power(1).divide(arg.power(1)).multiply(
                                 new CompositeUnit(halveExponents(arg.exponents())));
                     }
-                    // Odd exponents — result has fractional dimensions, treat as dimensionless
+                    // Odd exponents — result has fractional dimensions; propagate the
+                    // original unit so downstream operations still produce mismatch warnings
                     if (!arg.isDimensionless()) {
                         warnings.add(new DimensionWarning(
                                 "SQRT of non-even-dimensioned quantity: "
                                 + arg.displayString()));
+                        return arg;
                     }
                 }
             }

--- a/courant-engine/src/test/java/systems/courant/sd/measure/DimensionalAnalyzerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/DimensionalAnalyzerTest.java
@@ -311,6 +311,30 @@ class DimensionalAnalyzerTest {
         }
 
         @Test
+        void shouldPropagateUnitForSQRTOfOddExponentInput() {
+            // SQRT of a dimensioned quantity with odd exponents should warn
+            // but propagate the original unit for downstream checking
+            TestContext ctx = new TestContext()
+                    .put("Volume", new CompositeUnit(Map.of(Dimension.LENGTH, 3)));
+            var result = analyze("SQRT(Volume)", ctx);
+            assertThat(result.isConsistent()).isFalse();
+            assertThat(result.warnings().getFirst().message()).contains("SQRT");
+            // Should propagate the original unit, not return dimensionless
+            assertThat(result.inferredUnit()).isNotNull();
+            assertThat(result.inferredUnit().isDimensionless()).isFalse();
+        }
+
+        @Test
+        void shouldHalveExponentsForSQRTOfEvenDimensions() {
+            TestContext ctx = new TestContext()
+                    .put("Area", new CompositeUnit(Map.of(Dimension.LENGTH, 2)));
+            var result = analyze("SQRT(Area)", ctx);
+            assertThat(result.isConsistent()).isTrue();
+            assertThat(result.inferredUnit().exponents())
+                    .containsEntry(Dimension.LENGTH, 1);
+        }
+
+        @Test
         void shouldReturnDimensionlessForSTEP() {
             var result = analyze("STEP(10, 5)", new TestContext());
             assertThat(result.inferredUnit().isDimensionless()).isTrue();


### PR DESCRIPTION
## Summary
- SQRT of odd-exponent dimensioned quantities now propagates the original unit instead of returning dimensionless
- Warning still fires, but downstream operations continue to produce meaningful mismatch warnings

## Test plan
- [x] New test: SQRT of odd-exponent input warns but propagates unit
- [x] New test: SQRT of even-exponent input halves exponents correctly
- [x] SpotBugs clean

Closes #625