### PR TITLE
Unify duplicate detection to name-based across all Model add methods

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/Model.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Model.java
@@ -108,9 +108,8 @@ public class Model extends Element {
      */
     public void addArrayedStock(ArrayedStock arrayedStock) {
         for (Stock stock : arrayedStock.getStocks()) {
-            if (!stocks.contains(stock)) {
+            if (stockNames.add(stock.getName())) {
                 stocks.add(stock);
-                stockNames.add(stock.getName());
             }
         }
     }
@@ -129,9 +128,8 @@ public class Model extends Element {
      */
     public void addMultiArrayedStock(MultiArrayedStock multiArrayedStock) {
         for (Stock stock : multiArrayedStock.getStocks()) {
-            if (!stocks.contains(stock)) {
+            if (stockNames.add(stock.getName())) {
                 stocks.add(stock);
-                stockNames.add(stock.getName());
             }
         }
     }
@@ -166,23 +164,19 @@ public class Model extends Element {
 
         modules.add(module);
         for (Stock stock : module.getStocks()) {
-            if (!stocks.contains(stock)) {
-                if (stockNames.contains(stock.getName())) {
-                    log.warn("Module '{}' stock '{}' has same name as existing stock in model '{}'",
-                            module.getName(), stock.getName(), getName());
-                }
+            if (!stockNames.add(stock.getName())) {
+                log.warn("Module '{}' stock '{}' has same name as existing stock in model '{}'"
+                        + " — skipping duplicate", module.getName(), stock.getName(), getName());
+            } else {
                 stocks.add(stock);
-                stockNames.add(stock.getName());
             }
         }
         for (Flow flow : module.getFlows()) {
-            if (!flows.contains(flow)) {
-                if (flowNames.contains(flow.getName())) {
-                    log.warn("Module '{}' flow '{}' has same name as existing flow in model '{}'",
-                            module.getName(), flow.getName(), getName());
-                }
+            if (!flowNames.add(flow.getName())) {
+                log.warn("Module '{}' flow '{}' has same name as existing flow in model '{}'"
+                        + " — skipping duplicate", module.getName(), flow.getName(), getName());
+            } else {
                 flows.add(flow);
-                flowNames.add(flow.getName());
             }
         }
         for (Variable variable : module.getVariables()) {

--- a/courant-engine/src/test/java/systems/courant/sd/model/ModelTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/ModelTest.java
@@ -94,16 +94,16 @@ public class ModelTest {
     }
 
     @Test
-    public void shouldWarnOnModuleWithCollidingStockName() {
+    public void shouldWarnAndSkipModuleWithCollidingStockName() {
         Stock stock = new Stock("Population", 100, THING);
         model.addStock(stock);
 
         Module module = new Module("SubModel");
         module.addStock(new Stock("Population", 200, THING));
 
-        // Stock collisions log a warning but do not throw
+        // Stock name collisions log a warning and skip the duplicate
         model.addModule(module);
-        assertThat(model.getStocks()).hasSize(2);
+        assertThat(model.getStocks()).hasSize(1);
     }
 
     @Test
@@ -197,5 +197,17 @@ public class ModelTest {
         assertThat(model.getFlows()).hasSize(1000);
         assertThatThrownBy(() -> model.addFlow(Flow.create("Flow500", MINUTE, () -> new Quantity(0, THING))))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void shouldSkipDuplicateFlowNameInModule() {
+        model.addFlow(Flow.create("Birth Rate", MINUTE, () -> new Quantity(10, THING)));
+
+        Module module = new Module("SubModel");
+        module.addFlow(Flow.create("Birth Rate", MINUTE, () -> new Quantity(5, THING)));
+
+        model.addModule(module);
+        // Should not add the duplicate — only 1 flow
+        assertThat(model.getFlows()).hasSize(1);
     }
 }


### PR DESCRIPTION
## Summary
- `addArrayedStock` and `addMultiArrayedStock` now use `stockNames.add()` instead of `stocks.contains()` for dedup
- `addModule` now skips duplicate stocks/flows by name (with warning) instead of adding both
- All add paths now consistently use name-based duplicate detection

## Test plan
- [x] Updated existing test to reflect new skip-on-collision behavior
- [x] New test for duplicate flow name in module
- [x] All 21 ModelTest tests pass
- [x] Full reactor compile succeeds
- [x] SpotBugs clean

Closes #592