### PR TITLE
Fix layout overlap, int overflow, stale editor race, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Courant — System Dynamics Modeling Tool
 
-> **1.0-Alpha-4 Release** — This system is not ready for production use. APIs, file formats, and features may change without notice.
+> **Current release:** 1.0-Alpha-4
 
 The ability to reason about and make predictions on complex, dynamic systems is essential today. Courant is an open-source [System Dynamics](userdocs/Key%20Reasons%20for%20Using%20System%20Dynamics.md) simulation engine and visual modeling environment written in Java. It was created so that, when it's ready, everyone will have access to a professional quality system dynamics environment for free. 
 
@@ -23,7 +23,7 @@ The engine supports creating training simulations, games, scenario testing, and 
 - **Delay detection** — visual "D" badges on elements containing delay functions (SMOOTH, DELAY3, DELAY_FIXED)
 - **Canvas features** — sparklines in stocks, resizable elements, undo/redo, zoom, diagram export (PNG/JPG)
 - **Import/export** — Vensim `.mdl` import, XMILE import/export, native JSON persistence
-- **35 bundled example models** spanning epidemiology, ecology, economics, demographics, supply chain, technology adoption, and more
+- **More than 100 bundled example models** spanning causal loops, control theory, demographics, ecology, economics, education, environment, epidemiology, management, marketing, physics, policy, population, social dynamics, supply chain, technology adoption, urban systems, and more
 
 ## Screenshots
 
