### PR TITLE
Fix 20 low-priority easy issues (batch 2)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/BehaviorModeClassifier.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/BehaviorModeClassifier.java
@@ -53,7 +53,7 @@ public final class BehaviorModeClassifier {
                 // If the value at the end is near zero relative to the start, it's decay.
                 double first = values[0];
                 double last = values[values.length - 1];
-                if (first != 0 && last / first < 0.1) {
+                if (first != 0 && Math.abs(last / first) < 0.1) {
                     return "Exponential decay";
                 }
                 return "Goal-seeking";

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ChartUtils.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ChartUtils.java
@@ -128,6 +128,9 @@ public final class ChartUtils {
                 && Math.abs(value) <= Long.MAX_VALUE) {
             return String.valueOf((long) value);
         }
+        if (value != 0 && Math.abs(value) < 0.0001) {
+            return String.format(Locale.US, "%g", value);
+        }
         return String.format(Locale.US, "%.4f", value);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/DashboardPanel.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/DashboardPanel.java
@@ -342,8 +342,6 @@ public class DashboardPanel extends VBox {
                 dominanceTab = null;
             } else if (tab == phasePlotTab) {
                 phasePlotTab = null;
-            } else if (tab == dominanceTab) {
-                dominanceTab = null;
             }
             if (resultTabs.getTabs().isEmpty()) {
                 hideTabs();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ReportGenerator.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ReportGenerator.java
@@ -369,6 +369,9 @@ public final class ReportGenerator {
     }
 
     private static String formatNumber(double value) {
+        if (!Double.isFinite(value)) {
+            return String.valueOf(value);
+        }
         if (value == (long) value) {
             return String.valueOf((long) value);
         }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SweepResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SweepResultPane.java
@@ -79,6 +79,10 @@ public class SweepResultPane extends BorderPane {
                 ? result.getStockNames().indexOf(variableName)
                 : result.getVariableNames().indexOf(variableName);
 
+        if (colIndex < 0) {
+            return;
+        }
+
         for (int r = 0; r < result.getRunCount(); r++) {
             RunResult run = result.getResult(r);
             double paramValue = run.getParameterValue();

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ChartUtilsTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ChartUtilsTest.java
@@ -36,6 +36,7 @@ class ChartUtilsTest {
         @DisplayName("Very small fractional values show decimals")
         void smallFractionalValues() {
             assertThat(ChartUtils.formatNumber(0.0001)).isEqualTo("0.0001");
+            assertThat(ChartUtils.formatNumber(0.000001)).isEqualTo("1.00000e-06");
         }
 
         @Test

--- a/courant-demos/src/main/java/systems/courant/sd/demo/waterfall/WaterfallSoftwareDevelopmentDemo.java
+++ b/courant-demos/src/main/java/systems/courant/sd/demo/waterfall/WaterfallSoftwareDevelopmentDemo.java
@@ -48,15 +48,38 @@ import systems.courant.sd.ui.StockLevelChartViewer;
 public class WaterfallSoftwareDevelopmentDemo {
 
     public static void main(String[] args) {
+        // Workforce parameters
+        double initialNewHires = 2;
+        double initialExperienced = 4;
+        double workforceNeed = 30;
+        double hiringDelayWeeks = 8;
+        double assimilationDelayWeeks = 16;
+        double trainersPerNewHire = 0.2;
+        double avgEmploymentDays = 673;
+        double communicationOverhead = 0.003;
+        // StaffAllocation parameters
+        double plannedFractionForQA = 0.15;
+        double overheadLoss = 0.10;
+        // SoftwareProduction parameters
+        double projectSize = 500;
+        double baseFCC = 0.80;
+        double nominalProductivityExp = 1.0;
+        double nominalProductivityNew = 0.5;
+        double baseReworkDiscovery = 0.05;
+        double testingReworkDiscovery = 0.40;
+        double integrationCoefficient = 1.5;
+        // Simulation
+        int durationDays = 200;
+
         new WaterfallSoftwareDevelopmentDemo().run(
-                // Workforce parameters
-                2, 4, 30, 8, 16, 0.2, 673, 0.003,
-                // StaffAllocation parameters
-                0.15, 0.10,
-                // SoftwareProduction parameters
-                500, 0.80, 1.0, 0.5, 0.05, 0.40, 1.5,
-                // Simulation duration in days (work finishes ~day 175; 200 gives margin)
-                200
+                initialNewHires, initialExperienced, workforceNeed,
+                hiringDelayWeeks, assimilationDelayWeeks,
+                trainersPerNewHire, avgEmploymentDays, communicationOverhead,
+                plannedFractionForQA, overheadLoss,
+                projectSize, baseFCC,
+                nominalProductivityExp, nominalProductivityNew,
+                baseReworkDiscovery, testingReworkDiscovery, integrationCoefficient,
+                durationDays
         );
     }
 

--- a/courant-demos/src/test/java/systems/courant/sd/demo/DemoSmokeTest.java
+++ b/courant-demos/src/test/java/systems/courant/sd/demo/DemoSmokeTest.java
@@ -3,9 +3,13 @@ package systems.courant.sd.demo;
 import systems.courant.sd.Simulation;
 import systems.courant.sd.demo.agile.AgileSoftwareDevelopmentDemo;
 import systems.courant.sd.demo.waterfall.WaterfallSoftwareDevelopmentDemo;
+import systems.courant.sd.io.CsvSubscriber;
 import systems.courant.sd.measure.Quantity;
+import systems.courant.sd.measure.Units;
+import systems.courant.sd.measure.units.time.TimeUnits;
 import systems.courant.sd.measure.units.time.Times;
 import systems.courant.sd.model.Flow;
+import systems.courant.sd.model.Flows;
 import systems.courant.sd.model.Model;
 import systems.courant.sd.model.Stock;
 import systems.courant.sd.sweep.MonteCarlo;
@@ -220,7 +224,7 @@ class DemoSmokeTest {
     void thirdOrderDelayDemo() {
         Model model = new ThirdOrderMaterialDelayDemo().getModel();
         assertThat(model.getStocks()).isNotEmpty();
-        var hour = systems.courant.sd.measure.units.time.TimeUnits.HOUR;
+        var hour = TimeUnits.HOUR;
         Simulation sim = new Simulation(model, hour, Times.hours(24));
         sim.execute();
         Stock step2 = findStock(model, "Step 2");
@@ -282,15 +286,15 @@ class DemoSmokeTest {
     @Test
     @DisplayName("ThirdOrderMaterialDelayDemo flows clamp to zero when stocks are negative")
     void thirdOrderDelayFlowsClamped() {
-        var hour = systems.courant.sd.measure.units.time.TimeUnits.HOUR;
+        var hour = TimeUnits.HOUR;
         var model = new Model("Clamp Test");
-        var step1 = new systems.courant.sd.model.Stock("Step 1", -10,
-                systems.courant.sd.measure.Units.DIMENSIONLESS);
+        var step1 = new Stock("Step 1", -10,
+                Units.DIMENSIONLESS);
         double delayHours = 5.0;
-        var flow = systems.courant.sd.model.Flow.create("Step 1 delay", hour, () ->
+        var flow = Flow.create("Step 1 delay", hour, () ->
                 new Quantity(Math.max(0, Math.min(step1.getValue(),
                         step1.getValue() / delayHours)),
-                        systems.courant.sd.measure.Units.DIMENSIONLESS));
+                        Units.DIMENSIONLESS));
         step1.addOutflow(flow);
         model.addStock(step1);
         new Simulation(model, hour, Times.hours(1)).execute();
@@ -301,15 +305,15 @@ class DemoSmokeTest {
     @Test
     @DisplayName("FlowTimeDemo TAT stays non-negative during simulation")
     void flowTimeDemoTatNonNegative() {
-        var hour = systems.courant.sd.measure.units.time.TimeUnits.HOUR;
+        var hour = TimeUnits.HOUR;
         var model = new Model("TAT Clamp Test");
-        var tat = new systems.courant.sd.model.Stock("TAT", 0, hour);
+        var tat = new Stock("TAT", 0, hour);
         double capacity = 100;
         double hoursPerDay = 24.0;
         double adjustmentTime = 24.0;
-        var wip = new systems.courant.sd.model.Stock("WIP", 500,
-                systems.courant.sd.measure.Units.DIMENSIONLESS);
-        var tatAdjustment = systems.courant.sd.model.Flow.create("TAT Adjustment", hour, () -> {
+        var wip = new Stock("WIP", 500,
+                Units.DIMENSIONLESS);
+        var tatAdjustment = Flow.create("TAT Adjustment", hour, () -> {
             double currentTAT = Math.max(0, tat.getValue());
             double actualTAT = (wip.getValue() / capacity) * hoursPerDay;
             return new Quantity((actualTAT - currentTAT) / adjustmentTime, hour);
@@ -324,24 +328,24 @@ class DemoSmokeTest {
     @Test
     @DisplayName("FlowTimeDemo throughput uses clamped history index when TAT exceeds current step (#466)")
     void flowTimeDemoClampedHistoryIndex() {
-        var hour = systems.courant.sd.measure.units.time.TimeUnits.HOUR;
+        var hour = TimeUnits.HOUR;
         var model = new Model("FlowTime Clamp Test");
         double capacity = 190;
         double tatGoalHours = 336;
 
-        Stock wip = new Stock("WIP", 1000, systems.courant.sd.measure.Units.DIMENSIONLESS);
+        Stock wip = new Stock("WIP", 1000, Units.DIMENSIONLESS);
         Stock tat = new Stock("TAT", tatGoalHours, hour);
 
         Simulation sim = new Simulation(model, hour, WEEK, 1);
 
-        Flow demand = systems.courant.sd.model.Flows.linearGrowth("New Orders", DAY, wip, 200);
+        Flow demand = Flows.linearGrowth("New Orders", DAY, wip, 200);
 
         Flow throughput = Flow.create("Delivered Reports", DAY, () -> {
             int demandDelay = Math.max(0, (int) Math.round(tat.getValue()));
             int stepToGet = Math.max(0, (int) sim.getCurrentStep() - demandDelay);
             double demandPlusDelay = demand.getHistoryAtTimeStep(stepToGet);
             return new Quantity(Math.min(capacity, demandPlusDelay),
-                    systems.courant.sd.measure.Units.DIMENSIONLESS);
+                    Units.DIMENSIONLESS);
         });
 
         wip.addInflow(demand);
@@ -370,12 +374,12 @@ class DemoSmokeTest {
     void csvSubscriberWritesToTmpdir(@TempDir Path tempDir) throws Exception {
         String csvPath = tempDir.resolve("courant-test.csv").toString();
         var model = new Model("CSV Path Test");
-        var stock = new Stock("Level", 100, systems.courant.sd.measure.Units.DIMENSIONLESS);
+        var stock = new Stock("Level", 100, Units.DIMENSIONLESS);
         model.addStock(stock);
 
-        var csv = new systems.courant.sd.io.CsvSubscriber(csvPath);
-        var sim = new Simulation(model, systems.courant.sd.measure.Units.MINUTE,
-                systems.courant.sd.measure.Units.MINUTE, 2);
+        var csv = new CsvSubscriber(csvPath);
+        var sim = new Simulation(model, MINUTE,
+                MINUTE, 2);
         sim.addEventHandler(csv);
         sim.execute();
 

--- a/courant-demos/src/test/java/systems/courant/sd/demo/waterfall/WaterfallIntegrationTest.java
+++ b/courant-demos/src/test/java/systems/courant/sd/demo/waterfall/WaterfallIntegrationTest.java
@@ -6,6 +6,7 @@ import systems.courant.sd.measure.units.time.TimeUnits;
 import systems.courant.sd.model.Model;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WaterfallIntegrationTest {
@@ -60,7 +61,7 @@ class WaterfallIntegrationTest {
         Model model = demo.getModel();
 
         // 3 modules should be registered
-        assertTrue(model.getModules().size() == 3, "Model should have 3 modules");
+        assertEquals(3, model.getModules().size(), "Model should have 3 modules");
 
         // Workforce stocks
         assertTrue(model.getStockNames().contains("Newly hired"),

--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -55,6 +55,7 @@ public class ModelDefinitionSerializer {
 
     private static final Logger log = LoggerFactory.getLogger(ModelDefinitionSerializer.class);
     private static final int MAX_MODULE_DEPTH = 50;
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
     private final ObjectMapper mapper;
 
@@ -123,8 +124,6 @@ public class ModelDefinitionSerializer {
      * @throws IOException if the file cannot be read
      * @throws IllegalArgumentException if the JSON is malformed or missing required fields
      */
-    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
-
     public ModelDefinition fromFile(Path path) throws IOException {
         long size = Files.size(path);
         if (size > MAX_FILE_SIZE) {

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
@@ -1208,8 +1208,6 @@ public class VensimImporter implements ModelImporter {
             sortedYs[i] = ys[indices[i]];
         }
 
-        boolean wasUnsorted = !sorted;
-
         // Deduplicate consecutive x-values (keep last y-value)
         List<Double> newXs = new ArrayList<>();
         List<Double> newYs = new ArrayList<>();
@@ -1226,14 +1224,11 @@ public class VensimImporter implements ModelImporter {
             }
         }
 
-        if (wasUnsorted && dupes > 0) {
+        if (dupes > 0) {
             warnings.add("Lookup '" + name + "': sorted non-monotonic x-values and removed "
                     + dupes + " duplicate(s)");
-        } else if (wasUnsorted) {
-            warnings.add("Lookup '" + name + "': sorted non-monotonic x-values");
         } else {
-            warnings.add("Lookup '" + name + "': removed " + dupes
-                    + " duplicate x-value(s)");
+            warnings.add("Lookup '" + name + "': sorted non-monotonic x-values");
         }
         return new double[][]{
                 newXs.stream().mapToDouble(Double::doubleValue).toArray(),

--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
@@ -294,6 +294,14 @@ public final class XmileExporter {
             elem.appendChild(units);
         }
 
+        // <doc>
+        if (stock.comment() != null && !stock.comment().isBlank()) {
+            Element docElem = doc.createElementNS(
+                    XmileConstants.NAMESPACE_URI, "doc");
+            docElem.setTextContent(stock.comment());
+            elem.appendChild(docElem);
+        }
+
         // <non_negative>
         if ("CLAMP_TO_ZERO".equals(stock.negativeValuePolicy())) {
             Element nonNeg = doc.createElementNS(
@@ -323,6 +331,14 @@ public final class XmileExporter {
                     XmileConstants.NAMESPACE_URI, XmileConstants.UNITS);
             units.setTextContent(flow.timeUnit());
             elem.appendChild(units);
+        }
+
+        // <doc>
+        if (flow.comment() != null && !flow.comment().isBlank()) {
+            Element docElem = doc.createElementNS(
+                    XmileConstants.NAMESPACE_URI, "doc");
+            docElem.setTextContent(flow.comment());
+            elem.appendChild(docElem);
         }
 
         variablesElem.appendChild(elem);
@@ -365,6 +381,14 @@ public final class XmileExporter {
                     XmileConstants.NAMESPACE_URI, XmileConstants.UNITS);
             units.setTextContent(v.unit());
             elem.appendChild(units);
+        }
+
+        // <doc>
+        if (v.comment() != null && !v.comment().isBlank()) {
+            Element docElem = doc.createElementNS(
+                    XmileConstants.NAMESPACE_URI, "doc");
+            docElem.setTextContent(v.comment());
+            elem.appendChild(docElem);
         }
 
         variablesElem.appendChild(elem);

--- a/courant-engine/src/main/java/systems/courant/sd/model/IndexedValue.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/IndexedValue.java
@@ -57,6 +57,13 @@ public final class IndexedValue {
         this.values = values.clone();
     }
 
+    /** Trusted internal constructor — skips defensive clone. Caller must not retain the array. */
+    @SuppressWarnings("unused") // tag parameter distinguishes from cloning constructor
+    private IndexedValue(SubscriptRange range, double[] values, boolean trusted) {
+        this.range = range;
+        this.values = values;
+    }
+
     // --- Factory methods ---
 
     /**
@@ -411,14 +418,14 @@ public final class IndexedValue {
             for (int i = 0; i < result.length; i++) {
                 result[i] = op.apply(this.values[0], other.values[i]);
             }
-            return new IndexedValue(other.range, result);
+            return new IndexedValue(other.range, result, true);
         }
         if (other.isScalar()) {
             double[] result = new double[this.values.length];
             for (int i = 0; i < result.length; i++) {
                 result[i] = op.apply(this.values[i], other.values[0]);
             }
-            return new IndexedValue(this.range, result);
+            return new IndexedValue(this.range, result, true);
         }
         // Both indexed — need broadcasting
         return broadcastOp(other, op);
@@ -445,7 +452,7 @@ public final class IndexedValue {
             for (int i = 0; i < result.length; i++) {
                 result[i] = op.apply(this.values[i], other.values[i]);
             }
-            return new IndexedValue(this.range, result);
+            return new IndexedValue(this.range, result, true);
         }
 
         // Build result dimensions: all left dims, then right-only dims
@@ -494,7 +501,7 @@ public final class IndexedValue {
             result[i] = op.apply(this.values[leftFlat], other.values[rightFlat]);
         }
 
-        return new IndexedValue(resultRange, result);
+        return new IndexedValue(resultRange, result, true);
     }
 
     // --- Helpers ---

--- a/courant-engine/src/main/java/systems/courant/sd/model/Module.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Module.java
@@ -5,7 +5,6 @@ import systems.courant.sd.measure.TimeUnit;
 
 import com.google.common.base.Preconditions;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -130,7 +129,7 @@ public class Module extends Element {
      * Returns an unmodifiable list of all stocks in this module.
      */
     public List<Stock> getStocks() {
-        return Collections.unmodifiableList(new ArrayList<>(stocks.values()));
+        return List.copyOf(stocks.values());
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -842,8 +842,11 @@ public class ExprCompiler {
         requireArgs("DELAY_FIXED", args, 3);
         DoubleSupplier input = compileExpr(args.get(0));
         double delayTime = evaluateConstant(args.get(1), "DELAY_FIXED delayTime");
+        if (Double.isNaN(delayTime)) {
+            delayTime = 0;
+        }
         int delaySteps = (int) Math.round(delayTime);
-        if (Double.isNaN(delayTime) || delaySteps <= 0) {
+        if (delaySteps <= 0) {
             String msg = "DELAY_FIXED delayTime evaluated to " + delayTime
                     + " (rounded to " + delaySteps
                     + ") at compile time; using default of 1 step"

--- a/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprStringifier.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprStringifier.java
@@ -51,9 +51,13 @@ public final class ExprStringifier {
 
     private static void appendLiteral(StringBuilder sb, Expr.Literal lit) {
         double v = lit.value();
-        if (Double.isNaN(v) || Double.isInfinite(v)) {
-            throw new IllegalArgumentException(
-                    "Cannot stringify non-finite literal: " + v);
+        if (Double.isNaN(v)) {
+            sb.append("NAN");
+            return;
+        }
+        if (Double.isInfinite(v)) {
+            sb.append(v > 0 ? "INF" : "(-INF)");
+            return;
         }
         if (v == (long) v && Math.abs(v) < 1e15) {
             sb.append((long) v);

--- a/courant-engine/src/test/java/systems/courant/sd/model/expr/ExprStringifierTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/expr/ExprStringifierTest.java
@@ -128,17 +128,17 @@ class ExprStringifierTest {
     }
 
     @Test
-    void shouldThrowForNaNLiteral() {
-        assertThatThrownBy(() -> ExprStringifier.stringify(new Expr.Literal(Double.NaN)))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("non-finite");
+    void shouldStringifyNaNLiteral() {
+        assertThat(ExprStringifier.stringify(new Expr.Literal(Double.NaN)))
+                .isEqualTo("NAN");
     }
 
     @Test
-    void shouldThrowForInfinityLiteral() {
-        assertThatThrownBy(() -> ExprStringifier.stringify(new Expr.Literal(Double.POSITIVE_INFINITY)))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("non-finite");
+    void shouldStringifyInfinityLiteral() {
+        assertThat(ExprStringifier.stringify(new Expr.Literal(Double.POSITIVE_INFINITY)))
+                .isEqualTo("INF");
+        assertThat(ExprStringifier.stringify(new Expr.Literal(Double.NEGATIVE_INFINITY)))
+                .isEqualTo("(-INF)");
     }
 
     @Test

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
@@ -95,7 +95,6 @@ public class DemoClassGenerator {
     private void emitImports(StringBuilder sb, ModelDefinition definition) {
         sb.append("import systems.courant.sd.Simulation;\n");
         sb.append("import systems.courant.sd.model.ModelMetadata;\n");
-        sb.append("import systems.courant.sd.model.compile.CompiledModel;\n");
         sb.append("import systems.courant.sd.model.compile.ModelCompiler;\n");
         sb.append("import systems.courant.sd.model.def.ModelDefinitionBuilder;\n");
 


### PR DESCRIPTION
## Summary

Batch fix of 20 low-priority, easy-difficulty issues:

- **#771** Remove unused CompiledModel import from DemoClassGenerator
- **#716** Emit `<doc>` elements in XmileExporter for stocks, flows, variables
- **#715** Fix BehaviorModeClassifier misclassification with negative values
- **#714** Guard colIndex == -1 in SweepResultPane to prevent AIOOBE
- **#713** Check `Double.isFinite` before integer cast in ReportGenerator.formatNumber
- **#697** Remove dead `wasUnsorted` variable and unreachable branch in VensimImporter
- **#653** Already fixed upstream (LOOKUP_AREA uses `table.evaluate()`)
- **#652** Reorder NaN check before int cast in DELAY_FIXED
- **#651** Remove duplicate `dominanceTab` check in DashboardPanel
- **#650** Use `%g` format for small values in ChartUtils.formatNumber
- **#647** Handle NaN/Infinity in ExprStringifier instead of throwing
- **#610** Move MAX_FILE_SIZE to static fields section in ModelDefinitionSerializer
- **#609** Already fixed upstream (collectAllStocks outside loop)
- **#608** Already fixed upstream (same as #653)
- **#586** Replace fully qualified names with imports in DemoSmokeTest
- **#585** Use assertEquals instead of assertTrue in WaterfallIntegrationTest
- **#578** Add trusted no-clone constructor for internal IndexedValue operations
- **#577** Use List.copyOf in Module.getStocks
- **#576** Skipped — requires Unit interface changes
- **#574** Use named local variables in WaterfallSoftwareDevelopmentDemo.main

Closes #771, closes #716, closes #715, closes #714, closes #713, closes #697, closes #653, closes #652, closes #651, closes #650, closes #647, closes #610, closes #609, closes #608, closes #586, closes #585, closes #578, closes #577, closes #574

## Test plan
- [x] Full reactor `mvn clean compile` passes
- [x] Full reactor `mvn clean test` passes (2182 tests, 0 failures)
- [x] SpotBugs clean — zero findings