### PR TITLE
Fix IF function docs to show function-call syntax

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/FunctionDocRegistry.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/FunctionDocRegistry.java
@@ -503,14 +503,14 @@ public final class FunctionDocRegistry {
                 List.of("LOOKUP"));
 
         // ── Conditional ─────────────────────────────────────────────────
-        add(m, "IF", "IF condition THEN a ELSE b", "Conditional expression",
+        add(m, "IF", "IF(condition, a, b)", "Conditional expression",
                 "Special",
                 List.of(p("condition", "expression that evaluates to true (non-zero) or false (zero)"),
                         p("a", "value returned when condition is true"),
                         p("b", "value returned when condition is false")),
                 "Evaluates the condition and returns 'a' if true (non-zero), 'b' if false (zero). "
                         + "Comparisons return 1 for true and 0 for false.",
-                "IF Population > 1000 THEN Growth_Rate ELSE 0",
+                "IF(Population > 1000, Growth_Rate, 0)",
                 List.of());
 
         DOCS = Collections.unmodifiableMap(m);

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/FunctionDocRegistryTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/FunctionDocRegistryTest.java
@@ -77,6 +77,13 @@ class FunctionDocRegistryTest {
     }
 
     @Test
+    void shouldDocumentIFWithFunctionCallSyntax() {
+        FunctionDoc doc = FunctionDocRegistry.get("IF").orElseThrow();
+        assertThat(doc.signature()).isEqualTo("IF(condition, a, b)");
+        assertThat(doc.example()).isEqualTo("IF(Population > 1000, Growth_Rate, 0)");
+    }
+
+    @Test
     void shouldDocumentRandomNormalWith5Parameters() {
         FunctionDoc doc = FunctionDocRegistry.get("RANDOM_NORMAL").orElseThrow();
         assertThat(doc.parameters()).hasSize(5);


### PR DESCRIPTION
## Summary
- Updates `FunctionDocRegistry` IF entry from `IF condition THEN a ELSE b` to `IF(condition, a, b)`
- Updates example from keyword syntax to function-call syntax
- The parser only supports function-call syntax; the old docs were misleading

## Test plan
- [x] Added test verifying signature and example match function-call form
- [x] All tests pass, SpotBugs clean

Closes #764