### PR TITLE
Narrow catch clause in BatchImportCli (#895)

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
@@ -145,7 +145,7 @@ public class BatchImportCli {
 
                 succeeded++;
                 log.info("  OK: {}", entry.className());
-            } catch (Exception e) {
+            } catch (IOException | IllegalArgumentException | IllegalStateException e) {
                 failed++;
                 String msg = entry.className() + ": " + e.getMessage();
                 failures.add(msg);


### PR DESCRIPTION
## Summary
- Replace broad `catch(Exception)` with `catch(IOException | IllegalArgumentException | IllegalStateException)` in `BatchImportCli.run()` so programmer errors (NPE, ClassCastException, etc.) propagate as crashes instead of being silently recorded as batch failures.

Closes #895