### PR TITLE
Support exogenous input time-series driven by external data

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/TimeSeries.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/TimeSeries.java
@@ -1,0 +1,119 @@
+package systems.courant.sd.model;
+
+import java.util.Arrays;
+import java.util.function.DoubleSupplier;
+
+/**
+ * A time-indexed data series that implements {@link Formula}, providing
+ * exogenous input values interpolated from external data at each time step.
+ *
+ * <p>Unlike a {@link LookupTable} (which maps an arbitrary input expression
+ * to an output value), a TimeSeries maps simulation time to a data value.
+ * This is the mechanism for driving a model with observed real-world data.
+ *
+ * <p>Interpolation modes:
+ * <ul>
+ *     <li><b>LINEAR</b> — linear interpolation between data points</li>
+ *     <li><b>STEP</b> — step function (holds each value until the next data point)</li>
+ * </ul>
+ *
+ * <p>Extrapolation modes (for times outside the data range):
+ * <ul>
+ *     <li><b>HOLD</b> — holds the first/last data value (default)</li>
+ *     <li><b>ZERO</b> — returns 0 outside the data range</li>
+ * </ul>
+ */
+public class TimeSeries implements Formula {
+
+    private final double[] timeValues;
+    private final double[] dataValues;
+    private final DoubleSupplier timeSupplier;
+    private final boolean stepInterpolation;
+    private final boolean zeroExtrapolation;
+
+    private TimeSeries(double[] timeValues, double[] dataValues,
+                       DoubleSupplier timeSupplier,
+                       boolean stepInterpolation, boolean zeroExtrapolation) {
+        this.timeValues = timeValues;
+        this.dataValues = dataValues;
+        this.timeSupplier = timeSupplier;
+        this.stepInterpolation = stepInterpolation;
+        this.zeroExtrapolation = zeroExtrapolation;
+    }
+
+    /**
+     * Creates a time series with linear interpolation and hold extrapolation.
+     */
+    public static TimeSeries linear(double[] timeValues, double[] dataValues,
+                                     DoubleSupplier timeSupplier) {
+        return new TimeSeries(timeValues.clone(), dataValues.clone(),
+                timeSupplier, false, false);
+    }
+
+    /**
+     * Creates a time series with step interpolation and hold extrapolation.
+     */
+    public static TimeSeries step(double[] timeValues, double[] dataValues,
+                                   DoubleSupplier timeSupplier) {
+        return new TimeSeries(timeValues.clone(), dataValues.clone(),
+                timeSupplier, true, false);
+    }
+
+    /**
+     * Creates a time series with configurable interpolation and extrapolation.
+     *
+     * @param timeValues     sorted ascending time points
+     * @param dataValues     data values at each time point
+     * @param timeSupplier   supplies the current simulation time
+     * @param interpolation  "LINEAR" or "STEP"
+     * @param extrapolation  "HOLD" or "ZERO"
+     */
+    public static TimeSeries create(double[] timeValues, double[] dataValues,
+                                     DoubleSupplier timeSupplier,
+                                     String interpolation, String extrapolation) {
+        boolean isStep = "STEP".equalsIgnoreCase(interpolation);
+        boolean isZero = "ZERO".equalsIgnoreCase(extrapolation);
+        return new TimeSeries(timeValues.clone(), dataValues.clone(),
+                timeSupplier, isStep, isZero);
+    }
+
+    @Override
+    public double getCurrentValue() {
+        double t = timeSupplier.getAsDouble();
+
+        // Before first data point
+        if (t <= timeValues[0]) {
+            return zeroExtrapolation ? 0.0 : dataValues[0];
+        }
+
+        // After last data point
+        if (t >= timeValues[timeValues.length - 1]) {
+            return zeroExtrapolation ? 0.0 : dataValues[dataValues.length - 1];
+        }
+
+        // Binary search for the interval containing t
+        int idx = Arrays.binarySearch(timeValues, t);
+        if (idx >= 0) {
+            // Exact match
+            return dataValues[idx];
+        }
+
+        // idx = -(insertion point) - 1, so insertion point = -(idx + 1)
+        int insertionPoint = -(idx + 1);
+        int lo = insertionPoint - 1;
+        int hi = insertionPoint;
+
+        if (stepInterpolation) {
+            // Step function: hold the value at the lower bound
+            return dataValues[lo];
+        }
+
+        // Linear interpolation
+        double t0 = timeValues[lo];
+        double t1 = timeValues[hi];
+        double v0 = dataValues[lo];
+        double v1 = dataValues[hi];
+        double fraction = (t - t0) / (t1 - t0);
+        return v0 + fraction * (v1 - v0);
+    }
+}

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ModelCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ModelCompiler.java
@@ -10,7 +10,9 @@ import systems.courant.sd.model.Model;
 import systems.courant.sd.model.Module;
 import systems.courant.sd.model.NegativeValuePolicy;
 import systems.courant.sd.model.Stock;
