### PR TITLE
Fix appendLiteral integer formatting for extreme values (#860)

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprStringifier.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprStringifier.java
@@ -55,7 +55,7 @@ public final class ExprStringifier {
             throw new IllegalArgumentException(
                     "Cannot stringify non-finite literal: " + v);
         }
-        if (v == (long) v && Math.abs(v) < 1e15) {
+        if (Math.abs(v) < (1L << 53) && v == (long) v) {
             sb.append((long) v);
         } else {
             sb.append(v);

--- a/courant-engine/src/test/java/systems/courant/sd/model/expr/ExprStringifierTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/expr/ExprStringifierTest.java
@@ -176,6 +176,26 @@ class ExprStringifierTest {
     }
 
     @Test
+    @DisplayName("extreme values near Long.MAX_VALUE should not use integer format (#860)")
+    void shouldNotTruncateExtremeValues() {
+        // Long.MAX_VALUE as a double — must not go through the (long) cast branch
+        double maxVal = (double) Long.MAX_VALUE;
+        String result = ExprStringifier.stringify(new Expr.Literal(maxVal));
+        // Should use Double.toString format, not integer format
+        assertThat(result).isEqualTo(Double.toString(maxVal));
+
+        // Long.MIN_VALUE as a double
+        double minVal = (double) Long.MIN_VALUE;
+        result = ExprStringifier.stringify(new Expr.Literal(minVal));
+        assertThat(result).isEqualTo(Double.toString(minVal));
+
+        // Value just beyond 2^53 should also use double format
+        double beyondPrecision = (double) ((1L << 53) + 1);
+        result = ExprStringifier.stringify(new Expr.Literal(beyondPrecision));
+        assertThat(result).isEqualTo(Double.toString(beyondPrecision));
+    }
+
+    @Test
     void shouldQuoteReservedWordsUnderTurkishLocale() {
         Locale original = Locale.getDefault();
         try {


### PR DESCRIPTION
## Summary
- Swap the range guard before the `(long)` cast in `ExprStringifier.appendLiteral()` to prevent silent overflow for values near `Long.MAX_VALUE`/`Long.MIN_VALUE`
- Tighten threshold from `1e15` to `2^53` (the exact double-to-long precision boundary)
- Add test for extreme value formatting

Closes #860