### PR TITLE
Fix 3 medium-priority issues: chart validation, y-axis, MC params

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
@@ -247,6 +247,13 @@ final class SimulationController {
         }
 
         MonteCarloDialog.Config config = configOpt.get();
+
+        String validationError = validateDistributionParameters(config.parameters());
+        if (!validationError.isEmpty()) {
+            showError.accept(validationError);
+            return;
+        }
+
         ModelDefinition def = canvas.toModelDefinition();
         SimulationSettings finalSettings = settings;
 
@@ -499,6 +506,30 @@ final class SimulationController {
                             params.size() + " parameters, " + result.findings().size() + " findings"));
                 },
                 "Extreme Condition Test Error");
+    }
+
+    /**
+     * Validates distribution parameters for Monte Carlo configurations.
+     * Returns an empty string if all parameters are valid, or a descriptive
+     * error message for the first invalid parameter found.
+     */
+    static String validateDistributionParameters(List<MonteCarloDialog.ParameterConfig> parameters) {
+        for (MonteCarloDialog.ParameterConfig p : parameters) {
+            if (p.distribution() == MonteCarloDialog.DistributionType.NORMAL) {
+                if (p.param2() <= 0) {
+                    return "Parameter '" + p.name()
+                            + "': Normal distribution requires a positive standard deviation, got "
+                            + p.param2() + ".";
+                }
+            } else {
+                if (p.param1() >= p.param2()) {
+                    return "Parameter '" + p.name()
+                            + "': Uniform distribution requires min < max, got min="
+                            + p.param1() + ", max=" + p.param2() + ".";
+                }
+            }
+        }
+        return "";
     }
 
     private void showMultiSweepSensitivity(

--- a/courant-app/src/test/java/systems/courant/sd/app/SimulationControllerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/SimulationControllerTest.java
@@ -1,0 +1,188 @@
+package systems.courant.sd.app;
+
+import systems.courant.sd.app.canvas.dialogs.MonteCarloDialog;
+import systems.courant.sd.app.canvas.dialogs.MonteCarloDialog.DistributionType;
+import systems.courant.sd.app.canvas.dialogs.MonteCarloDialog.ParameterConfig;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SimulationController")
+class SimulationControllerTest {
+
+    @Nested
+    @DisplayName("validateDistributionParameters")
+    class ValidateDistributionParameters {
+
+        // ---- Normal distribution ----
+
+        @Test
+        void shouldAcceptNormalDistributionWithPositiveSigma() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("alpha", DistributionType.NORMAL, 10.0, 2.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldRejectNormalDistributionWithZeroSigma() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("alpha", DistributionType.NORMAL, 10.0, 0.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result)
+                    .contains("alpha")
+                    .contains("positive standard deviation")
+                    .contains("0.0");
+        }
+
+        @Test
+        void shouldRejectNormalDistributionWithNegativeSigma() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("beta", DistributionType.NORMAL, 5.0, -1.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result)
+                    .contains("beta")
+                    .contains("positive standard deviation")
+                    .contains("-1.0");
+        }
+
+        @Test
+        void shouldAcceptNormalDistributionWithNegativeMean() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("gamma", DistributionType.NORMAL, -5.0, 1.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldAcceptNormalDistributionWithZeroMean() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("delta", DistributionType.NORMAL, 0.0, 3.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldAcceptNormalDistributionWithVerySmallSigma() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("epsilon", DistributionType.NORMAL, 0.0, 0.001));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result).isEmpty();
+        }
+
+        // ---- Uniform distribution ----
+
+        @Test
+        void shouldAcceptUniformDistributionWithMinLessThanMax() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("alpha", DistributionType.UNIFORM, 1.0, 10.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldRejectUniformDistributionWithMinEqualToMax() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("alpha", DistributionType.UNIFORM, 5.0, 5.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result)
+                    .contains("alpha")
+                    .contains("min < max")
+                    .contains("min=5.0")
+                    .contains("max=5.0");
+        }
+
+        @Test
+        void shouldRejectUniformDistributionWithMinGreaterThanMax() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("beta", DistributionType.UNIFORM, 10.0, 1.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result)
+                    .contains("beta")
+                    .contains("min < max")
+                    .contains("min=10.0")
+                    .contains("max=1.0");
+        }
+
+        @Test
+        void shouldAcceptUniformDistributionWithNegativeRange() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("gamma", DistributionType.UNIFORM, -10.0, -1.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result).isEmpty();
+        }
+
+        // ---- Multiple parameters ----
+
+        @Test
+        void shouldAcceptMultipleValidParameters() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("alpha", DistributionType.NORMAL, 0.0, 1.0),
+                    new ParameterConfig("beta", DistributionType.UNIFORM, 0.0, 10.0),
+                    new ParameterConfig("gamma", DistributionType.NORMAL, 5.0, 0.5));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReportFirstInvalidParameterWhenMultipleAreInvalid() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("alpha", DistributionType.NORMAL, 0.0, 1.0),
+                    new ParameterConfig("beta", DistributionType.NORMAL, 5.0, 0.0),
+                    new ParameterConfig("gamma", DistributionType.UNIFORM, 10.0, 1.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result).contains("beta");
+        }
+
+        @Test
+        void shouldReportInvalidUniformAfterValidNormal() {
+            List<ParameterConfig> params = List.of(
+                    new ParameterConfig("alpha", DistributionType.NORMAL, 0.0, 1.0),
+                    new ParameterConfig("beta", DistributionType.UNIFORM, 5.0, 5.0));
+
+            String result = SimulationController.validateDistributionParameters(params);
+
+            assertThat(result)
+                    .contains("beta")
+                    .contains("min < max");
+        }
+
+        // ---- Empty list ----
+
+        @Test
+        void shouldAcceptEmptyParameterList() {
+            String result = SimulationController.validateDistributionParameters(List.of());
+
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/courant-ui/src/main/java/systems/courant/sd/ui/ChartViewerApplication.java
+++ b/courant-ui/src/main/java/systems/courant/sd/ui/ChartViewerApplication.java
@@ -247,6 +247,8 @@ public class ChartViewerApplication extends Application {
 
     /**
      * Adds a data point to each series using a formatted timestamp as the x-axis label.
+     *
+     * @throws IllegalArgumentException if the total number of values does not match the number of series
      */
     public static void addValues(List<Double> modelEntityValues,
                                  List<Double> variableValues,
@@ -254,8 +256,9 @@ public class ChartViewerApplication extends Application {
         synchronized (LOCK) {
             List<Double> allValues = new ArrayList<>(modelEntityValues);
             allValues.addAll(variableValues);
+            validateValueCount(allValues.size());
 
-            for (int i = 0; i < allValues.size() && i < series.size(); i++) {
+            for (int i = 0; i < allValues.size(); i++) {
                 double value = allValues.get(i);
                 series.get(i).getData()
                         .add(new XYChart.Data<>(currentTime.format(formatter), value));
@@ -265,6 +268,8 @@ public class ChartViewerApplication extends Application {
 
     /**
      * Adds a data point to each series using the step number as the x-axis label.
+     *
+     * @throws IllegalArgumentException if the total number of values does not match the number of series
      */
     public static void addValues(List<Double> modelEntityValues,
                                  List<Double> variableValues,
@@ -272,12 +277,28 @@ public class ChartViewerApplication extends Application {
         synchronized (LOCK) {
             List<Double> allValues = new ArrayList<>(modelEntityValues);
             allValues.addAll(variableValues);
+            validateValueCount(allValues.size());
 
-            for (int i = 0; i < allValues.size() && i < series.size(); i++) {
+            for (int i = 0; i < allValues.size(); i++) {
                 double value = allValues.get(i);
                 series.get(i).getData()
                         .add(new XYChart.Data<>(String.valueOf(step), value));
             }
+        }
+    }
+
+    /**
+     * Validates that the number of values matches the number of series.
+     * Must be called while holding {@link #LOCK}.
+     *
+     * @param valueCount the total number of values to add
+     * @throws IllegalArgumentException if valueCount does not equal the series count
+     */
+    private static void validateValueCount(int valueCount) {
+        if (valueCount != series.size()) {
+            throw new IllegalArgumentException(
+                    "Value count (%d) does not match series count (%d)"
+                            .formatted(valueCount, series.size()));
         }
     }
 

--- a/courant-ui/src/main/java/systems/courant/sd/ui/FanChart.java
+++ b/courant-ui/src/main/java/systems/courant/sd/ui/FanChart.java
@@ -143,13 +143,9 @@ public class FanChart extends Application {
             maxVal = Math.max(maxVal, pct97[i]);
         }
 
-        // Add 5% padding
-        double range = maxVal - minVal;
-        if (range == 0) {
-            range = 1;
-        }
-        minVal -= range * 0.05;
-        maxVal += range * 0.05;
+        double[] padded = padAxisRange(minVal, maxVal);
+        minVal = padded[0];
+        maxVal = padded[1];
 
         double plotWidth = WIDTH - MARGIN_LEFT - MARGIN_RIGHT;
         double plotHeight = HEIGHT - MARGIN_TOP - MARGIN_BOTTOM;
@@ -235,5 +231,25 @@ public class FanChart extends Application {
         // X-axis label
         gc.setFont(Font.font(12));
         gc.fillText("Step", MARGIN_LEFT + plotWidth / 2 - 15, HEIGHT - 5);
+    }
+
+    /**
+     * Computes a padded y-axis range from the raw data min/max. When the data range is
+     * non-zero, adds 5% padding on each side. When all values are constant (range == 0),
+     * produces a sensible range centered on the constant value, proportional to its
+     * magnitude — or +/-1 when the constant value is zero.
+     *
+     * @param rawMin the minimum data value
+     * @param rawMax the maximum data value
+     * @return a two-element array {@code [paddedMin, paddedMax]}
+     */
+    static double[] padAxisRange(double rawMin, double rawMax) {
+        double range = rawMax - rawMin;
+        if (range != 0) {
+            return new double[]{rawMin - range * 0.05, rawMax + range * 0.05};
+        }
+        // All values are constant — use 10% of |value| as half-range, or 1 if value is 0
+        double halfRange = (rawMin == 0) ? 1.0 : Math.abs(rawMin) * 0.1;
+        return new double[]{rawMin - halfRange, rawMax + halfRange};
     }
 }

--- a/courant-ui/src/test/java/systems/courant/sd/ui/ChartViewerApplicationTest.java
+++ b/courant-ui/src/test/java/systems/courant/sd/ui/ChartViewerApplicationTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for ChartViewerApplication's static data accumulation methods.
@@ -94,30 +95,73 @@ class ChartViewerApplicationTest {
     }
 
     @Test
-    @DisplayName("addValues gracefully handles more values than series")
-    void shouldHandleExtraValues() {
+    @DisplayName("addValues with step throws on more values than series (#865)")
+    void shouldThrowOnMoreValuesThanSeries() {
         ChartViewerApplication.setSeries(List.of("OnlyOne"), List.of());
-        ChartViewerApplication.addValues(List.of(1.0, 2.0, 3.0), List.of(), 0);
 
-        // Only the first value should be recorded (one series exists)
-        ChartViewerApplication.ChartData snap = ChartViewerApplication.snapshot();
-        assertThat(snap.series()).hasSize(1);
-        assertThat(snap.series().getFirst().getData()).hasSize(1);
-        assertThat(snap.series().getFirst().getData().getFirst().getYValue().doubleValue())
-                .isEqualTo(1.0);
+        assertThatThrownBy(() ->
+                ChartViewerApplication.addValues(List.of(1.0, 2.0, 3.0), List.of(), 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Value count (3) does not match series count (1)");
     }
 
     @Test
-    @DisplayName("addValues gracefully handles fewer values than series")
-    void shouldHandleFewerValues() {
+    @DisplayName("addValues with step throws on fewer values than series (#865)")
+    void shouldThrowOnFewerValuesThanSeries() {
         ChartViewerApplication.setSeries(List.of("A", "B", "C"), List.of());
-        ChartViewerApplication.addValues(List.of(1.0), List.of(), 0);
 
-        // Only the first series should have a data point
+        assertThatThrownBy(() ->
+                ChartViewerApplication.addValues(List.of(1.0), List.of(), 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Value count (1) does not match series count (3)");
+    }
+
+    @Test
+    @DisplayName("addValues with timestamp throws on more values than series (#865)")
+    void shouldThrowOnMoreValuesThanSeriesWithTimestamp() {
+        ChartViewerApplication.setSeries(List.of("OnlyOne"), List.of());
+
+        assertThatThrownBy(() ->
+                ChartViewerApplication.addValues(List.of(1.0, 2.0), List.of(),
+                        LocalDateTime.of(2026, 1, 1, 12, 0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Value count (2) does not match series count (1)");
+    }
+
+    @Test
+    @DisplayName("addValues with timestamp throws on fewer values than series (#865)")
+    void shouldThrowOnFewerValuesThanSeriesWithTimestamp() {
+        ChartViewerApplication.setSeries(List.of("A", "B", "C"), List.of());
+
+        assertThatThrownBy(() ->
+                ChartViewerApplication.addValues(List.of(1.0), List.of(),
+                        LocalDateTime.of(2026, 1, 1, 12, 0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Value count (1) does not match series count (3)");
+    }
+
+    @Test
+    @DisplayName("addValues throws on zero values when series exist (#865)")
+    void shouldThrowOnZeroValuesWhenSeriesExist() {
+        ChartViewerApplication.setSeries(List.of("A"), List.of());
+
+        assertThatThrownBy(() ->
+                ChartViewerApplication.addValues(List.of(), List.of(), 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Value count (0) does not match series count (1)");
+    }
+
+    @Test
+    @DisplayName("addValues succeeds when values match series count exactly (#865)")
+    void shouldSucceedWhenValuesMatchSeriesCount() {
+        ChartViewerApplication.setSeries(List.of("A", "B"), List.of("C"));
+        ChartViewerApplication.addValues(List.of(1.0, 2.0), List.of(3.0), 0);
+
         ChartViewerApplication.ChartData snap = ChartViewerApplication.snapshot();
+        assertThat(snap.series()).hasSize(3);
         assertThat(snap.series().get(0).getData()).hasSize(1);
-        assertThat(snap.series().get(1).getData()).isEmpty();
-        assertThat(snap.series().get(2).getData()).isEmpty();
+        assertThat(snap.series().get(1).getData()).hasSize(1);
+        assertThat(snap.series().get(2).getData()).hasSize(1);
     }
 
     @Test

--- a/courant-ui/src/test/java/systems/courant/sd/ui/FanChartTest.java
+++ b/courant-ui/src/test/java/systems/courant/sd/ui/FanChartTest.java
@@ -4,6 +4,7 @@ import javafx.application.Platform;
 import javafx.stage.Stage;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.framework.junit5.ApplicationExtension;
@@ -13,6 +14,7 @@ import org.testfx.util.WaitForAsyncUtils;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 @DisplayName("FanChart")
 @ExtendWith(ApplicationExtension.class)
@@ -49,5 +51,83 @@ class FanChartTest {
         assertThat(result)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("FanChart requires a MonteCarloResult");
+    }
+
+    @Nested
+    @DisplayName("padAxisRange (#864)")
+    class PadAxisRangeTest {
+
+        @Test
+        @DisplayName("non-zero range adds 5% padding on each side")
+        void shouldAdd5PercentPaddingForNonZeroRange() {
+            double[] result = FanChart.padAxisRange(100, 200);
+
+            assertThat(result[0]).isCloseTo(95.0, within(1e-9));
+            assertThat(result[1]).isCloseTo(205.0, within(1e-9));
+        }
+
+        @Test
+        @DisplayName("constant non-zero value centers range at +/-10% of magnitude (#864)")
+        void shouldCenterRangeAroundConstantNonZeroValue() {
+            double[] result = FanChart.padAxisRange(1000, 1000);
+
+            // halfRange = |1000| * 0.1 = 100
+            assertThat(result[0]).isCloseTo(900.0, within(1e-9));
+            assertThat(result[1]).isCloseTo(1100.0, within(1e-9));
+        }
+
+        @Test
+        @DisplayName("constant zero value uses +/-1 range (#864)")
+        void shouldUseUnitRangeForConstantZero() {
+            double[] result = FanChart.padAxisRange(0, 0);
+
+            assertThat(result[0]).isCloseTo(-1.0, within(1e-9));
+            assertThat(result[1]).isCloseTo(1.0, within(1e-9));
+        }
+
+        @Test
+        @DisplayName("constant negative value centers range at +/-10% of magnitude (#864)")
+        void shouldCenterRangeAroundConstantNegativeValue() {
+            double[] result = FanChart.padAxisRange(-500, -500);
+
+            // halfRange = |-500| * 0.1 = 50
+            assertThat(result[0]).isCloseTo(-550.0, within(1e-9));
+            assertThat(result[1]).isCloseTo(-450.0, within(1e-9));
+        }
+
+        @Test
+        @DisplayName("small constant value scales proportionally (#864)")
+        void shouldScaleProportionallyForSmallConstant() {
+            double[] result = FanChart.padAxisRange(0.001, 0.001);
+
+            // halfRange = 0.001 * 0.1 = 0.0001
+            assertThat(result[0]).isCloseTo(0.0009, within(1e-12));
+            assertThat(result[1]).isCloseTo(0.0011, within(1e-12));
+        }
+
+        @Test
+        @DisplayName("large constant value scales proportionally (#864)")
+        void shouldScaleProportionallyForLargeConstant() {
+            double[] result = FanChart.padAxisRange(1_000_000, 1_000_000);
+
+            // halfRange = 1_000_000 * 0.1 = 100_000
+            assertThat(result[0]).isCloseTo(900_000.0, within(1e-6));
+            assertThat(result[1]).isCloseTo(1_100_000.0, within(1e-6));
+        }
+
+        @Test
+        @DisplayName("padded min is always less than padded max")
+        void shouldAlwaysProducePaddedMinLessThanPaddedMax() {
+            double[][] testCases = {
+                    {0, 0}, {1000, 1000}, {-500, -500}, {0.001, 0.001},
+                    {100, 200}, {-200, -100}, {-100, 100}
+            };
+            for (double[] tc : testCases) {
+                double[] result = FanChart.padAxisRange(tc[0], tc[1]);
+                assertThat(result[0])
+                        .as("padAxisRange(%.1f, %.1f): min < max", tc[0], tc[1])
+                        .isLessThan(result[1]);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **#865**: `ChartViewerApplication.addValues` now throws `IllegalArgumentException` on series count mismatch instead of silently dropping data
- **#864**: `FanChart` y-axis uses value-proportional padding (10% of absolute value) when all percentile values are constant, instead of an arbitrary 1-unit range
- **#861**: `SimulationController` validates Monte Carlo distribution parameters before execution — normal sigma > 0, uniform min < max — with clear user-facing error messages

Closes #865, #864, #861