+import systems.courant.sd.model.TimeSeries;
 import systems.courant.sd.model.Variable;
+import systems.courant.sd.model.def.TimeSeriesDef;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.DefinitionValidator;
 import systems.courant.sd.model.def.FlowDef;
@@ -129,6 +131,7 @@ public class ModelCompiler {
         resolveInitialExpressions(def.stocks(), context);
 
         buildLookupTables(def, context);
+        buildTimeSeries(def, model, context, stepHolder);
 
         // Variables — use DoubleSupplier[] holders for indirection
         List<DoubleSupplier[]> auxHolders = new ArrayList<>();
@@ -195,6 +198,7 @@ public class ModelCompiler {
         resolveInitialExpressions(innerDef.stocks(), moduleContext);
 
         buildLookupTables(innerDef, moduleContext);
+        buildTimeSeries(innerDef, module, moduleContext, stepHolder);
 
         // Variables with holder indirection
         List<DoubleSupplier[]> auxHolders = new ArrayList<>();
@@ -291,6 +295,33 @@ public class ModelCompiler {
             }
             context.addLookupTable(tDef.name(), table, inputHolder);
             context.addLookupTableDef(tDef.name(), tDef);
+        }
+    }
+
+    private void buildTimeSeries(ModelDefinition def, Model model,
+                                  CompilationContext context, long[] stepHolder) {
+        buildTimeSeriesInto(def, model::addVariable, context, stepHolder);
+    }
+
+    private void buildTimeSeries(ModelDefinition def, Module module,
+                                  CompilationContext context, long[] stepHolder) {
+        buildTimeSeriesInto(def, module::addVariable, context, stepHolder);
+    }
+
+    private void buildTimeSeriesInto(ModelDefinition def,
+                                      java.util.function.Consumer<Variable> variableAdder,
+                                      CompilationContext context, long[] stepHolder) {
+        for (TimeSeriesDef tsDef : def.timeSeries()) {
+            double[] dtHolder = context.getDtHolder();
+            DoubleSupplier timeSupplier = () -> stepHolder[0] * dtHolder[0];
+            TimeSeries ts = TimeSeries.create(
+                    tsDef.timeValues(), tsDef.dataValues(),
+                    timeSupplier, tsDef.interpolation(), tsDef.extrapolation());
+            Unit unit = tsDef.unit() != null ? unitRegistry.resolve(tsDef.unit())
+                    : unitRegistry.resolve("Thing");
+            Variable variable = new Variable(tsDef.name(), unit, ts::getCurrentValue);
+            variableAdder.accept(variable);
+            context.addVariable(tsDef.name(), variable);
         }
     }
 

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/DefinitionValidator.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/DefinitionValidator.java
@@ -73,6 +73,9 @@ public final class DefinitionValidator {
         for (CldVariableDef v : def.cldVariables()) {
             checkDuplicateName(v.name(), allNames, lowerToOriginal, errors);
         }
+        for (TimeSeriesDef ts : def.timeSeries()) {
+            checkDuplicateName(ts.name(), allNames, lowerToOriginal, errors);
+        }
 
         // Build set of stock names for flow source/sink validation
         Set<String> stockNames = new HashSet<>();

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/ModelDefinition.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/ModelDefinition.java
@@ -26,6 +26,7 @@ import java.util.List;
  * @param defaultSimulation optional default simulation settings
  * @param metadata optional attribution and licensing metadata
  * @param referenceDatasets observed/expected time-series datasets for model validation
+ * @param timeSeries exogenous input time-series definitions driven by external data
  */
 public record ModelDefinition(
         String name,
@@ -43,8 +44,28 @@ public record ModelDefinition(
         List<ViewDef> views,
         SimulationSettings defaultSimulation,
         ModelMetadata metadata,
-        List<ReferenceDataset> referenceDatasets
+        List<ReferenceDataset> referenceDatasets,
+        List<TimeSeriesDef> timeSeries
 ) {
+
+    /**
+     * Backward-compatible constructor without time series.
+     */
+    public ModelDefinition(
+            String name, String comment, ModuleInterface moduleInterface,
+            List<StockDef> stocks, List<FlowDef> flows,
+            List<VariableDef> variables,
+            List<LookupTableDef> lookupTables, List<ModuleInstanceDef> modules,
+            List<SubscriptDef> subscripts,
+            List<CldVariableDef> cldVariables, List<CausalLinkDef> causalLinks,
+            List<CommentDef> comments,
+            List<ViewDef> views, SimulationSettings defaultSimulation,
+            ModelMetadata metadata, List<ReferenceDataset> referenceDatasets) {
+        this(name, comment, moduleInterface, stocks, flows, variables,
+                lookupTables, modules, subscripts, cldVariables, causalLinks,
+                comments, views, defaultSimulation, metadata, referenceDatasets,
+                List.of());
+    }
 
     /**
      * Backward-compatible constructor without comments or reference datasets.
@@ -60,7 +81,8 @@ public record ModelDefinition(
             ModelMetadata metadata, List<ReferenceDataset> referenceDatasets) {
         this(name, comment, moduleInterface, stocks, flows, variables,
                 lookupTables, modules, subscripts, cldVariables, causalLinks,
-                List.of(), views, defaultSimulation, metadata, referenceDatasets);
+                List.of(), views, defaultSimulation, metadata, referenceDatasets,
+                List.of());
     }
 
     /**
@@ -77,7 +99,8 @@ public record ModelDefinition(
             ModelMetadata metadata) {
         this(name, comment, moduleInterface, stocks, flows, variables,
                 lookupTables, modules, subscripts, cldVariables, causalLinks,
-                List.of(), views, defaultSimulation, metadata, List.of());
+                List.of(), views, defaultSimulation, metadata, List.of(),
+                List.of());
     }
 
     /**
@@ -93,7 +116,8 @@ public record ModelDefinition(
             List<ViewDef> views, SimulationSettings defaultSimulation) {
         this(name, comment, moduleInterface, stocks, flows, variables,
                 lookupTables, modules, subscripts, cldVariables, causalLinks,
-                List.of(), views, defaultSimulation, null, List.of());
+                List.of(), views, defaultSimulation, null, List.of(),
+                List.of());
     }
 
     /**
@@ -108,7 +132,8 @@ public record ModelDefinition(
             List<ViewDef> views, SimulationSettings defaultSimulation) {
         this(name, comment, moduleInterface, stocks, flows, variables,
                 lookupTables, modules, subscripts, List.of(), List.of(),
-                List.of(), views, defaultSimulation, null, List.of());
+                List.of(), views, defaultSimulation, null, List.of(),
+                List.of());
     }
 
     public ModelDefinition {
@@ -126,6 +151,7 @@ public record ModelDefinition(
         comments = comments == null ? List.of() : List.copyOf(comments);
         views = views == null ? List.of() : List.copyOf(views);
         referenceDatasets = referenceDatasets == null ? List.of() : List.copyOf(referenceDatasets);
+        timeSeries = timeSeries == null ? List.of() : List.copyOf(timeSeries);
     }
 
     /**
@@ -150,6 +176,7 @@ public record ModelDefinition(
         comments.forEach(b::comment);
         views.forEach(b::view);
         referenceDatasets.forEach(b::referenceDataset);
+        timeSeries.forEach(b::timeSeries);
         return b;
     }
 
@@ -195,6 +222,7 @@ public record ModelDefinition(
         return new ModelDefinition(name, comment, moduleInterface,
                 stocks, flows, merged,
                 lookupTables, modules, subscripts, cldVariables, causalLinks,
-                comments, views, defaultSimulation, metadata, List.of());
+                comments, views, defaultSimulation, metadata, List.of(),
+                List.of());
     }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/ModelDefinitionBuilder.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/ModelDefinitionBuilder.java
@@ -25,6 +25,7 @@ public class ModelDefinitionBuilder {
     private final List<CommentDef> comments = new ArrayList<>();
     private final List<ViewDef> views = new ArrayList<>();
     private final List<ReferenceDataset> referenceDatasets = new ArrayList<>();
+    private final List<TimeSeriesDef> timeSeries = new ArrayList<>();
     private SimulationSettings defaultSimulation;
     private ModelMetadata metadata;
 
@@ -500,6 +501,32 @@ public class ModelDefinitionBuilder {
     public ModelDefinitionBuilder clearReferenceDatasets() { referenceDatasets.clear(); return this; }
 
     /**
+     * Adds an exogenous input time-series definition.
+     *
+     * @param tsDef the time series definition
+     * @return this builder
+     */
+    public ModelDefinitionBuilder timeSeries(TimeSeriesDef tsDef) {
+        timeSeries.add(tsDef);
+        return this;
+    }
+
+    /**
+     * Adds an exogenous input time-series with default interpolation (linear) and extrapolation (hold).
+     *
+     * @param name       the variable name
+     * @param timeValues the time points
+     * @param dataValues the data values
+     * @param unit       the unit of measure (may be null)
+     * @return this builder
+     */
+    public ModelDefinitionBuilder timeSeries(String name, double[] timeValues,
+                                             double[] dataValues, String unit) {
+        timeSeries.add(new TimeSeriesDef(name, timeValues, dataValues, unit));
+        return this;
+    }
+
+    /**
      * Builds and returns an immutable {@link ModelDefinition} from the accumulated state.
      * The model name must have been set via {@link #name(String)} before calling this method.
      *
@@ -520,6 +547,7 @@ public class ModelDefinitionBuilder {
                 name, comment, moduleInterface,
                 stocks, flows, variables, lookupTables,
                 modules, subscripts, cldVariables, causalLinks,
-                comments, views, defaultSimulation, metadata, referenceDatasets);
+                comments, views, defaultSimulation, metadata, referenceDatasets,
+                timeSeries);
     }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/TimeSeriesDef.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/TimeSeriesDef.java
@@ -1,0 +1,59 @@
+package systems.courant.sd.model.def;
+
+/**
+ * Definition of an exogenous input time-series that drives a model variable
+ * with external data rather than an equation.
+ *
+ * <p>At each simulation time step, the value is obtained by interpolating the
+ * provided data points. This supports scenarios where a model is driven by
+ * observed real-world data (e.g., historical order volumes, reported case counts).
+ *
+ * @param name           the variable name
+ * @param timeValues     the time points at which data is available (must be sorted ascending)
+ * @param dataValues     the data values at each time point (same length as timeValues)
+ * @param unit           the unit of measure (may be null)
+ * @param comment        optional description
+ * @param interpolation  interpolation mode: "LINEAR" (default) or "STEP"
+ * @param extrapolation  extrapolation mode: "HOLD" (default, holds last value) or "ZERO"
+ */
+public record TimeSeriesDef(
+        String name,
+        double[] timeValues,
+        double[] dataValues,
+        String unit,
+        String comment,
+        String interpolation,
+        String extrapolation
+) {
+
+    public TimeSeriesDef {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Time series name must not be blank");
+        }
+        if (timeValues == null || dataValues == null) {
+            throw new IllegalArgumentException("Time series data must not be null");
+        }
+        if (timeValues.length != dataValues.length) {
+            throw new IllegalArgumentException(
+                    "timeValues and dataValues must have the same length");
+        }
+        if (timeValues.length == 0) {
+            throw new IllegalArgumentException("Time series must have at least one data point");
+        }
+        timeValues = timeValues.clone();
+        dataValues = dataValues.clone();
+        if (interpolation == null) {
+            interpolation = "LINEAR";
+        }
+        if (extrapolation == null) {
+            extrapolation = "HOLD";
+        }
+    }
+
+    /**
+     * Convenience constructor with default interpolation and extrapolation.
+     */
+    public TimeSeriesDef(String name, double[] timeValues, double[] dataValues, String unit) {
+        this(name, timeValues, dataValues, unit, null, "LINEAR", "HOLD");
+    }
+}

--- a/courant-engine/src/test/java/systems/courant/sd/integration/TimeSeriesIntegrationTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/integration/TimeSeriesIntegrationTest.java
@@ -1,0 +1,70 @@
+package systems.courant.sd.integration;
+
+import systems.courant.sd.Simulation;
+import systems.courant.sd.model.Stock;
+import systems.courant.sd.model.Variable;
+import systems.courant.sd.model.compile.CompiledModel;
+import systems.courant.sd.model.compile.ModelCompiler;
+import systems.courant.sd.model.def.FlowDef;
+import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.ModelDefinitionBuilder;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@DisplayName("TimeSeries integration (#481)")
+class TimeSeriesIntegrationTest {
+
+    @Test
+    @DisplayName("should drive a stock with an exogenous time-series input")
+    void shouldDriveStockWithTimeSeries() {
+        // External data: orders arrive at rate [10, 20, 30, 20, 10] over time 0-4
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("ExogenousInput")
+                .defaultSimulation("Day", 4, "Day")
+                .timeSeries("order_rate",
+                        new double[]{0, 1, 2, 3, 4},
+                        new double[]{10, 20, 30, 20, 10},
+                        "Thing/Day")
+                .stock("Backlog", 0.0, "Thing")
+                .flow(new FlowDef("orders_in", "order_rate", "Day", null, "Backlog"))
+                .build();
+
+        CompiledModel compiled = new ModelCompiler().compile(def);
+        Simulation sim = compiled.createSimulation();
+        sim.execute();
+
+        // After simulation, check the stock value
+        Stock backlog = compiled.getModel().getStocks().stream()
+                .filter(s -> s.getName().equals("Backlog"))
+                .findFirst().orElseThrow();
+
+        // With dt=1, 5 steps (0→4): rate=10+20+30+20+10 = 90
+        assertThat(backlog.getValue()).isCloseTo(90.0, within(1.0));
+    }
+
+    @Test
+    @DisplayName("should allow time-series variable to be referenced in equations")
+    void shouldAllowTimeSeriesInEquations() {
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("DerivedFromTimeSeries")
+                .defaultSimulation("Day", 3, "Day")
+                .timeSeries("temperature",
+                        new double[]{0, 1, 2, 3},
+                        new double[]{20, 25, 30, 28},
+                        null)
+                .variable("doubled_temp", "temperature * 2", "Dmnl")
+                .build();
+
+        CompiledModel compiled = new ModelCompiler().compile(def);
+        Simulation sim = compiled.createSimulation();
+        sim.execute();
+
+        // After simulation at time=3, temperature=28, doubled_temp=56
+        Variable doubled = compiled.getModel().getVariable("doubled_temp").orElseThrow();
+        assertThat(doubled.getValue()).isCloseTo(56.0, within(1.0));
+    }
+}

--- a/courant-engine/src/test/java/systems/courant/sd/model/TimeSeriesTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/TimeSeriesTest.java
@@ -1,0 +1,91 @@
+package systems.courant.sd.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@DisplayName("TimeSeries")
+class TimeSeriesTest {
+
+    private static final double[] TIMES = {0.0, 1.0, 2.0, 3.0, 4.0};
+    private static final double[] VALUES = {10.0, 20.0, 30.0, 25.0, 15.0};
+
+    @Nested
+    @DisplayName("Linear interpolation")
+    class LinearInterpolation {
+
+        @Test
+        void shouldReturnExactValueAtDataPoint() {
+            double[] time = {0};
+            TimeSeries ts = TimeSeries.linear(TIMES, VALUES, () -> time[0]);
+
+            time[0] = 0.0;
+            assertThat(ts.getCurrentValue()).isEqualTo(10.0);
+            time[0] = 2.0;
+            assertThat(ts.getCurrentValue()).isEqualTo(30.0);
+            time[0] = 4.0;
+            assertThat(ts.getCurrentValue()).isEqualTo(15.0);
+        }
+
+        @Test
+        void shouldInterpolateLinearly() {
+            double[] time = {0};
+            TimeSeries ts = TimeSeries.linear(TIMES, VALUES, () -> time[0]);
+
+            time[0] = 0.5;
+            assertThat(ts.getCurrentValue()).isCloseTo(15.0, within(1e-10));
+            time[0] = 1.5;
+            assertThat(ts.getCurrentValue()).isCloseTo(25.0, within(1e-10));
+        }
+
+        @Test
+        void shouldHoldFirstValueBeforeRange() {
+            double[] time = {-1.0};
+            TimeSeries ts = TimeSeries.linear(TIMES, VALUES, () -> time[0]);
+            assertThat(ts.getCurrentValue()).isEqualTo(10.0);
+        }
+
+        @Test
+        void shouldHoldLastValueAfterRange() {
+            double[] time = {10.0};
+            TimeSeries ts = TimeSeries.linear(TIMES, VALUES, () -> time[0]);
+            assertThat(ts.getCurrentValue()).isEqualTo(15.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("Step interpolation")
+    class StepInterpolation {
+
+        @Test
+        void shouldReturnValueAtLowerBound() {
+            double[] time = {0};
+            TimeSeries ts = TimeSeries.step(TIMES, VALUES, () -> time[0]);
+
+            time[0] = 0.5;
+            assertThat(ts.getCurrentValue()).isEqualTo(10.0);
+            time[0] = 1.9;
+            assertThat(ts.getCurrentValue()).isEqualTo(20.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("Zero extrapolation")
+    class ZeroExtrapolation {
+
+        @Test
+        void shouldReturnZeroOutsideRange() {
+            double[] time = {0};
+            TimeSeries ts = TimeSeries.create(TIMES, VALUES, () -> time[0],
+                    "LINEAR", "ZERO");
+
+            time[0] = -1.0;
+            assertThat(ts.getCurrentValue()).isEqualTo(0.0);
+            time[0] = 5.0;
+            assertThat(ts.getCurrentValue()).isEqualTo(0.0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `TimeSeries` formula class with linear/step interpolation and hold/zero extrapolation
- Adds `TimeSeriesDef` record for defining exogenous inputs in model definitions
- Integrates into `ModelCompiler` pipeline — time-series variables are compiled and usable in equations
- Updates `DefinitionValidator` to recognize time-series names for reference validation
- Updates `ModelDefinition` and `ModelDefinitionBuilder` with `timeSeries()` support

This enables models to be driven by observed real-world data (e.g., historical order volumes, reported case counts) rather than equations — prerequisite for Vensim's `GET_XLS_DATA`/`GET_DIRECT_DATA` function support.

Closes #481