### PR TITLE
Evaluate IF condition before branches in non-short-circuit mode

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -1080,12 +1080,14 @@ public class ExprCompiler {
             return () -> condition.getAsDouble() != 0
                     ? thenExpr.getAsDouble() : elseExpr.getAsDouble();
         }
-        // IF: evaluate both branches every step so stateful SD functions (SMOOTH, DELAY3,
-        // TREND, etc.) in the untaken branch keep their internal state current.
+        // IF: evaluate condition first, then both branches every step so stateful
+        // SD functions (SMOOTH, DELAY3, TREND, etc.) in the untaken branch keep
+        // their internal state current without influencing the condition result.
         return () -> {
+            double condVal = condition.getAsDouble();
             double thenVal = thenExpr.getAsDouble();
             double elseVal = elseExpr.getAsDouble();
-            return condition.getAsDouble() != 0 ? thenVal : elseVal;
+            return condVal != 0 ? thenVal : elseVal;
         };
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
@@ -1380,6 +1380,28 @@ class ExprCompilerTest {
         }
 
         @Test
+        void shouldEvaluateConditionBeforeBranchesInNonShortCircuit() {
+            // The condition depends on a value. Both branches have side effects
+            // that could change the value. Condition must be evaluated first.
+            double[] counter = {0};
+            context.addVariable("counter",
+                    new systems.courant.sd.model.Variable("counter",
+                            ItemUnits.THING, () -> counter[0]));
+            context.addVariable("inc",
+                    new systems.courant.sd.model.Variable("inc",
+                            ItemUnits.THING, () -> { counter[0]++; return 1.0; }));
+
+            // counter starts at 0, so condition (counter > 0) is false.
+            // Both branches evaluate 'inc' which increments counter.
+            // Without the fix, branches evaluate first, making counter > 0 true.
+            Formula formula = compiler.compile("IF(counter > 0, inc, inc + 10)");
+            double result = formula.getCurrentValue();
+            // Condition evaluated first (counter=0, false), then branches run.
+            // Should return else branch value: inc + 10 = 1 + 10 = 11
+            assertThat(result).isEqualTo(11.0);
+        }
+
+        @Test
         void shouldDistinguishIfFromIfShort() {
             Expr ifExpr = ExprParser.parse("IF(x > 0, x, 0)");
             Expr ifShortExpr = ExprParser.parse("IF_SHORT(x > 0, x, 0)");


### PR DESCRIPTION
## Summary
- In non-short-circuit `IF`, condition was evaluated after both branches, so stateful functions (SMOOTH, DELAY) in branches could modify state that the condition depends on, returning the wrong branch
- Now evaluates condition first, then both branches (to keep stateful functions current), then selects based on the pre-branch condition value

## Test plan
- [x] Added test verifying condition is evaluated before branches
- [x] All existing IF/IF_SHORT tests pass
- [x] SpotBugs clean

Closes #624