### PR TITLE
Truncate long element names that exceed element width

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
@@ -786,10 +786,7 @@ public final class SvgExporter {
                     "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%n",
                     cx, fontSize, svgColor(ColorPalette.TEXT));
             for (int i = 0; i < lineCount; i++) {
-                String line = lines.get(i);
-                if (i == 1 && lines.size() > 2) {
-                    line = ElementRenderer.truncate(line, font, maxWidth);
-                }
+                String line = ElementRenderer.truncate(lines.get(i), font, maxWidth);
                 w.printf(Locale.US,
                         "    <tspan x=\"%.2f\" y=\"%.2f\" dominant-baseline=\"central\">%s</tspan>%n",
                         cx, startY + i * lineHeight, escapeXml(line));

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
@@ -466,10 +466,7 @@ public final class ElementRenderer {
             double startY = y + (height - totalHeight) / 2 + lineHeight / 2;
 
             for (int i = 0; i < lineCount; i++) {
-                String line = lines.get(i);
-                if (i == 1 && lines.size() > 2) {
-                    line = truncate(line, font, maxWidth);
-                }
+                String line = truncate(lines.get(i), font, maxWidth);
                 gc.fillText(line, x + width / 2, startY + i * lineHeight);
             }
         }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/renderers/ElementRendererTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/renderers/ElementRendererTest.java
@@ -256,6 +256,32 @@ class ElementRendererTest {
     }
 
     @Nested
+    @DisplayName("truncate (#854)")
+    class Truncate {
+
+        @Test
+        void shouldReturnNameUnchangedWhenItFits() {
+            String name = "Stock_1";
+            String result = ElementRenderer.truncate(name, LayoutMetrics.AUX_NAME_FONT, 200);
+            assertThat(result).isEqualTo(name);
+        }
+
+        @Test
+        void shouldTruncateLongUnderscoreName() {
+            String name = "normal_immune_population_fraction_region_2_lookup";
+            String result = ElementRenderer.truncate(name, LayoutMetrics.AUX_NAME_FONT, 100);
+            assertThat(result).endsWith("\u2026");
+            assertThat(result.length()).isLessThan(name.length());
+        }
+
+        @Test
+        void shouldReturnEllipsisWhenNothingFits() {
+            String result = ElementRenderer.truncate("ABCDEFG", LayoutMetrics.AUX_NAME_FONT, 1);
+            assertThat(result).isEqualTo("\u2026");
+        }
+    }
+
+    @Nested
     @DisplayName("measureLineHeight (#459)")
     class MeasureLineHeight {
 


### PR DESCRIPTION
## Summary
- `drawWrappedName()` now truncates every line that overflows the element width, not just line 2 when there are 3+ wrapped lines
- Fixes names without spaces (e.g. `normal_immune_population_fraction_region_2_lookup`) that `wrapText()` cannot break into multiple words, causing the full name to overflow the element box
- Same fix applied to SVG exporter for consistency

## Test plan
- [x] New truncation tests for long underscore-separated names
- [x] Full reactor compile passes
- [x] All tests pass
- [x] SpotBugs clean

Closes #854