### PR TITLE
Improve unit handling for imported models

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
@@ -1,10 +1,12 @@
 package systems.courant.sd.measure;
 
 import systems.courant.sd.measure.units.dimensionless.DimensionlessUnits;
+import systems.courant.sd.measure.units.item.ItemUnit;
 import systems.courant.sd.measure.units.item.ItemUnits;
 import systems.courant.sd.measure.units.length.LengthUnits;
 import systems.courant.sd.measure.units.mass.MassUnits;
 import systems.courant.sd.measure.units.money.MoneyUnits;
+import systems.courant.sd.measure.units.money.NamedCurrency;
 import systems.courant.sd.measure.units.temperature.TemperatureUnits;
 import systems.courant.sd.measure.units.time.TimeUnits;
 import systems.courant.sd.measure.units.volume.VolumeUnits;
@@ -18,8 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Maps unit name strings to {@link Unit} objects. Auto-registers all built-in unit enums.
- * Custom units (e.g. {@link systems.courant.sd.measure.units.item.ItemUnit})
- * can be registered dynamically.
+ * Custom units (e.g. {@link ItemUnit}) can be registered dynamically.
  *
  * <p>Lookup is case-sensitive with a case-insensitive fallback.
  */
@@ -28,28 +29,27 @@ public class UnitRegistry {
     private static final Logger log = LoggerFactory.getLogger(UnitRegistry.class);
     private static final int MAX_CUSTOM_UNITS = 10_000;
 
+    /** Dimensionless-equivalent names (lowercase). Resolved to DIMENSIONLESS. */
+    private static final Set<String> DIMENSIONLESS_NAMES = Set.of(
+            "dmnl", "units", "unit", "dimensionless",
+            "fraction", "percent", "percentage", "ratio", "index");
+
     /**
-     * Unit names that should be silently accepted as dimensionless/item units
-     * without a "possible typo" warning. Lowercase for case-insensitive matching.
-     * Includes Vensim conventions, common physical-sounding labels, and generic quantity words.
+     * Currency names (lowercase) that should be created as {@link NamedCurrency}
+     * in the MONEY dimension rather than as ITEM units.
      */
-    private static final Set<String> KNOWN_ACCEPTABLE_NAMES = Set.of(
-            // Dimensionless conventions
-            "units", "unit", "dmnl", "dimensionless",
-            "fraction", "percent", "percentage", "ratio", "index",
-            // Domain-specific countable labels commonly used in Vensim models
-            "person", "persons", "people",
-            "patient", "patients",
-            "vehicle", "vehicles",
-            "ship", "ships",
-            "fish",
-            "widget", "widgets",
-            "item", "items",
-            "job", "jobs",
-            "order", "orders",
-            "call", "calls",
-            "trip", "trips"
-    );
+    private static final Set<String> CURRENCY_NAMES = Set.of(
+            // Major currencies
+            "eur", "euro", "euros", "gbp", "jpy", "chf", "cad", "aud", "nzd",
+            "cny", "yuan", "inr", "rupee", "rupees", "krw", "won",
+            "sek", "nok", "dkk", "sgd", "hkd", "brl", "real", "reais",
+            "mxn", "peso", "pesos", "zar", "rand",
+            // USD aliases
+            "dollar", "dollars", "$", "us$",
+            // Scale-prefixed
+            "m$", "thou $", "k$",
+            // Generic money labels used in SD models
+            "currency", "money", "cost", "revenue", "price");
 
     private final Map<String, Unit> byName = new ConcurrentHashMap<>();
     private final Map<String, Unit> byNameLower = new ConcurrentHashMap<>();
@@ -68,6 +68,8 @@ public class UnitRegistry {
         registerAll(TemperatureUnits.values());
         registerAll(DimensionlessUnits.values());
         registerTimeUnitAliases();
+        registerCurrencyAliases();
+        registerAreaUnits();
     }
 
     /**
@@ -80,6 +82,43 @@ public class UnitRegistry {
             byName.put(plural, tu);
             byNameLower.put(plural.toLowerCase(), tu);
         }
+    }
+
+    /**
+     * Pre-registers common currency aliases as MONEY-dimension units.
+     */
+    private void registerCurrencyAliases() {
+        registerAlias("dollar", MoneyUnits.USD);
+        registerAlias("dollars", MoneyUnits.USD);
+        registerAlias("$", MoneyUnits.USD);
+        registerAlias("US$", MoneyUnits.USD);
+    }
+
+    /**
+     * Registers area units as composite Length^2 constants with conversion factors to m^2.
+     */
+    private void registerAreaUnits() {
+        // hectare = 10,000 m^2
+        registerBuiltIn(new AreaUnit("hectare", 10_000.0));
+        registerBuiltIn(new AreaUnit("hectares", 10_000.0));
+        registerBuiltIn(new AreaUnit("ha", 10_000.0));
+        // km^2 = 1,000,000 m^2
+        registerBuiltIn(new AreaUnit("km2", 1_000_000.0));
+        registerBuiltIn(new AreaUnit("km²", 1_000_000.0));
+        // acre = 4,046.8564224 m^2
+        registerBuiltIn(new AreaUnit("acre", 4_046.8564224));
+        registerBuiltIn(new AreaUnit("acres", 4_046.8564224));
+    }
+
+    /**
+     * Registers an alias that maps to an existing unit.
+     *
+     * @param alias  the alias name
+     * @param target the unit the alias resolves to
+     */
+    public void registerAlias(String alias, Unit target) {
+        byName.put(alias, target);
+        byNameLower.put(alias.toLowerCase(), target);
     }
 
     private void registerAll(Unit[] units) {
@@ -122,8 +161,16 @@ public class UnitRegistry {
 
     /**
      * Resolves a unit by name. Case-sensitive first, then case-insensitive fallback.
-     * If the name is not found, creates and registers a new
-     * {@link systems.courant.sd.measure.units.item.ItemUnit} with that name.
+     *
+     * <p>If the name is not found:
+     * <ul>
+     *   <li>Dimensionless-equivalent names resolve to {@link DimensionlessUnits#DIMENSIONLESS}</li>
+     *   <li>Currency names create a {@link NamedCurrency} in the MONEY dimension</li>
+     *   <li>All other names create an {@link ItemUnit} in the ITEM dimension</li>
+     * </ul>
+     *
+     * <p>Imported models are expected to carry arbitrary domain-specific names (e.g.,
+     * "Deer", "Widget", "Ship"), so auto-creation is logged at DEBUG level.
      *
      * @param name the unit name
      * @return the resolved unit
@@ -142,21 +189,27 @@ public class UnitRegistry {
             if (unit != null) {
                 return unit;
             }
-            // Auto-create custom ItemUnit for unknown names
-            // Treat dimensionless-equivalent names as DIMENSIONLESS
             String lower = name.toLowerCase();
-            if (Set.of("dmnl", "units", "unit", "dimensionless",
-                    "fraction", "percent", "percentage", "ratio", "index").contains(lower)) {
-                Unit dmnl = systems.courant.sd.measure.units.dimensionless.DimensionlessUnits.DIMENSIONLESS;
+
+            // Dimensionless-equivalent names
+            if (DIMENSIONLESS_NAMES.contains(lower)) {
+                Unit dmnl = DimensionlessUnits.DIMENSIONLESS;
                 byName.put(name, dmnl);
                 byNameLower.put(lower, dmnl);
                 return dmnl;
             }
-            if (!KNOWN_ACCEPTABLE_NAMES.contains(lower)) {
-                log.warn("Auto-creating unit for unknown name '{}' — possible typo", name);
+
+            // Currency names → MONEY dimension
+            if (CURRENCY_NAMES.contains(lower)) {
+                log.debug("Auto-creating currency unit for '{}'", name);
+                NamedCurrency currency = new NamedCurrency(name);
+                register(currency);
+                return currency;
             }
-            systems.courant.sd.measure.units.item.ItemUnit custom =
-                    new systems.courant.sd.measure.units.item.ItemUnit(name);
+
+            // All other names → ITEM dimension
+            log.debug("Auto-creating item unit for '{}'", name);
+            ItemUnit custom = new ItemUnit(name);
             register(custom);
             return custom;
         }
@@ -194,5 +247,57 @@ public class UnitRegistry {
             return unit;
         }
         return byNameLower.get(name.toLowerCase());
+    }
+
+    /**
+     * A simple area unit (Length^2) with a conversion factor to square meters.
+     */
+    private static final class AreaUnit implements Unit {
+
+        private final String name;
+        private final double sqMeters;
+
+        AreaUnit(String name, double sqMeters) {
+            this.name = name;
+            this.sqMeters = sqMeters;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public Dimension getDimension() {
+            return Dimension.LENGTH;
+        }
+
+        /**
+         * Returns the ratio to the base length unit (Meter) such that
+         * dimensional analysis treats this as Length^2. The actual conversion
+         * factor is sqrt(sqMeters) so that area = unit * unit = sqMeters m^2.
+         */
+        @Override
+        public double ratioToBaseUnit() {
+            return Math.sqrt(sqMeters);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            AreaUnit areaUnit = (AreaUnit) o;
+            return name.equals(areaUnit.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
     }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/measure/units/money/NamedCurrency.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/units/money/NamedCurrency.java
@@ -1,0 +1,63 @@
+package systems.courant.sd.measure.units.money;
+
+import systems.courant.sd.measure.Dimension;
+import systems.courant.sd.measure.Unit;
+
+/**
+ * A dynamic currency unit for the {@link Dimension#MONEY} dimension,
+ * parallel to {@link systems.courant.sd.measure.units.item.ItemUnit} for items.
+ *
+ * <p>Imported models carry currency names like "EURO", "GBP", "JPY" that don't
+ * map to the built-in {@link MoneyUnits} enum. This class allows them to be
+ * created dynamically while remaining in the MONEY dimension (rather than
+ * falling back to ITEM).
+ *
+ * <p>All named currencies use ratio 1.0 (no exchange-rate conversion).
+ * Two instances with the same name are considered equal.
+ */
+public class NamedCurrency implements Unit {
+
+    private final String name;
+
+    /**
+     * Creates a new named currency unit.
+     *
+     * @param name the display name (e.g., "EUR", "EURO", "GBP")
+     */
+    public NamedCurrency(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Dimension getDimension() {
+        return Dimension.MONEY;
+    }
+
+    @Override
+    public double ratioToBaseUnit() {
+        return 1.0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NamedCurrency that = (NamedCurrency) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/courant-engine/src/test/java/systems/courant/sd/measure/UnitRegistryTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/UnitRegistryTest.java
@@ -2,6 +2,8 @@ package systems.courant.sd.measure;
 
 import systems.courant.sd.measure.units.dimensionless.DimensionlessUnits;
 import systems.courant.sd.measure.units.item.ItemUnit;
+import systems.courant.sd.measure.units.money.MoneyUnits;
+import systems.courant.sd.measure.units.money.NamedCurrency;
 import systems.courant.sd.measure.units.time.TimeUnits;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -193,11 +195,12 @@ class UnitRegistryTest {
         }
 
         @Test
-        @DisplayName("should silently create unit for known acceptable names like 'patient'")
-        void shouldSilentlyCreateKnownAcceptableName() {
-            Unit unit = registry.resolve("patient");
+        @DisplayName("should silently create unit for domain-specific names like 'Deer'")
+        void shouldSilentlyCreateDomainSpecificName() {
+            Unit unit = registry.resolve("Deer");
             assertThat(unit).isNotNull();
-            assertThat(unit.getName()).isEqualTo("patient");
+            assertThat(unit.getName()).isEqualTo("Deer");
+            assertThat(unit).isInstanceOf(ItemUnit.class);
         }
 
         @Test
@@ -212,6 +215,117 @@ class UnitRegistryTest {
         void shouldResolvePercentToDimensionless() {
             Unit unit = registry.resolve("percent");
             assertThat(unit).isSameAs(DimensionlessUnits.DIMENSIONLESS);
+        }
+    }
+
+    @Nested
+    @DisplayName("Currency recognition (#749)")
+    class CurrencyRecognition {
+
+        @Test
+        @DisplayName("should resolve 'EURO' to a NamedCurrency in MONEY dimension")
+        void shouldResolveEuroToMoney() {
+            Unit unit = registry.resolve("EURO");
+            assertThat(unit).isInstanceOf(NamedCurrency.class);
+            assertThat(unit.getDimension()).isSameAs(Dimension.MONEY);
+            assertThat(unit.getName()).isEqualTo("EURO");
+        }
+
+        @Test
+        @DisplayName("should resolve 'GBP' to a NamedCurrency in MONEY dimension")
+        void shouldResolveGbpToMoney() {
+            Unit unit = registry.resolve("GBP");
+            assertThat(unit).isInstanceOf(NamedCurrency.class);
+            assertThat(unit.getDimension()).isSameAs(Dimension.MONEY);
+        }
+
+        @Test
+        @DisplayName("should resolve 'dollar' to USD via alias")
+        void shouldResolveDollarAlias() {
+            Unit unit = registry.find("dollar");
+            assertThat(unit).isSameAs(MoneyUnits.USD);
+        }
+
+        @Test
+        @DisplayName("should resolve '$' to USD via alias")
+        void shouldResolveDollarSign() {
+            Unit unit = registry.find("$");
+            assertThat(unit).isSameAs(MoneyUnits.USD);
+        }
+
+        @Test
+        @DisplayName("should resolve 'M$' as currency")
+        void shouldResolveMDollar() {
+            Unit unit = registry.resolve("M$");
+            assertThat(unit.getDimension()).isSameAs(Dimension.MONEY);
+        }
+
+        @Test
+        @DisplayName("should resolve currency names case-insensitively")
+        void shouldResolveCurrencyCaseInsensitive() {
+            Unit euro = registry.resolve("euro");
+            assertThat(euro.getDimension()).isSameAs(Dimension.MONEY);
+
+            Unit yen = registry.resolve("JPY");
+            assertThat(yen.getDimension()).isSameAs(Dimension.MONEY);
+        }
+    }
+
+    @Nested
+    @DisplayName("Area unit recognition (#749)")
+    class AreaUnits {
+
+        @Test
+        @DisplayName("should find 'hectare' as a built-in unit")
+        void shouldFindHectare() {
+            Unit unit = registry.find("hectare");
+            assertThat(unit).isNotNull();
+            assertThat(unit.getDimension()).isSameAs(Dimension.LENGTH);
+        }
+
+        @Test
+        @DisplayName("should find 'km2' as a built-in unit")
+        void shouldFindKm2() {
+            Unit unit = registry.find("km2");
+            assertThat(unit).isNotNull();
+            assertThat(unit.getDimension()).isSameAs(Dimension.LENGTH);
+        }
+
+        @Test
+        @DisplayName("should find 'acre' as a built-in unit")
+        void shouldFindAcre() {
+            Unit unit = registry.find("acre");
+            assertThat(unit).isNotNull();
+            assertThat(unit.getDimension()).isSameAs(Dimension.LENGTH);
+        }
+
+        @Test
+        @DisplayName("should find 'hectares' (plural) as a built-in unit")
+        void shouldFindHectaresPlural() {
+            Unit unit = registry.find("hectares");
+            assertThat(unit).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Alias registration (#749)")
+    class AliasRegistration {
+
+        @Test
+        @DisplayName("registerAlias should make name resolve to target unit")
+        void shouldRegisterAlias() {
+            UnitRegistry reg = new UnitRegistry();
+            reg.registerAlias("personen", reg.find("Person"));
+            assertThat(reg.find("personen")).isNotNull();
+            assertThat(reg.find("personen").getName()).isEqualTo("Person");
+        }
+
+        @Test
+        @DisplayName("alias should be case-insensitive")
+        void shouldRegisterAliasCaseInsensitive() {
+            UnitRegistry reg = new UnitRegistry();
+            reg.registerAlias("Persoon", reg.find("Person"));
+            assertThat(reg.find("persoon")).isNotNull();
         }
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/measure/units/money/NamedCurrencyTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/units/money/NamedCurrencyTest.java
@@ -1,0 +1,51 @@
+package systems.courant.sd.measure.units.money;
+
+import systems.courant.sd.measure.Dimension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("NamedCurrency")
+class NamedCurrencyTest {
+
+    @Test
+    void shouldHaveMoneyDimension() {
+        NamedCurrency eur = new NamedCurrency("EUR");
+        assertThat(eur.getDimension()).isSameAs(Dimension.MONEY);
+    }
+
+    @Test
+    void shouldReturnRatioOfOne() {
+        NamedCurrency gbp = new NamedCurrency("GBP");
+        assertThat(gbp.ratioToBaseUnit()).isEqualTo(1.0);
+    }
+
+    @Test
+    void shouldPreserveName() {
+        NamedCurrency jpy = new NamedCurrency("JPY");
+        assertThat(jpy.getName()).isEqualTo("JPY");
+        assertThat(jpy.toString()).isEqualTo("JPY");
+    }
+
+    @Test
+    void shouldBeEqualForSameName() {
+        NamedCurrency a = new NamedCurrency("EUR");
+        NamedCurrency b = new NamedCurrency("EUR");
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void shouldNotBeEqualForDifferentName() {
+        NamedCurrency eur = new NamedCurrency("EUR");
+        NamedCurrency gbp = new NamedCurrency("GBP");
+        assertThat(eur).isNotEqualTo(gbp);
+    }
+
+    @Test
+    void shouldNotBeEqualToNull() {
+        NamedCurrency eur = new NamedCurrency("EUR");
+        assertThat(eur).isNotEqualTo(null);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `NamedCurrency` class for dynamic MONEY-dimension units (EUR, GBP, JPY, etc.) — currencies no longer misclassified as ITEM
- Adds `registerAlias()` to `UnitRegistry` for importer synonym mapping (e.g., `personen → Person`)
- Pre-registers common currency names/aliases (EUR, GBP, dollar, $, M$, etc.) as MONEY-dimension units
- Registers area units (hectare, acre, km2) as built-in LENGTH-dimension units
- Downgrades auto-creation log from WARN to DEBUG — imported models are expected to carry arbitrary domain-specific names

Closes #749