### PR TITLE
Guard against NPE in InputDispatcher when editor is null

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/InputDispatcher.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/InputDispatcher.java
@@ -364,7 +364,7 @@ final class InputDispatcher {
             ConnectionId connHit = HitTester.hitTestInfoLink(
                     canvasState, canvas.getConnectors(), worldX, worldY, hideAux);
             boolean isCausal = false;
-            if (connHit == null) {
+            if (connHit == null && editor != null) {
                 connHit = HitTester.hitTestCausalLink(canvasState,
                         editor.getCausalLinks(), worldX, worldY, hideAux);
                 isCausal = connHit != null;


### PR DESCRIPTION
## Summary
- Add null check on `editor` before calling `getCausalLinks()` in `handleSelectClick()`, preventing NPE when clicking the canvas before a model is loaded

## Test plan
- [x] Full reactor compile passes
- [x] All tests pass
- [x] SpotBugs clean

Closes #886