### PR TITLE
Replace blocking 5-second decompress with non-blocking retry loop

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/UndoManager.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/UndoManager.java
@@ -15,12 +15,10 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 
 /**
  * Snapshot-based undo/redo manager. Stores LZ4-compressed JSON snapshots
@@ -331,27 +329,25 @@ public class UndoManager implements AutoCloseable {
         if (raw != null) {
             return raw;
         }
-        // Prefer non-blocking getNow() to avoid stalling the FX thread.
-        // Fall back to a bounded get() with a 5-second timeout to prevent
-        // indefinite blocking if something goes wrong.
-        CompressedData data;
-        try {
-            data = entry.future().getNow(null);
-        } catch (java.util.concurrent.CompletionException e) {
-            throw new IllegalStateException("Undo compression failed", e.getCause());
-        }
-        if (data == null) {
+        // Non-blocking retry loop: try getNow() with brief pauses to avoid
+        // blocking the FX thread for more than ~100ms total.  The raw snapshot
+        // fast-path above handles most cases; this loop covers entries whose
+        // raw snapshot was already consumed but whose compression is nearly done.
+        CompressedData data = null;
+        for (int attempt = 0; attempt < 10; attempt++) {
             try {
-                data = entry.future().get(5, TimeUnit.SECONDS);
-            } catch (TimeoutException e) {
-                throw new IllegalStateException(
-                        "Undo decompression timed out — compression did not complete within 5 seconds", e);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException("Undo decompression interrupted", e);
-            } catch (ExecutionException e) {
+                data = entry.future().getNow(null);
+            } catch (java.util.concurrent.CompletionException e) {
                 throw new IllegalStateException("Undo compression failed", e.getCause());
             }
+            if (data != null) {
+                break;
+            }
+            LockSupport.parkNanos(10_000_000L); // 10 ms
+        }
+        if (data == null) {
+            throw new IllegalStateException(
+                    "Undo decompression timed out — compression did not complete within 100 ms");
         }
         byte[] rawBytes = new byte[data.originalLength()];
         DECOMPRESSOR.decompress(data.data(), 0, rawBytes, 0, data.originalLength());

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/UndoManagerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/UndoManagerTest.java
@@ -387,6 +387,25 @@ class UndoManagerTest {
         }
 
         @Test
+        void shouldTimeoutWithinMillisecondsNotSeconds() {
+            // Inject an entry whose future never completes and raw snapshot is null.
+            // The old code would block for 5 seconds; the new code times out in ~100ms.
+            CompletableFuture<UndoManager.CompressedData> neverComplete = new CompletableFuture<>();
+            UndoManager.UndoEntry entry = new UndoManager.UndoEntry(
+                    neverComplete, "Stuck", null);
+            manager.pushEntry(entry);
+
+            long start = System.nanoTime();
+            assertThatThrownBy(() -> manager.undo(snapshot("Current")))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("100 ms");
+            long elapsed = (System.nanoTime() - start) / 1_000_000;
+
+            assertThat(elapsed).isLessThan(500); // well under 5 seconds
+            neverComplete.cancel(false);
+        }
+
+        @Test
         void shouldThrowOnCompressionFailure() {
             // Inject an entry whose compression future completed exceptionally
             // and whose rawSnapshot is null (simulating a lost snapshot)


### PR DESCRIPTION
## Summary
- `decompress()` now uses a non-blocking retry loop (10 x 10ms `getNow()` checks) instead of `future.get(5, SECONDS)`
- Maximum FX thread stall reduced from 5 seconds to ~100ms
- Removed unused `TimeUnit`, `TimeoutException`, and `ExecutionException` imports

## Test plan
- [x] New test verifies timeout completes in <500ms (not 5 seconds)
- [x] Existing compression round-trip tests still pass
- [x] Full reactor compile and test pass
- [x] SpotBugs clean

Closes #863