### PR TITLE
Handle missing variable in fan chart drawing

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/FanChartPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/FanChartPane.java
@@ -79,8 +79,16 @@ public class FanChartPane extends Pane {
             return;
         }
 
-        Map<Double, double[]> pctMap = result.getPercentileSeries(variableName,
-                2.5, 12.5, 25.0, 50.0, 75.0, 87.5, 97.5);
+        Map<Double, double[]> pctMap;
+        try {
+            pctMap = result.getPercentileSeries(variableName,
+                    2.5, 12.5, 25.0, 50.0, 75.0, 87.5, 97.5);
+        } catch (IllegalArgumentException e) {
+            gc.setFill(Color.BLACK);
+            gc.setFont(Font.font(14));
+            gc.fillText("Variable not found: " + variableName, MARGIN_LEFT, h / 2);
+            return;
+        }
         double[] pct2 = pctMap.get(2.5);
         double[] pct97 = pctMap.get(97.5);
         double[] pct12 = pctMap.get(12.5);

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/FanChartPaneFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/FanChartPaneFxTest.java
@@ -94,6 +94,16 @@ class FanChartPaneFxTest {
         assertThat(pane.getChildren()).hasSize(1);
     }
 
+    @Test
+    @DisplayName("Redraw with missing variable does not throw (#894)")
+    void redrawWithMissingVariableDoesNotThrow(FxRobot robot) {
+        MonteCarloResult mcResult = buildMonteCarloResult();
+        javafx.application.Platform.runLater(() -> pane.redraw(mcResult, "NonExistentVariable"));
+        org.testfx.util.WaitForAsyncUtils.waitForFxEvents();
+        // Should display a message instead of throwing
+        assertThat(pane.getChildren()).hasSize(1);
+    }
+
     private static MonteCarloResult buildMonteCarloResult() {
         List<RunResult> runs = new ArrayList<>();
         for (int i = 0; i < 20; i++) {

--- a/courant-ui/src/main/java/systems/courant/sd/ui/FanChart.java
+++ b/courant-ui/src/main/java/systems/courant/sd/ui/FanChart.java
@@ -114,8 +114,16 @@ public class FanChart extends Application {
         }
 
         // Compute all percentile series in a single pass
-        Map<Double, double[]> pctMap = result.getPercentileSeries(variableName,
-                2.5, 12.5, 25.0, 50.0, 75.0, 87.5, 97.5);
+        Map<Double, double[]> pctMap;
+        try {
+            pctMap = result.getPercentileSeries(variableName,
+                    2.5, 12.5, 25.0, 50.0, 75.0, 87.5, 97.5);
+        } catch (IllegalArgumentException e) {
+            gc.setFill(Color.BLACK);
+            gc.setFont(Font.font(14));
+            gc.fillText("Variable not found: " + variableName, MARGIN_LEFT, HEIGHT / 2);
+            return;
+        }
         double[] pct2 = pctMap.get(2.5);
         double[] pct97 = pctMap.get(97.5);
         double[] pct12 = pctMap.get(12.5);


### PR DESCRIPTION
## Summary
- Catch `IllegalArgumentException` in `FanChartPane.drawFanChart` and `FanChart.drawFanChart` when variable name is not found in Monte Carlo result
- Display a user-friendly "Variable not found" message on the canvas instead of crashing
- Add TestFX test verifying `redraw` with a missing variable does not throw

Closes #894