@@ -50,7 +50,7 @@ mvn clean package -DskipTests
 java -jar courant-app/target/courant-app-*.jar
 ```
 
-Open an example model via **File → Open Example** to explore the 35 bundled models.
+Open an example model via **File → Open Example** to explore the 100+ bundled models.
 
 ## Quick Start
 
@@ -173,7 +173,7 @@ Courant can exchange models with other System Dynamics tools:
 
 ### Visual Editor Bundled Models
 
-35 models across 11 categories accessible via **File → Open Example**: introductory, demographics, ecology, economics, epidemiology, management, policy, population, supply chain, technology, and more.
+More than 100 models across 18 categories accessible via **File → Open Example**: introductory, causal loop, control, demographics, ecology, economics, education, environment, epidemiology, management, marketing, physics, policy, population, social, supply chain, technology, and urban.
 
 ## Documentation
 

--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -38,6 +38,7 @@ import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.ValidationResult;
 import systems.courant.sd.model.def.ViewDef;
 import systems.courant.sd.model.graph.AutoLayout;
+import systems.courant.sd.model.graph.ElementSizes;
 import systems.courant.sd.model.graph.FeedbackAnalysis;
 
 import javafx.application.Platform;
@@ -767,6 +768,7 @@ public class ModelWindow {
         editor.addListener(staleListener);
         editor.addListener(dirtyListener);
         editor.loadFrom(def);
+        var editorSnapshot = this.editor;
 
         if (def.stocks().isEmpty() && def.flows().isEmpty()
                 && def.variables().isEmpty()) {
@@ -777,7 +779,7 @@ public class ModelWindow {
             } else {
                 view = new ViewDef("Main", List.of(), List.of(), List.of());
             }
-            applyView(view, displayName);
+            applyView(editorSnapshot, view, displayName);
         } else {
             // Run auto-layout on a background thread to keep the UI responsive.
             // ELK initialization on first use and layout of large models can
@@ -785,11 +787,13 @@ public class ModelWindow {
             statusBar.showProgress("Computing layout\u2026");
             canvas.setDisable(true);
             Thread layoutThread = new Thread(() -> {
-                ViewDef view = AutoLayout.layout(def);
+                var sizeOverrides = systems.courant.sd.app.canvas.LayoutMetrics
+                        .computeSizeOverrides(def);
+                ViewDef view = AutoLayout.layout(def, sizeOverrides);
                 Platform.runLater(() -> {
                     canvas.setDisable(false);
                     statusBar.clearProgress();
-                    applyView(view, displayName);
+                    applyView(editorSnapshot, view, displayName);
                 });
             }, "auto-layout");
             layoutThread.setDaemon(true);
@@ -797,10 +801,10 @@ public class ModelWindow {
         }
     }
 
-    private void applyView(ViewDef view, String displayName) {
+    private void applyView(ModelEditor ed, ViewDef view, String displayName) {
         canvas.clearNavigation();
         canvas.clearSparklines();
-        canvas.setModel(editor, view);
+        canvas.setModel(ed, view);
         undoManager.clear();
         fileController.setDirty(false);
         if (dashboardPanel != null) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/LayoutMetrics.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/LayoutMetrics.java
@@ -1,10 +1,20 @@
 package systems.courant.sd.app.canvas;
 
+import systems.courant.sd.model.def.CldVariableDef;
 import systems.courant.sd.model.def.ElementType;
+import systems.courant.sd.model.def.LookupTableDef;
+import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.ModuleInstanceDef;
+import systems.courant.sd.model.def.StockDef;
+import systems.courant.sd.model.def.VariableDef;
+import systems.courant.sd.model.graph.ElementSizes;
 
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Element dimensions, spacing, and font metrics for the Layered Flow Diagram.
@@ -139,10 +149,18 @@ public final class LayoutMetrics {
     public static final double AUX_MAX_AUTO_WIDTH = 200;
     /** Maximum auto-computed width for LOOKUP elements (2x default). */
     public static final double LOOKUP_MAX_AUTO_WIDTH = 200;
+    /** Maximum auto-computed width for STOCK elements (2x default). */
+    public static final double STOCK_MAX_AUTO_WIDTH = 280;
+    /** Maximum auto-computed width for MODULE elements (2x default). */
+    public static final double MODULE_MAX_AUTO_WIDTH = 240;
     /** Horizontal padding around text for AUX variable auto-sizing. */
     public static final double AUX_TEXT_PADDING = 24;
     /** Horizontal padding around text for LOOKUP auto-sizing. */
     public static final double LOOKUP_TEXT_PADDING = 20;
+    /** Horizontal padding around text for STOCK auto-sizing. */
+    public static final double STOCK_TEXT_PADDING = 24;
+    /** Horizontal padding around text for MODULE auto-sizing. */
+    public static final double MODULE_TEXT_PADDING = 24;
 
     /**
      * Returns the width for a given element type.
@@ -227,6 +245,32 @@ public final class LayoutMetrics {
     }
 
     /**
+     * Computes the width for a STOCK based on its text label.
+     * Returns the measured text width plus padding, clamped to
+     * [{@link #STOCK_WIDTH}, {@link #STOCK_MAX_AUTO_WIDTH}].
+     */
+    public static double stockWidthForName(String name) {
+        Text text = new Text(name);
+        text.setFont(STOCK_NAME_FONT);
+        double textWidth = text.getLayoutBounds().getWidth();
+        return Math.max(STOCK_WIDTH,
+                Math.min(textWidth + STOCK_TEXT_PADDING, STOCK_MAX_AUTO_WIDTH));
+    }
+
+    /**
+     * Computes the width for a MODULE based on its text label.
+     * Returns the measured text width plus padding, clamped to
+     * [{@link #MODULE_WIDTH}, {@link #MODULE_MAX_AUTO_WIDTH}].
+     */
+    public static double moduleWidthForName(String name) {
+        Text text = new Text(name);
+        text.setFont(MODULE_NAME_FONT);
+        double textWidth = text.getLayoutBounds().getWidth();
+        return Math.max(MODULE_WIDTH,
+                Math.min(textWidth + MODULE_TEXT_PADDING, MODULE_MAX_AUTO_WIDTH));
+    }
+
+    /**
      * Computes the width for a CLD variable based on its text label.
      * Returns the measured text width plus padding, clamped to the minimum.
      */
@@ -261,5 +305,39 @@ public final class LayoutMetrics {
         double textWidth = text.getLayoutBounds().getWidth();
         return Math.max(minWidthFor(ElementType.LOOKUP),
                 Math.min(textWidth + LOOKUP_TEXT_PADDING, LOOKUP_MAX_AUTO_WIDTH));
+    }
+
+    /**
+     * Computes per-element size overrides for elements whose rendered size depends on
+     * their name text (AUX, LOOKUP, CLD_VARIABLE). These overrides should be passed to
+     * {@link systems.courant.sd.model.graph.AutoLayout#layout(ModelDefinition, Map)}
+     * so the layout algorithm uses actual rendered dimensions instead of fixed defaults.
+     *
+     * @param def the model definition whose elements need size computation
+     * @return a map of element name to {@link ElementSizes} for elements with text-dependent widths
+     */
+    public static Map<String, ElementSizes> computeSizeOverrides(ModelDefinition def) {
+        Map<String, ElementSizes> overrides = new HashMap<>();
+        for (StockDef s : def.stocks()) {
+            double w = stockWidthForName(s.name());
+            overrides.put(s.name(), new ElementSizes(w, STOCK_HEIGHT));
+        }
+        for (ModuleInstanceDef m : def.modules()) {
+            double w = moduleWidthForName(m.instanceName());
+            overrides.put(m.instanceName(), new ElementSizes(w, MODULE_HEIGHT));
+        }
+        for (VariableDef v : def.variables()) {
+            double w = auxWidthForName(v.name());
+            overrides.put(v.name(), new ElementSizes(w, AUX_HEIGHT));
+        }
+        for (LookupTableDef t : def.lookupTables()) {
+            double w = lookupWidthForName(t.name());
+            overrides.put(t.name(), new ElementSizes(w, LOOKUP_HEIGHT));
+        }
+        for (CldVariableDef c : def.cldVariables()) {
+            double w = cldVarWidthForName(c.name());
+            overrides.put(c.name(), new ElementSizes(w, CLD_VAR_HEIGHT));
+        }
+        return overrides;
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
@@ -1126,7 +1126,8 @@ public class ModelCanvas extends Canvas {
         if (!module.definition().views().isEmpty()) {
             moduleView = module.definition().views().getFirst();
         } else {
-            moduleView = AutoLayout.layout(module.definition());
+            var sizeOverrides = LayoutMetrics.computeSizeOverrides(module.definition());
+            moduleView = AutoLayout.layout(module.definition(), sizeOverrides);
         }
 
         this.editor = moduleEditor;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Delay1.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Delay1.java
@@ -122,7 +122,7 @@ public class Delay1 implements Formula, Resettable {
             lastStep = step;
         } else if (step > lastStep) {
             long delta = step - lastStep;
-            for (int d = 0; d < delta; d++) {
+            for (long d = 0; d < delta; d++) {
                 double inputVal = input.getAsDouble();
                 double rate = stage / delayTime;
                 stage += inputVal - rate;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Delay3.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Delay3.java
@@ -133,7 +133,7 @@ public class Delay3 implements Formula, Resettable {
             double stageTime = delayTime / 3.0;
             long delta = step - lastStep;
             double inputVal = input.getAsDouble();
-            for (int d = 0; d < delta; d++) {
+            for (long d = 0; d < delta; d++) {
                 // Compute outflow rates from current stage levels
                 double rate1 = stage1 / stageTime;
                 double rate2 = stage2 / stageTime;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Forecast.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Forecast.java
@@ -97,7 +97,7 @@ public class Forecast implements Formula, Resettable {
             lastStep = step;
         } else if (step > lastStep) {
             long delta = step - lastStep;
-            for (int d = 0; d < delta; d++) {
+            for (long d = 0; d < delta; d++) {
                 lastInputVal = input.getAsDouble();
                 averageInput += (lastInputVal - averageInput) / averagingTime;
                 double denom = averageInput * averagingTime;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Npv.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Npv.java
@@ -125,7 +125,7 @@ public class Npv implements Formula, Resettable {
             double discountMultiplier = 1 + discountRate;
             double streamVal = stream.getAsDouble();
             // Compound discount for all elapsed steps
-            for (int d = 0; d < delta; d++) {
+            for (long d = 0; d < delta; d++) {
                 cumulativeDiscount *= discountMultiplier;
             }
             // Add only the current step's payment at the final discount level

--- a/courant-engine/src/main/java/systems/courant/sd/model/Trend.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Trend.java
@@ -97,7 +97,7 @@ public class Trend implements Formula, Resettable {
             lastStep = step;
         } else if (step > lastStep) {
             long delta = step - lastStep;
-            for (int d = 0; d < delta; d++) {
+            for (long d = 0; d < delta; d++) {
                 double inputVal = input.getAsDouble();
                 averageInput += (inputVal - averageInput) / averagingTime;
                 double denom = averageInput * averagingTime;

--- a/courant-engine/src/main/java/systems/courant/sd/model/graph/AutoLayout.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/graph/AutoLayout.java
@@ -69,6 +69,21 @@ public final class AutoLayout {
      * @return a view definition with element placements and connector routes
      */
     public static ViewDef layout(ModelDefinition def) {
+        return layout(def, Map.of());
+    }
+
+    /**
+     * Generates a {@link ViewDef} with all elements placed using ELK's layered algorithm,
+     * using the given per-element size overrides instead of the default {@link ElementSizes}.
+     * This allows callers to pre-compute text-based sizes (e.g. for AUX, LOOKUP, CLD_VARIABLE)
+     * so that the layout algorithm positions elements based on their actual rendered dimensions.
+     *
+     * @param def           the model definition whose elements are to be laid out
+     * @param sizeOverrides per-element size overrides keyed by element name; elements not in
+     *                      this map use the default size for their type
+     * @return a view definition with element placements and connector routes
+     */
+    public static ViewDef layout(ModelDefinition def, Map<String, ElementSizes> sizeOverrides) {
         if (def.stocks().isEmpty() && def.flows().isEmpty() && def.variables().isEmpty()
                 && def.lookupTables().isEmpty()
                 && def.modules().isEmpty() && def.cldVariables().isEmpty()) {
@@ -98,27 +113,27 @@ public final class AutoLayout {
 
         for (StockDef s : def.stocks()) {
             addNode(factory, root, nodeMap, typeMap, s.name(), ElementType.STOCK,
-                    westPorts, eastPorts);
+                    westPorts, eastPorts, sizeOverrides);
         }
         for (FlowDef f : def.flows()) {
             addNode(factory, root, nodeMap, typeMap, f.name(), ElementType.FLOW,
-                    westPorts, eastPorts);
+                    westPorts, eastPorts, sizeOverrides);
         }
         for (VariableDef a : def.variables()) {
             addNode(factory, root, nodeMap, typeMap, a.name(), ElementType.AUX,
-                    westPorts, eastPorts);
+                    westPorts, eastPorts, sizeOverrides);
         }
         for (LookupTableDef t : def.lookupTables()) {
             addNode(factory, root, nodeMap, typeMap, t.name(), ElementType.LOOKUP,
-                    westPorts, eastPorts);
+                    westPorts, eastPorts, sizeOverrides);
         }
         for (ModuleInstanceDef m : def.modules()) {
             addNode(factory, root, nodeMap, typeMap, m.instanceName(), ElementType.MODULE,
-                    westPorts, eastPorts);
+                    westPorts, eastPorts, sizeOverrides);
         }
         for (CldVariableDef v : def.cldVariables()) {
             addNode(factory, root, nodeMap, typeMap, v.name(), ElementType.CLD_VARIABLE,
-                    westPorts, eastPorts);
+                    westPorts, eastPorts, sizeOverrides);
         }
 
         // Set initial X positions from the material flow chain so INTERACTIVE
@@ -225,7 +240,7 @@ public final class AutoLayout {
         }
 
         alignFlowsWithStocks(placements, def);
-        resolveOverlaps(placements);
+        resolveOverlaps(placements, sizeOverrides);
 
         List<ConnectorRoute> connectors = ConnectorGenerator.generate(def);
         return new ViewDef("Auto Layout", placements, connectors, List.of());
@@ -236,11 +251,12 @@ public final class AutoLayout {
                                 Map<String, ElementType> typeMap,
                                 String name, ElementType type,
                                 Map<String, ElkPort> westPorts,
-                                Map<String, ElkPort> eastPorts) {
+                                Map<String, ElkPort> eastPorts,
+                                Map<String, ElementSizes> sizeOverrides) {
         ElkNode node = factory.createElkNode();
         node.setParent(root);
         node.setIdentifier(name);
-        ElementSizes size = ElementSizes.forType(type);
+        ElementSizes size = sizeOverrides.getOrDefault(name, ElementSizes.forType(type));
         node.setWidth(size.width());
         node.setHeight(size.height());
         nodeMap.put(name, node);
@@ -524,7 +540,8 @@ public final class AutoLayout {
     /**
      * Resolves overlaps by checking all element pairs and nudging apart any that overlap.
      */
-    private static void resolveOverlaps(List<ElementPlacement> placements) {
+    private static void resolveOverlaps(List<ElementPlacement> placements,
+                                         Map<String, ElementSizes> sizeOverrides) {
         double minGap = 20;
         for (int pass = 0; pass < 3; pass++) {
             boolean changed = false;
@@ -532,10 +549,14 @@ public final class AutoLayout {
                 for (int j = i + 1; j < placements.size(); j++) {
                     ElementPlacement a = placements.get(i);
                     ElementPlacement b = placements.get(j);
-                    double aw = ElementSizes.forType(a.type()).width() / 2.0;
-                    double ah = ElementSizes.forType(a.type()).height() / 2.0;
-                    double bw = ElementSizes.forType(b.type()).width() / 2.0;
-                    double bh = ElementSizes.forType(b.type()).height() / 2.0;
+                    ElementSizes sizeA = sizeOverrides.getOrDefault(a.name(),
+                            ElementSizes.forType(a.type()));
+                    ElementSizes sizeB = sizeOverrides.getOrDefault(b.name(),
+                            ElementSizes.forType(b.type()));
+                    double aw = sizeA.width() / 2.0;
+                    double ah = sizeA.height() / 2.0;
+                    double bw = sizeB.width() / 2.0;
+                    double bh = sizeB.height() / 2.0;
 
                     double overlapX = (aw + bw + minGap) - Math.abs(a.x() - b.x());
                     double overlapY = (ah + bh + minGap) - Math.abs(a.y() - b.y());

--- a/userdocs/Quickstart.md
+++ b/userdocs/Quickstart.md
@@ -14,7 +14,7 @@ java -jar courant-app/target/courant-app-*.jar
 
 A blank canvas opens. This is your workspace — you'll drag and drop elements here to build a visual model.
 
-> **Tip:** If you'd rather explore a finished model first, go to **File > Open Example** and pick any of the 8 bundled models. You can run them immediately with **Ctrl+R**.
+> **Tip:** If you'd rather explore a finished model first, go to **File > Open Example** and pick any of the 100+ bundled models. You can run them immediately with **Ctrl+R**.
 
 ---
 
@@ -200,7 +200,7 @@ These five building blocks can model surprisingly complex systems — from disea
 
 ## Next steps
 
-- **Open the example models** — File > Open Example has 8 models covering population growth, epidemiology, ecology, and supply chains
+- **Open the example models** — File > Open Example has more than 100 models covering causal loops, control theory, demographics, ecology, economics, epidemiology, management, marketing, physics, policy, social dynamics, supply chain, technology, urban systems, and more
 - **Try a positive feedback loop** — Build an exponential growth model (stock = Population, inflow = Births = Population * Birth_Rate). Compare it to the negative feedback you just built
 - **Explore causal loop diagrams** — Press **8** to place CLD variables and **9** to draw causal links. Sketch your system's causal structure before formalizing it into stocks and flows
 - **Read the [Expression Language Reference](Expression_Language.md)** — covers all built-in functions (SMOOTH, DELAY3, STEP, RAMP, IF, LOOKUP, etc.)

--- a/userdocs/Visual Editor Guide.md
+++ b/userdocs/Visual Editor Guide.md
@@ -63,7 +63,7 @@ All panes support right-click CSV export.
 
 ## Additional Features
 
-- **Example models** — File → Open Example provides 35 bundled models across 11 categories
+- **Example models** — File → Open Example provides more than 100 bundled models across 18 categories
 - **Context-sensitive help** — F1 shows documentation for the current tool or selected element type
 - **Activity log** — timestamped event log for model creation, file operations, simulation runs, analysis executions, and validation checks
 - **Equation autocomplete** — element names and built-in functions


### PR DESCRIPTION
## Summary
- **#854** Compute text-based size overrides for all element types before AutoLayout runs, preventing element overlap
- **#855** Change `int d` to `long d` in catch-up loops of Delay1, Delay3, Trend, Forecast, Npv to prevent integer overflow
- **#856** Capture editor snapshot before async layout thread to prevent stale editor/view mismatch on rapid file opens
- **#882** Update docs to reflect 100+ bundled models across 18 categories, replace production disclaimer

## Test plan
- [x] `mvn clean compile` — passes
- [x] `mvn clean test` — 2178/2180 pass (2 pre-existing NestedModuleTest failures)
- [x] `mvn spotbugs:check` — clean

Closes #854, closes #855, closes #856