### PR TITLE
Close module UndoManagers on navigation clear to prevent thread leak

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
@@ -1234,6 +1234,16 @@ public class ModelCanvas extends Canvas {
     }
 
     public void clearNavigation() {
+        if (navController.isInsideModule()) {
+            // Close the current module-level UndoManager
+            this.undoManager.close();
+            // Restore the root UndoManager and close all intermediate ones
+            List<NavigationStack.Frame> frames = navController.frames();
+            this.undoManager = frames.getFirst().undoManager();
+            for (int i = 1; i < frames.size(); i++) {
+                frames.get(i).undoManager().close();
+            }
+        }
         navController.clear();
     }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/UndoManager.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/UndoManager.java
@@ -295,6 +295,13 @@ public class UndoManager implements AutoCloseable {
         compressor.shutdownNow();
     }
 
+    /**
+     * Returns true if this manager has been closed.
+     */
+    boolean isClosed() {
+        return compressor.isShutdown();
+    }
+
     private UndoEntry compressAsync(Snapshot snapshot, String label) {
         ModelDefinition model = snapshot.model();
         // Ensure the view is embedded in the model for serialization

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ClearNavigationUndoFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ClearNavigationUndoFxTest.java
@@ -1,0 +1,117 @@
+package systems.courant.sd.app.canvas;
+
+import systems.courant.sd.model.def.ElementType;
+import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.ModelDefinitionBuilder;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link ModelCanvas#clearNavigation()} closes module-level
+ * UndoManagers stored in navigation frames, preventing executor thread leaks (#885).
+ */
+@DisplayName("clearNavigation closes module UndoManagers (#885)")
+@ExtendWith(ApplicationExtension.class)
+class ClearNavigationUndoFxTest {
+
+    private ModelCanvas canvas;
+    private UndoManager rootUndoManager;
+
+    @Start
+    void start(Stage stage) {
+        canvas = new ModelCanvas(new Clipboard());
+        rootUndoManager = new UndoManager();
+        canvas.setUndoManager(rootUndoManager);
+        stage.setScene(new Scene(new StackPane(canvas), 800, 600));
+        stage.show();
+    }
+
+    private void loadNestedModules() {
+        ModelDefinition innerDef = new ModelDefinitionBuilder()
+                .name("Inner")
+                .stock("InnerStock", 10, "units")
+                .build();
+
+        ModelDefinition middleDef = new ModelDefinitionBuilder()
+                .name("Middle")
+                .stock("MiddleStock", 20, "units")
+                .module("Module 1", innerDef, Map.of(), Map.of())
+                .build();
+
+        ModelDefinition rootDef = new ModelDefinitionBuilder()
+                .name("Root")
+                .stock("RootStock", 30, "units")
+                .module("Module 1", middleDef, Map.of(), Map.of())
+                .build();
+
+        ModelEditor editor = new ModelEditor();
+        editor.loadFrom(rootDef);
+
+        CanvasState state = new CanvasState();
+        state.addElement("RootStock", ElementType.STOCK, 100, 200);
+        state.addElement("Module 1", ElementType.MODULE, 300, 200);
+
+        canvas.setModel(editor, state.toViewDef());
+    }
+
+    @Test
+    @DisplayName("clearNavigation after drill-in should close module UndoManager and restore root")
+    void shouldCloseModuleUndoManagerOnClear() {
+        loadNestedModules();
+        canvas.drillInto("Module 1");
+
+        assertThat(canvas.isInsideModule()).isTrue();
+        UndoManager moduleUm = canvas.getUndoManager();
+        assertThat(moduleUm).isNotSameAs(rootUndoManager);
+
+        canvas.clearNavigation();
+
+        assertThat(moduleUm.isClosed()).isTrue();
+        assertThat(canvas.getUndoManager()).isSameAs(rootUndoManager);
+        assertThat(rootUndoManager.isClosed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("clearNavigation after multi-level drill-in should close all module UndoManagers")
+    void shouldCloseAllModuleUndoManagersOnClear() {
+        loadNestedModules();
+        canvas.drillInto("Module 1");
+        UndoManager level1Um = canvas.getUndoManager();
+
+        canvas.drillInto("Module 1");
+        UndoManager level2Um = canvas.getUndoManager();
+
+        assertThat(level1Um).isNotSameAs(rootUndoManager);
+        assertThat(level2Um).isNotSameAs(level1Um);
+
+        canvas.clearNavigation();
+
+        assertThat(level2Um.isClosed()).isTrue();
+        assertThat(level1Um.isClosed()).isTrue();
+        assertThat(canvas.getUndoManager()).isSameAs(rootUndoManager);
+        assertThat(rootUndoManager.isClosed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("clearNavigation at root level should not close root UndoManager")
+    void shouldNotCloseRootUndoManagerWhenAtRoot() {
+        loadNestedModules();
+
+        canvas.clearNavigation();
+
+        assertThat(canvas.getUndoManager()).isSameAs(rootUndoManager);
+        assertThat(rootUndoManager.isClosed()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- `clearNavigation()` now closes all module-level UndoManagers stored in navigation frames before clearing the stack, preventing executor thread leaks on drill-in/drill-out cycles
- Restores the root UndoManager when clearing navigation from inside a module
- Adds `isClosed()` method to UndoManager for testability

## Test plan
- [x] New `ClearNavigationUndoFxTest` verifies single-level, multi-level, and root-level clear scenarios
- [x] Full reactor compile passes
- [x] All tests pass
- [x] SpotBugs clean

Closes #885