### PR TITLE
Add --json-name CLI option to ImportPipelineCli

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
@@ -20,7 +20,7 @@ import java.util.Scanner;
  *   java ImportPipelineCli --file model.xmile --class-name SirDemo \
  *       --license "CC-BY-SA-4.0" --source "Kermack &amp; McKendrick (1927)" \
  *       [--author "..."] [--url "..."] \
- *       [--category epidemiology] \
+ *       [--category epidemiology] [--json-name my-model] \
  *       [--output-dir path/to/src/main/java] \
  *       [--metadata-file metadata.json] \
  *       [--dry-run] [--overwrite]
@@ -81,6 +81,7 @@ public class ImportPipelineCli implements Closeable {
                 metadata,
                 parsed.category,
                 parsed.className,
+                parsed.jsonName,
                 Path.of(parsed.outputDir),
                 parsed.dryRun,
                 parsed.overwrite,
@@ -172,6 +173,7 @@ public class ImportPipelineCli implements Closeable {
                 case "--source" -> { parsed.source = requireValue(args, i); i++; }
                 case "--license" -> { parsed.license = requireValue(args, i); i++; }
                 case "--url" -> { parsed.url = requireValue(args, i); i++; }
+                case "--json-name" -> { parsed.jsonName = requireValue(args, i); i++; }
                 case "--output-dir" -> { parsed.outputDir = requireValue(args, i); i++; }
                 case "--metadata-file" -> { parsed.metadataFile = requireValue(args, i); i++; }
                 case "--dry-run" -> parsed.dryRun = true;
@@ -211,6 +213,7 @@ public class ImportPipelineCli implements Closeable {
 
                 Output:
                   --category <name>       Target sub-package (e.g. "epidemiology")
+                  --json-name <name>      Custom JSON filename (default: derived from class name)
                   --output-dir <path>     Root source directory (default: courant-demos/src/main/java)
                   --json-only             Write model definition as JSON instead of generating Java code
                   --dry-run               Print generated source without writing to disk
@@ -226,6 +229,7 @@ public class ImportPipelineCli implements Closeable {
         String source;
         String license;
         String url;
+        String jsonName;
         String metadataFile;
         String outputDir = "courant-demos/src/main/java";
         boolean dryRun;

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/ImportPipelineCliTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/ImportPipelineCliTest.java
@@ -31,6 +31,7 @@ class ImportPipelineCliTest {
                     "--source", "Some Paper (2024)",
                     "--license", "CC-BY-SA-4.0",
                     "--url", "https://example.com",
+                    "--json-name", "custom-model",
                     "--output-dir", "/tmp/src",
                     "--metadata-file", "meta.json",
                     "--dry-run",
@@ -47,6 +48,7 @@ class ImportPipelineCliTest {
             assertThat(parsed.source).isEqualTo("Some Paper (2024)");
             assertThat(parsed.license).isEqualTo("CC-BY-SA-4.0");
             assertThat(parsed.url).isEqualTo("https://example.com");
+            assertThat(parsed.jsonName).isEqualTo("custom-model");
             assertThat(parsed.outputDir).isEqualTo("/tmp/src");
             assertThat(parsed.metadataFile).isEqualTo("meta.json");
             assertThat(parsed.dryRun).isTrue();
@@ -58,6 +60,12 @@ class ImportPipelineCliTest {
         void shouldDefaultJsonOnlyToFalse() {
             ImportPipelineCli.CliArgs parsed = ImportPipelineCli.parseArgs(new String[]{});
             assertThat(parsed.jsonOnly).isFalse();
+        }
+
+        @Test
+        void shouldDefaultJsonNameToNull() {
+            ImportPipelineCli.CliArgs parsed = ImportPipelineCli.parseArgs(new String[]{});
+            assertThat(parsed.jsonName).isNull();
         }
 
         @Test
@@ -234,6 +242,26 @@ class ImportPipelineCliTest {
                 });
                 assertThat(exitCode).isEqualTo(1);
             }
+        }
+
+        @Test
+        void shouldWriteJsonOnlyWithCustomJsonName(@TempDir Path tempDir) throws IOException {
+            Path model = copyTestModel(tempDir);
+            try (ImportPipelineCli cli = new ImportPipelineCli()) {
+                int exitCode = cli.run(new String[]{
+                        "--file", model.toString(),
+                        "--class-name", "TeacupDemo",
+                        "--license", "CC-BY-SA-4.0",
+                        "--output-dir", tempDir.toString(),
+                        "--json-only",
+                        "--json-name", "my-teacup",
+                        "--overwrite"
+                });
+                assertThat(exitCode).isZero();
+            }
+            Path expectedJson = tempDir.resolve("my-teacup.json");
+            assertThat(expectedJson).exists();
+            assertThat(Files.readString(expectedJson)).contains("Teacup");
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Adds `--json-name` CLI argument to `ImportPipelineCli` so single-file imports can specify a custom JSON output filename
- Passes the value through to the canonical `PipelineConfig` constructor (matching `BatchImportCli` behavior)
- Updates usage text and Javadoc

## Test plan
- [x] New parse test for `--json-name` flag
- [x] New integration test verifying custom JSON filename in output
- [x] Existing `shouldParseAllFlags` updated to include `--json-name`
- [x] Full reactor build + SpotBugs clean

Closes #857