### PR TITLE
Fix 4 medium-priority issues: overflow, validation, NaN, missing functions

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/Simulation.java
+++ b/courant-engine/src/main/java/systems/courant/sd/Simulation.java
@@ -186,8 +186,18 @@ public class Simulation {
         clearHistory();
         resetStatefulFormulas();
 
-        long nanos = Math.round(timeStep.ratioToBaseUnit() * dt * 1_000_000_000L);
-        if (nanos <= 0) {
+        // Compute the step duration in seconds (ratioToBaseUnit is in seconds).
+        // Use seconds + nanosecond remainder to avoid long overflow when
+        // ratioToBaseUnit * dt * 1e9 exceeds Long.MAX_VALUE (#888).
+        double stepSeconds = timeStep.ratioToBaseUnit() * dt;
+        if (stepSeconds <= 0 || !Double.isFinite(stepSeconds)) {
+            throw new IllegalArgumentException(
+                    "Time step too small to represent in nanoseconds: " + timeStep.getName()
+                            + " (ratioToBaseUnit=" + timeStep.ratioToBaseUnit() + ")");
+        }
+        long wholeSeconds = (long) stepSeconds;
+        long nanoAdjustment = Math.round((stepSeconds - wholeSeconds) * 1_000_000_000L);
+        if (wholeSeconds == 0 && nanoAdjustment <= 0) {
             throw new IllegalArgumentException(
                     "Time step too small to represent in nanoseconds: " + timeStep.getName()
                             + " (ratioToBaseUnit=" + timeStep.ratioToBaseUnit() + ")");
@@ -214,7 +224,7 @@ public class Simulation {
                             + "). Check duration and time step values.");
         }
 
-        Duration stepDuration = Duration.ofNanos(nanos);
+        Duration stepDuration = Duration.ofSeconds(wholeSeconds, nanoAdjustment);
         long deadlineMs = timeoutMs > 0 ? System.currentTimeMillis() + timeoutMs : Long.MAX_VALUE;
         Map<Flow, Quantity> flowMap = new IdentityHashMap<>();
         List<Stock> allStocks = collectAllStocks();

--- a/courant-engine/src/main/java/systems/courant/sd/io/FormatUtils.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/FormatUtils.java
@@ -15,10 +15,16 @@ public final class FormatUtils {
      *
      * @param value the value to format
      * @return the formatted string
+     * @throws IllegalArgumentException if value is NaN or infinite
      */
     public static String formatDouble(double value) {
-        if (value == Math.floor(value) && !Double.isInfinite(value)
-                && Math.abs(value) < 1e15) {
+        if (Double.isNaN(value)) {
+            throw new IllegalArgumentException("Cannot format NaN as a numeric string");
+        }
+        if (Double.isInfinite(value)) {
+            throw new IllegalArgumentException("Cannot format Infinity as a numeric string");
+        }
+        if (value == Math.floor(value) && Math.abs(value) < 1e15) {
             return String.valueOf((long) value);
         }
         return String.valueOf(value);

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -72,6 +72,12 @@ public final class VensimExporter {
             "(?i)\\bRANDOM_UNIFORM\\s*\\(");
     private static final Pattern PULSE_TRAIN_EXPORT_PATTERN = Pattern.compile(
             "(?i)\\bPULSE_TRAIN\\s*\\(");
+    private static final Pattern SAMPLE_IF_TRUE_EXPORT_PATTERN = Pattern.compile(
+            "(?i)\\bSAMPLE_IF_TRUE\\s*\\(");
+    private static final Pattern FIND_ZERO_EXPORT_PATTERN = Pattern.compile(
+            "(?i)\\bFIND_ZERO\\s*\\(");
+    private static final Pattern LOOKUP_AREA_EXPORT_PATTERN = Pattern.compile(
+            "(?i)\\bLOOKUP_AREA\\s*\\(");
 
     private VensimExporter() {
     }
@@ -474,6 +480,15 @@ public final class VensimExporter {
         // PULSE_TRAIN → PULSE TRAIN
         expr = PULSE_TRAIN_EXPORT_PATTERN.matcher(expr).replaceAll("PULSE TRAIN(");
 
+        // SAMPLE_IF_TRUE → SAMPLE IF TRUE
+        expr = SAMPLE_IF_TRUE_EXPORT_PATTERN.matcher(expr).replaceAll("SAMPLE IF TRUE(");
+
+        // FIND_ZERO → FIND ZERO
+        expr = FIND_ZERO_EXPORT_PATTERN.matcher(expr).replaceAll("FIND ZERO(");
+
+        // LOOKUP_AREA → LOOKUP AREA
+        expr = LOOKUP_AREA_EXPORT_PATTERN.matcher(expr).replaceAll("LOOKUP AREA(");
+
         // IF(...) → IF THEN ELSE(...)
         expr = IF_FUNC_PATTERN.matcher(expr).replaceAll("IF THEN ELSE(");
 
@@ -807,7 +822,7 @@ public final class VensimExporter {
     private static boolean isKnownFunction(String token) {
         String upper = token.toUpperCase(Locale.ROOT);
         return switch (upper) {
-            case "IF", "THEN", "ELSE", "INTEG", "SMOOTH", "DELAY3", "MIN", "MAX",
+            case "IF", "THEN", "ELSE", "INTEG", "SMOOTH", "DELAY3", "DELAY3I", "MIN", "MAX",
                  "ABS", "EXP", "LN", "LOG", "SQRT", "SIN", "COS", "TAN",
                  "INT", "ROUND", "SUM", "MEAN",
                  "LOOKUP", "WITH", "XIDZ", "ZIDZ", "PULSE", "STEP",
@@ -817,6 +832,9 @@ public final class VensimExporter {
                  "TREND", "FORECAST", "NPV",
                  "RANDOM_UNIFORM", "RANDOM_NORMAL", "RANDOM", "UNIFORM",
                  "PULSE_TRAIN", "TRAIN",
+                 "SAMPLE_IF_TRUE", "SAMPLE", "TRUE",
+                 "FIND_ZERO", "FIND", "ZERO",
+                 "LOOKUP_AREA", "AREA",
                  "AND", "OR", "NOT", "TIME", "DT" -> true;
             default -> false;
         };

--- a/courant-engine/src/main/java/systems/courant/sd/model/TimeSeries.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/TimeSeries.java
@@ -1,5 +1,7 @@
 package systems.courant.sd.model;
 
+import com.google.common.base.Preconditions;
+
 import java.util.Arrays;
 import java.util.function.DoubleSupplier;
 
@@ -43,18 +45,36 @@ public class TimeSeries implements Formula {
 
     /**
      * Creates a time series with linear interpolation and hold extrapolation.
+     *
+     * @param timeValues    sorted ascending time points (at least 2, all finite)
+     * @param dataValues    data values at each time point (same length, all finite)
+     * @param timeSupplier  supplies the current simulation time
+     * @return a new TimeSeries
+     * @throws IllegalArgumentException if arrays differ in length, have fewer than 2 points,
+     *                                  time values are not strictly ascending, or any value is
+     *                                  not finite
      */
     public static TimeSeries linear(double[] timeValues, double[] dataValues,
                                      DoubleSupplier timeSupplier) {
+        validateArrays(timeValues, dataValues);
         return new TimeSeries(timeValues.clone(), dataValues.clone(),
                 timeSupplier, false, false);
     }
 
     /**
      * Creates a time series with step interpolation and hold extrapolation.
+     *
+     * @param timeValues    sorted ascending time points (at least 2, all finite)
+     * @param dataValues    data values at each time point (same length, all finite)
+     * @param timeSupplier  supplies the current simulation time
+     * @return a new TimeSeries
+     * @throws IllegalArgumentException if arrays differ in length, have fewer than 2 points,
+     *                                  time values are not strictly ascending, or any value is
+     *                                  not finite
      */
     public static TimeSeries step(double[] timeValues, double[] dataValues,
                                    DoubleSupplier timeSupplier) {
+        validateArrays(timeValues, dataValues);
         return new TimeSeries(timeValues.clone(), dataValues.clone(),
                 timeSupplier, true, false);
     }
@@ -62,15 +82,20 @@ public class TimeSeries implements Formula {
     /**
      * Creates a time series with configurable interpolation and extrapolation.
      *
-     * @param timeValues     sorted ascending time points
-     * @param dataValues     data values at each time point
+     * @param timeValues     sorted ascending time points (at least 2, all finite)
+     * @param dataValues     data values at each time point (same length, all finite)
      * @param timeSupplier   supplies the current simulation time
      * @param interpolation  "LINEAR" or "STEP"
      * @param extrapolation  "HOLD" or "ZERO"
+     * @return a new TimeSeries
+     * @throws IllegalArgumentException if arrays differ in length, have fewer than 2 points,
+     *                                  time values are not strictly ascending, or any value is
+     *                                  not finite
      */
     public static TimeSeries create(double[] timeValues, double[] dataValues,
                                      DoubleSupplier timeSupplier,
                                      String interpolation, String extrapolation) {
+        validateArrays(timeValues, dataValues);
         boolean isStep = "STEP".equalsIgnoreCase(interpolation);
         boolean isZero = "ZERO".equalsIgnoreCase(extrapolation);
         return new TimeSeries(timeValues.clone(), dataValues.clone(),
@@ -115,5 +140,27 @@ public class TimeSeries implements Formula {
         double v1 = dataValues[hi];
         double fraction = (t - t0) / (t1 - t0);
         return v0 + fraction * (v1 - v0);
+    }
+
+    private static void validateArrays(double[] timeValues, double[] dataValues) {
+        Preconditions.checkArgument(timeValues.length == dataValues.length,
+                "time and data arrays must have the same length, but got %s and %s",
+                timeValues.length, dataValues.length);
+        Preconditions.checkArgument(timeValues.length >= 2,
+                "At least 2 data points are required, but got %s",
+                timeValues.length);
+        for (int i = 0; i < timeValues.length; i++) {
+            Preconditions.checkArgument(Double.isFinite(timeValues[i]),
+                    "time values must be finite, but time[%s]=%s",
+                    (Object) i, timeValues[i]);
+            Preconditions.checkArgument(Double.isFinite(dataValues[i]),
+                    "data values must be finite, but data[%s]=%s",
+                    (Object) i, dataValues[i]);
+        }
+        for (int i = 1; i < timeValues.length; i++) {
+            Preconditions.checkArgument(timeValues[i] > timeValues[i - 1],
+                    "time values must be strictly ascending, but time[%s]=%s is not greater than time[%s]=%s",
+                    i, timeValues[i], i - 1, timeValues[i - 1]);
+        }
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/SimulationTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/SimulationTest.java
@@ -11,6 +11,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import systems.courant.sd.measure.Dimension;
 
 import static systems.courant.sd.measure.Units.DAY;
@@ -20,6 +24,7 @@ import static systems.courant.sd.measure.Units.MINUTE;
 import static systems.courant.sd.measure.Units.SECOND;
 import static systems.courant.sd.measure.Units.THING;
 import static systems.courant.sd.measure.Units.WEEK;
+import static systems.courant.sd.measure.Units.YEAR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1124,6 +1129,146 @@ public class SimulationTest {
             // Second run: should reset to 75
             sim.execute();
             assertThat(stock.getValue()).isEqualTo(0.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("currentDateTime overflow for large dt (#888)")
+    class CurrentDateTimeOverflow {
+
+        @Test
+        void shouldNotOverflowWithLargeDtAndYearTimeStep() {
+            // dt=300 with YEAR: ratioToBaseUnit=31_536_000, so stepSeconds=9_460_800_000.
+            // Before the fix, 31_536_000 * 300 * 1e9 overflowed a long.
+            Model model = new Model("Large Dt");
+            Stock stock = new Stock("S", 1000, THING);
+            Flow drain = Flow.create("Drain", YEAR, () -> new Quantity(100, THING));
+            stock.addOutflow(drain);
+            model.addStock(stock);
+
+            LocalDateTime start = LocalDateTime.of(2000, 1, 1, 0, 0);
+            Simulation sim = new Simulation(model, YEAR, new Quantity(300, YEAR), start);
+            sim.setDt(300);
+            sim.execute();
+
+            // Simulation completes without overflow — stock value is finite
+            assertThat(Double.isFinite(stock.getValue())).isTrue();
+        }
+
+        @Test
+        void shouldProduceCorrectTimestampsForLargeDt() {
+            Model model = new Model("Timestamp Check");
+            LocalDateTime start = LocalDateTime.of(2000, 1, 1, 0, 0);
+            Simulation sim = new Simulation(model, YEAR, new Quantity(300, YEAR), start);
+            sim.setDt(300);
+
+            List<LocalDateTime> timestamps = new ArrayList<>();
+            sim.addEventHandler(new systems.courant.sd.event.EventHandler() {
+                @Override
+                public void handleSimulationStartEvent(
+                        systems.courant.sd.event.SimulationStartEvent e) { }
+                @Override
+                public void handleTimeStepEvent(
+                        systems.courant.sd.event.TimeStepEvent e) {
+                    timestamps.add(e.getCurrentTime());
+                }
+                @Override
+                public void handleSimulationEndEvent(
+                        systems.courant.sd.event.SimulationEndEvent e) { }
+            });
+
+            sim.execute();
+
+            // Step 0 fires at startTime, step 1 fires at startTime + 300 years
+            assertThat(timestamps).hasSize(2);
+            assertThat(timestamps.get(0)).isEqualTo(start);
+            // 300 years * 365 days * 86400 seconds = 9_460_800_000 seconds
+            assertThat(timestamps.get(1)).isAfter(start);
+        }
+
+        @Test
+        void shouldHandleLargeDtWithMonthTimeStep() {
+            // dt=100 with MONTH: ratioToBaseUnit=2_592_000, stepSeconds=259_200_000
+            // Still well within long range but exercises the new code path
+            Model model = new Model("Large Dt Month");
+            LocalDateTime start = LocalDateTime.of(2000, 1, 1, 0, 0);
+            Simulation sim = new Simulation(model, DAY, new Quantity(100, DAY), start);
+            sim.setDt(100);
+
+            List<LocalDateTime> timestamps = new ArrayList<>();
+            sim.addEventHandler(new systems.courant.sd.event.EventHandler() {
+                @Override
+                public void handleSimulationStartEvent(
+                        systems.courant.sd.event.SimulationStartEvent e) { }
+                @Override
+                public void handleTimeStepEvent(
+                        systems.courant.sd.event.TimeStepEvent e) {
+                    timestamps.add(e.getCurrentTime());
+                }
+                @Override
+                public void handleSimulationEndEvent(
+                        systems.courant.sd.event.SimulationEndEvent e) { }
+            });
+
+            sim.execute();
+
+            // 100 days / (DAY * dt=100) = 1 step, plus initial = 2
+            assertThat(timestamps).hasSize(2);
+            assertThat(timestamps.get(0)).isEqualTo(start);
+            // 100 days = 8_640_000 seconds advanced
+            assertThat(timestamps.get(1)).isEqualTo(start.plusSeconds(8_640_000L));
+        }
+
+        @Test
+        void shouldStillRejectSubNanosecondTimeStep() {
+            // Ensure the fix didn't break the existing sub-nanosecond guard
+            Model model = new Model("Sub-Nano Guard");
+            TimeUnit tinyUnit = new TimeUnit() {
+                @Override
+                public String getName() { return "SubNano"; }
+                @Override
+                public Dimension getDimension() { return Dimension.TIME; }
+                @Override
+                public double ratioToBaseUnit() { return 0.4e-9; }
+            };
+            Simulation sim = new Simulation(model, tinyUnit, new Quantity(1, SECOND));
+
+            assertThatThrownBy(sim::execute)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("too small to represent in nanoseconds");
+        }
+
+        @Test
+        void shouldHandleFractionalSecondStepDuration() {
+            // dt=0.5 with SECOND: stepSeconds=0.5, wholeSeconds=0, nanoAdjustment=500_000_000
+            Model model = new Model("Fractional Step");
+            LocalDateTime start = LocalDateTime.of(2025, 6, 1, 12, 0);
+            Simulation sim = new Simulation(model, SECOND, new Quantity(3, SECOND), start);
+            sim.setDt(0.5);
+
+            List<LocalDateTime> timestamps = new ArrayList<>();
+            sim.addEventHandler(new systems.courant.sd.event.EventHandler() {
+                @Override
+                public void handleSimulationStartEvent(
+                        systems.courant.sd.event.SimulationStartEvent e) { }
+                @Override
+                public void handleTimeStepEvent(
+                        systems.courant.sd.event.TimeStepEvent e) {
+                    timestamps.add(e.getCurrentTime());
+                }
+                @Override
+                public void handleSimulationEndEvent(
+                        systems.courant.sd.event.SimulationEndEvent e) { }
+            });
+
+            sim.execute();
+
+            // 3s / (1s * 0.5) = 6 steps, plus initial = 7
+            assertThat(timestamps).hasSize(7);
+            assertThat(timestamps.get(0)).isEqualTo(start);
+            // Each step advances 0.5 seconds = 500_000_000 nanos
+            assertThat(timestamps.get(2)).isEqualTo(start.plusSeconds(1));
+            assertThat(timestamps.get(6)).isEqualTo(start.plusSeconds(3));
         }
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/FormatUtilsTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/FormatUtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 @DisplayName("FormatUtils")
 class FormatUtilsTest {
@@ -34,8 +35,24 @@ class FormatUtilsTest {
         }
 
         @Test
-        void shouldFormatInfinity() {
-            assertThat(FormatUtils.formatDouble(Double.POSITIVE_INFINITY)).isEqualTo("Infinity");
+        void shouldRejectNaN() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> FormatUtils.formatDouble(Double.NaN))
+                    .withMessageContaining("NaN");
+        }
+
+        @Test
+        void shouldRejectPositiveInfinity() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> FormatUtils.formatDouble(Double.POSITIVE_INFINITY))
+                    .withMessageContaining("Infinity");
+        }
+
+        @Test
+        void shouldRejectNegativeInfinity() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> FormatUtils.formatDouble(Double.NEGATIVE_INFINITY))
+                    .withMessageContaining("Infinity");
         }
 
         @Test

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
@@ -735,6 +735,49 @@ class VensimExporterTest {
                     .isEqualTo("SMOOTH3(x, 3)");
             assertThat(VensimExporter.toVensimExpr("DELAY1(x, 3)"))
                     .isEqualTo("DELAY1(x, 3)");
+            assertThat(VensimExporter.toVensimExpr("DELAY3I(x, 3, init)"))
+                    .isEqualTo("DELAY3I(x, 3, init)");
+        }
+    }
+
+    @Nested
+    @DisplayName("SAMPLE_IF_TRUE / FIND_ZERO / LOOKUP_AREA reverse mapping (#866)")
+    class MissingFunctionReverse {
+
+        @Test
+        void shouldReverseSampleIfTrue() {
+            assertThat(VensimExporter.toVensimExpr("SAMPLE_IF_TRUE(cond, input, initial)"))
+                    .isEqualTo("SAMPLE IF TRUE(cond, input, initial)");
+        }
+
+        @Test
+        void shouldReverseFindZero() {
+            assertThat(VensimExporter.toVensimExpr("FIND_ZERO(x, lo, hi)"))
+                    .isEqualTo("FIND ZERO(x, lo, hi)");
+        }
+
+        @Test
+        void shouldReverseLookupArea() {
+            assertThat(VensimExporter.toVensimExpr("LOOKUP_AREA(table, lo, hi)"))
+                    .isEqualTo("LOOKUP AREA(table, lo, hi)");
+        }
+
+        @Test
+        void shouldPreserveFunctionNamesInMixedExpressions() {
+            // Ensure underscores in function names are not replaced with spaces
+            // by the denormalization step
+            assertThat(VensimExporter.toVensimExpr("SAMPLE_IF_TRUE(flag, my_var, 0)"))
+                    .isEqualTo("SAMPLE IF TRUE(flag, my var, 0)");
+        }
+
+        @Test
+        void shouldHandleCaseInsensitiveReversal() {
+            assertThat(VensimExporter.toVensimExpr("sample_if_true(cond, x, 0)"))
+                    .isEqualTo("SAMPLE IF TRUE(cond, x, 0)");
+            assertThat(VensimExporter.toVensimExpr("find_zero(x, 0, 10)"))
+                    .isEqualTo("FIND ZERO(x, 0, 10)");
+            assertThat(VensimExporter.toVensimExpr("lookup_area(tbl, 0, 5)"))
+                    .isEqualTo("LOOKUP AREA(tbl, 0, 5)");
         }
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/model/TimeSeriesTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/TimeSeriesTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 @DisplayName("TimeSeries")
@@ -86,6 +87,113 @@ class TimeSeriesTest {
             assertThat(ts.getCurrentValue()).isEqualTo(0.0);
             time[0] = 5.0;
             assertThat(ts.getCurrentValue()).isEqualTo(0.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("Input validation")
+    class InputValidation {
+
+        @Test
+        void shouldRejectMismatchedArrayLengths() {
+            assertThatThrownBy(() ->
+                    TimeSeries.linear(new double[]{0, 1, 2}, new double[]{10, 20}, () -> 0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("same length");
+        }
+
+        @Test
+        void shouldRejectEmptyArrays() {
+            assertThatThrownBy(() ->
+                    TimeSeries.linear(new double[]{}, new double[]{}, () -> 0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("At least 2");
+        }
+
+        @Test
+        void shouldRejectSinglePoint() {
+            assertThatThrownBy(() ->
+                    TimeSeries.linear(new double[]{1.0}, new double[]{10.0}, () -> 0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("At least 2");
+        }
+
+        @Test
+        void shouldRejectNonAscendingTimeValues() {
+            assertThatThrownBy(() ->
+                    TimeSeries.linear(new double[]{0, 2, 1}, new double[]{10, 20, 30}, () -> 0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("strictly ascending");
+        }
+
+        @Test
+        void shouldRejectDuplicateTimeValues() {
+            assertThatThrownBy(() ->
+                    TimeSeries.linear(new double[]{0, 1, 1}, new double[]{10, 20, 30}, () -> 0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("strictly ascending");
+        }
+
+        @Test
+        void shouldRejectNaNInTimeValues() {
+            assertThatThrownBy(() ->
+                    TimeSeries.linear(new double[]{0, Double.NaN}, new double[]{10, 20}, () -> 0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("time values must be finite");
+        }
+
+        @Test
+        void shouldRejectInfinityInTimeValues() {
+            assertThatThrownBy(() ->
+                    TimeSeries.linear(
+                            new double[]{0, Double.POSITIVE_INFINITY},
+                            new double[]{10, 20}, () -> 0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("time values must be finite");
+        }
+
+        @Test
+        void shouldRejectNaNInDataValues() {
+            assertThatThrownBy(() ->
+                    TimeSeries.linear(new double[]{0, 1}, new double[]{10, Double.NaN}, () -> 0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("data values must be finite");
+        }
+
+        @Test
+        void shouldRejectNegativeInfinityInDataValues() {
+            assertThatThrownBy(() ->
+                    TimeSeries.linear(
+                            new double[]{0, 1},
+                            new double[]{Double.NEGATIVE_INFINITY, 20}, () -> 0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("data values must be finite");
+        }
+
+        @Test
+        void shouldRejectInvalidInputInStepFactory() {
+            assertThatThrownBy(() ->
+                    TimeSeries.step(new double[]{}, new double[]{}, () -> 0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("At least 2");
+        }
+
+        @Test
+        void shouldRejectInvalidInputInCreateFactory() {
+            assertThatThrownBy(() ->
+                    TimeSeries.create(new double[]{}, new double[]{}, () -> 0,
+                            "LINEAR", "HOLD"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("At least 2");
+        }
+
+        @Test
+        void shouldAcceptValidMinimalInput() {
+            double[] time = {0};
+            TimeSeries ts = TimeSeries.linear(
+                    new double[]{0, 1}, new double[]{10, 20}, () -> time[0]);
+            time[0] = 0.5;
+            assertThat(ts.getCurrentValue()).isCloseTo(15.0, within(1e-10));
         }
     }
 }


### PR DESCRIPTION
## Summary
- **#888**: Simulation `currentDateTime` overflow for large dt — replaced `Duration.ofNanos()` with `Duration.ofSeconds(whole, nanoRemainder)` decomposition to avoid long overflow when `ratioToBaseUnit * dt * 1e9` exceeds `Long.MAX_VALUE`
- **#887**: TimeSeries factory methods now validate arrays for matching length, minimum 2 points, finite values, and strictly ascending time
- **#867**: `FormatUtils.formatDouble` rejects NaN/Infinity with `IllegalArgumentException` instead of silently producing unparseable strings
- **#866**: VensimExporter `isKnownFunction` now includes DELAY1, DELAY3I, SMOOTHI, SAMPLE_IF_TRUE, FIND_ZERO, LOOKUP_AREA with proper reverse translations

Closes #888, #887, #867, #866