### PR TITLE
Guard FanChartPane and FanChart against missing variable names

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/FanChartPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/FanChartPane.java
@@ -79,8 +79,16 @@ public class FanChartPane extends Pane {
             return;
         }
 
-        Map<Double, double[]> pctMap = result.getPercentileSeries(variableName,
-                2.5, 12.5, 25.0, 50.0, 75.0, 87.5, 97.5);
+        Map<Double, double[]> pctMap;
+        try {
+            pctMap = result.getPercentileSeries(variableName,
+                    2.5, 12.5, 25.0, 50.0, 75.0, 87.5, 97.5);
+        } catch (IllegalArgumentException e) {
+            gc.setFill(Color.BLACK);
+            gc.setFont(Font.font(14));
+            gc.fillText("Variable not found: " + variableName, MARGIN_LEFT, h / 2);
+            return;
+        }
         double[] pct2 = pctMap.get(2.5);
         double[] pct97 = pctMap.get(97.5);
         double[] pct12 = pctMap.get(12.5);

--- a/courant-ui/src/main/java/systems/courant/sd/ui/FanChart.java
+++ b/courant-ui/src/main/java/systems/courant/sd/ui/FanChart.java
@@ -114,8 +114,16 @@ public class FanChart extends Application {
         }
 
         // Compute all percentile series in a single pass
-        Map<Double, double[]> pctMap = result.getPercentileSeries(variableName,
-                2.5, 12.5, 25.0, 50.0, 75.0, 87.5, 97.5);
+        Map<Double, double[]> pctMap;
+        try {
+            pctMap = result.getPercentileSeries(variableName,
+                    2.5, 12.5, 25.0, 50.0, 75.0, 87.5, 97.5);
+        } catch (IllegalArgumentException e) {
+            gc.setFill(Color.BLACK);
+            gc.setFont(Font.font(14));
+            gc.fillText("Variable not found: " + variableName, MARGIN_LEFT, HEIGHT / 2);
+            return;
+        }
         double[] pct2 = pctMap.get(2.5);
         double[] pct97 = pctMap.get(97.5);
         double[] pct12 = pctMap.get(12.5);


### PR DESCRIPTION
## Summary
- Wrap `getPercentileSeries` calls in `FanChartPane` and `FanChart` with try-catch for `IllegalArgumentException`
- When a variable name is not found in the Monte Carlo result, display a friendly "Variable not found" message instead of crashing

Closes #894