### PR TITLE
Scope FIND_ZERO mutable holder to child context to prevent shadowing

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -958,11 +958,15 @@ public class ExprCompiler {
                     "FIND_ZERO second argument must be a variable reference", "FIND_ZERO");
         }
         String varName = ref.name();
-        // Register a dedicated mutable holder so the expression reads from it at runtime.
-        // Each FIND_ZERO gets its own holder — no shared mutable state.
+        // Compile the expression in a child context with the mutable holder, so the
+        // holder only shadows the variable within the FIND_ZERO expression — not in
+        // any formulas compiled afterward in the parent context.
         double[] holder = {0.0};
-        context.addMutableHolder(varName, holder);
-        DoubleSupplier expression = compileExpr(args.get(0));
+        CompilationContext childContext = new CompilationContext(
+                context.getUnitRegistry(), context.getCurrentStep(), context);
+        childContext.addMutableHolder(varName, holder);
+        ExprCompiler childCompiler = new ExprCompiler(childContext, resettables);
+        DoubleSupplier expression = childCompiler.compileExpr(args.get(0));
         DoubleSupplier lo = compileExpr(args.get(2));
         DoubleSupplier hi = compileExpr(args.get(3));
         FindZero findZero = FindZero.of(expression, holder, lo, hi);

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
@@ -1413,4 +1413,26 @@ class ExprCompilerTest {
             assertThat(formula.getCurrentValue()).isNaN();
         }
     }
+
+    @Nested
+    @DisplayName("FIND_ZERO scoping")
+    class FindZeroScoping {
+
+        @Test
+        @DisplayName("should not shadow model variable after FIND_ZERO compilation")
+        void shouldNotShadowVariableAfterFindZero() {
+            // Register x as a literal constant with value 5
+            context.addLiteralConstant("x", 5);
+
+            // Compile FIND_ZERO that uses x as the loop variable
+            // FIND_ZERO(x - 3, x, 0, 10) should find x = 3
+            Formula findZeroFormula = compiler.compile("FIND_ZERO(x - 3, x, 0, 10)");
+            assertThat(findZeroFormula.getCurrentValue()).isCloseTo(3.0, within(1e-6));
+
+            // After FIND_ZERO, compiling a new expression referencing x should resolve
+            // to the original model variable (value 5), not the FIND_ZERO holder
+            Formula afterFormula = compiler.compile("x");
+            assertThat(afterFormula.getCurrentValue()).isEqualTo(5.0);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- FIND_ZERO expression is now compiled in a child `CompilationContext` that has the mutable holder
- The holder no longer persists in the parent context, so subsequent formula compilations resolve the real model variable instead of the FIND_ZERO holder

## Test plan
- [x] New test: variable reference after FIND_ZERO resolves to original model element
- [x] All ExprCompiler tests pass
- [x] SpotBugs clean

Closes #622