### PR TITLE
Clear stale calibration data when all columns skipped

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialog.java
@@ -214,6 +214,11 @@ public class CalibrateDialog extends Dialog<CalibrateDialog.Config> {
             if (mapped != null) {
                 importedDataset = mapped;
                 buildFitTargetRows();
+            } else {
+                importedDataset = null;
+                fitTargetRows.clear();
+                fitTargetBox.getChildren().clear();
+                datasetLabel.setText("No columns mapped — import again");
             }
         } catch (IOException ex) {
             datasetLabel.setText("Error: " + ex.getMessage());


### PR DESCRIPTION
## Summary
- When `ColumnMappingDialog` returns null (all columns mapped to skip), clear `importedDataset`, fit target rows, and update the dataset label
- Prevents stale data from a previous import being used for calibration

Closes #893