### PR TITLE
Exclude simulation settings from output plots and dropdowns

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.app;
 
 import systems.courant.sd.app.canvas.AnalysisRunner;
+import systems.courant.sd.app.canvas.ChartUtils;
 import systems.courant.sd.app.canvas.DashboardPanel;
 import systems.courant.sd.app.canvas.ModelCanvas;
 import systems.courant.sd.app.canvas.ModelDefinitionFactory;
@@ -128,7 +129,9 @@ final class SimulationController {
         List<String> trackableNames = new ArrayList<>();
         activeEditor.getStocks().forEach(s -> trackableNames.add(s.name()));
         activeEditor.getFlows().forEach(f -> trackableNames.add(f.name()));
-        activeEditor.getVariables().forEach(a -> trackableNames.add(a.name()));
+        activeEditor.getVariables().stream()
+                .filter(a -> !ChartUtils.isSimulationSetting(a.name()))
+                .forEach(a -> trackableNames.add(a.name()));
 
         if (parameterNames.isEmpty()) {
             showError.accept("Model has no parameters to sweep.");
@@ -528,8 +531,8 @@ final class SimulationController {
     }
 
     private static List<String> collectTrackableNames(List<String> stocks, List<String> variables) {
-        List<String> names = new ArrayList<>(stocks);
-        names.addAll(variables);
+        List<String> names = new ArrayList<>(ChartUtils.filterSimulationSettings(stocks));
+        names.addAll(ChartUtils.filterSimulationSettings(variables));
         return names;
     }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ChartUtils.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ChartUtils.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * Shared chart utilities: color palette, series coloring, and number formatting.
@@ -38,7 +39,33 @@ public final class ChartUtils {
     /** Opacity applied to ghost run chart series. */
     public static final double GHOST_OPACITY = 0.30;
 
+    /**
+     * Simulation settings variable names that should be excluded from analysis
+     * dropdowns and output plots.
+     */
+    private static final Set<String> SIMULATION_SETTINGS_NAMES = Set.of(
+            "TIME_STEP", "INITIAL_TIME", "FINAL_TIME", "SAVEPER",
+            "TIME STEP", "INITIAL TIME", "FINAL TIME",
+            "Time Step", "Initial Time", "Final Time");
+
     private ChartUtils() {
+    }
+
+    /**
+     * Returns true if the given variable name is a simulation settings variable
+     * that should be excluded from analysis dropdowns and output charts.
+     */
+    public static boolean isSimulationSetting(String name) {
+        return SIMULATION_SETTINGS_NAMES.contains(name);
+    }
+
+    /**
+     * Filters a list of variable names, removing simulation settings variables.
+     */
+    public static List<String> filterSimulationSettings(List<String> names) {
+        return names.stream()
+                .filter(n -> !isSimulationSetting(n))
+                .toList();
     }
 
     public static void applySeriesColors(List<XYChart.Series<Number, Number>> allSeries) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/MonteCarloResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/MonteCarloResultPane.java
@@ -29,8 +29,8 @@ public class MonteCarloResultPane extends BorderPane {
         this.result = result;
 
         List<String> allNames = new ArrayList<>();
-        allNames.addAll(result.getStockNames());
-        allNames.addAll(result.getVariableNames());
+        allNames.addAll(ChartUtils.filterSimulationSettings(result.getStockNames()));
+        allNames.addAll(ChartUtils.filterSimulationSettings(result.getVariableNames()));
 
         ComboBox<String> varCombo = new ComboBox<>(FXCollections.observableArrayList(allNames));
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/MultiSweepResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/MultiSweepResultPane.java
@@ -69,7 +69,7 @@ public class MultiSweepResultPane extends BorderPane {
             table.getColumns().add(col);
         }
 
-        List<String> stockNames = result.getStockNames();
+        List<String> stockNames = ChartUtils.filterSimulationSettings(result.getStockNames());
         for (String stockName : stockNames) {
             TableColumn<RunResult, String> finalCol = new TableColumn<>(stockName + "_final");
             finalCol.setCellValueFactory(data -> {
@@ -170,6 +170,9 @@ public class MultiSweepResultPane extends BorderPane {
         for (int c = 0; c < allNames.size(); c++) {
             boolean isStock = c < run.getStockNames().size();
             int colIndex = isStock ? c : c - run.getStockNames().size();
+            if (ChartUtils.isSimulationSetting(allNames.get(c))) {
+                continue;
+            }
 
             XYChart.Series<Number, Number> series = new XYChart.Series<>();
             series.setName(allNames.get(c));

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/OptimizationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/OptimizationResultPane.java
@@ -96,6 +96,9 @@ public class OptimizationResultPane extends BorderPane {
 
         for (int c = 0; c < allNames.size(); c++) {
             String name = allNames.get(c);
+            if (ChartUtils.isSimulationSetting(name)) {
+                continue;
+            }
             boolean isStock = c < bestRun.getStockNames().size();
             int colIndex = isStock ? c : c - bestRun.getStockNames().size();
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/PhasePlotPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/PhasePlotPane.java
@@ -107,7 +107,10 @@ public class PhasePlotPane extends BorderPane {
     public static List<String> getVariableNames(SimulationRunner.SimulationResult result) {
         List<String> names = new ArrayList<>();
         for (int i = 1; i < result.columnNames().size(); i++) {
-            names.add(result.columnNames().get(i));
+            String name = result.columnNames().get(i);
+            if (!ChartUtils.isSimulationSetting(name)) {
+                names.add(name);
+            }
         }
         return names;
     }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SimulationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SimulationResultPane.java
@@ -138,6 +138,9 @@ public class SimulationResultPane extends BorderPane {
         List<String> columns = result.columnNames();
 
         for (int c = 0; c < columns.size(); c++) {
+            if (c > 0 && ChartUtils.isSimulationSetting(columns.get(c))) {
+                continue;
+            }
             final int colIndex = c;
             TableColumn<double[], String> col = new TableColumn<>(columns.get(c));
             col.setSortable(false);
@@ -202,6 +205,9 @@ public class SimulationResultPane extends BorderPane {
             List<XYChart.Series<Number, Number>> groupSeries = new ArrayList<>();
             int ghostStride = chartStride(ghostRows.size());
             for (int c = 1; c < ghostColumns.size(); c++) {
+                if (ChartUtils.isSimulationSetting(ghostColumns.get(c))) {
+                    continue;
+                }
                 XYChart.Series<Number, Number> series = new XYChart.Series<>();
                 series.setName(ghostColumns.get(c) + " (" + ghost.name() + ")");
                 for (int r = 0; r < ghostRows.size(); r += ghostStride) {
@@ -245,8 +251,11 @@ public class SimulationResultPane extends BorderPane {
         List<String> behaviorModes = new ArrayList<>();
         List<Boolean> isStock = new ArrayList<>();
         for (int c = 1; c < columns.size(); c++) {
-            XYChart.Series<Number, Number> series = new XYChart.Series<>();
             String name = columns.get(c);
+            if (ChartUtils.isSimulationSetting(name)) {
+                continue;
+            }
+            XYChart.Series<Number, Number> series = new XYChart.Series<>();
             series.setName(name);
             double[] colValues = new double[rows.size()];
             for (int r = 0; r < rows.size(); r++) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SweepResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SweepResultPane.java
@@ -38,8 +38,8 @@ public class SweepResultPane extends BorderPane {
         this.paramName = paramName;
 
         List<String> trackableNames = new ArrayList<>();
-        trackableNames.addAll(result.getStockNames());
-        trackableNames.addAll(result.getVariableNames());
+        trackableNames.addAll(ChartUtils.filterSimulationSettings(result.getStockNames()));
+        trackableNames.addAll(ChartUtils.filterSimulationSettings(result.getVariableNames()));
 
         ComboBox<String> varCombo = new ComboBox<>(FXCollections.observableArrayList(trackableNames));
         if (!trackableNames.isEmpty()) {

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ChartUtilsTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ChartUtilsTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,6 +105,52 @@ class ChartUtilsTest {
             Locale.setDefault(Locale.GERMANY);
             assertThat(ChartUtils.formatNumber(42.0)).isEqualTo("42");
             assertThat(ChartUtils.formatNumber(0.0)).isEqualTo("0");
+        }
+    }
+
+    @Nested
+    @DisplayName("filterSimulationSettings() (#880)")
+    class FilterSimulationSettings {
+
+        @Test
+        @DisplayName("filters out simulation settings variable names")
+        void shouldFilterSettingsNames() {
+            List<String> names = List.of("Population", "TIME_STEP", "INITIAL_TIME",
+                    "FINAL_TIME", "SAVEPER", "Birth Rate");
+            assertThat(ChartUtils.filterSimulationSettings(names))
+                    .containsExactly("Population", "Birth Rate");
+        }
+
+        @Test
+        @DisplayName("filters space-separated variants")
+        void shouldFilterSpaceSeparatedNames() {
+            List<String> names = List.of("Tank", "TIME STEP", "INITIAL TIME", "FINAL TIME");
+            assertThat(ChartUtils.filterSimulationSettings(names))
+                    .containsExactly("Tank");
+        }
+
+        @Test
+        @DisplayName("returns all names when no settings present")
+        void shouldReturnAllWhenNoSettings() {
+            List<String> names = List.of("Stock A", "Flow B", "Var C");
+            assertThat(ChartUtils.filterSimulationSettings(names))
+                    .containsExactly("Stock A", "Flow B", "Var C");
+        }
+
+        @Test
+        @DisplayName("isSimulationSetting returns false for normal names")
+        void shouldNotFlagNormalNames() {
+            assertThat(ChartUtils.isSimulationSetting("Population")).isFalse();
+            assertThat(ChartUtils.isSimulationSetting("Time")).isFalse();
+        }
+
+        @Test
+        @DisplayName("isSimulationSetting returns true for all known settings")
+        void shouldFlagAllKnownSettings() {
+            assertThat(ChartUtils.isSimulationSetting("TIME_STEP")).isTrue();
+            assertThat(ChartUtils.isSimulationSetting("INITIAL_TIME")).isTrue();
+            assertThat(ChartUtils.isSimulationSetting("FINAL_TIME")).isTrue();
+            assertThat(ChartUtils.isSimulationSetting("SAVEPER")).isTrue();
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `ChartUtils.isSimulationSetting()` and `filterSimulationSettings()` to identify and filter simulation settings variables (TIME_STEP, INITIAL_TIME, FINAL_TIME, SAVEPER)
- Filter applied in: SweepResultPane, MonteCarloResultPane, OptimizationResultPane, MultiSweepResultPane, PhasePlotPane, SimulationResultPane (chart + table), SimulationController (parameter sweep + sensitivity trackable names)
- Add unit tests for the new filtering methods

Closes #880