### PR TITLE
Fix element jump when zooming during drag

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/InputDispatcher.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/InputDispatcher.java
@@ -358,7 +358,7 @@ final class InputDispatcher {
             }
 
             // Start drag for all selected elements
-            dragController.start(hit, event.getX(), event.getY(), canvasState);
+            dragController.start(hit, event.getX(), event.getY(), canvasState, canvas.viewport());
         } else {
             // No element hit — check for connection click (info links then causal links)
             ConnectionId connHit = HitTester.hitTestInfoLink(

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/DragController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/DragController.java
@@ -15,8 +15,8 @@ public final class DragController {
     private boolean dragging;
     private String dragTarget;
     private boolean undoSaved;
-    private double startScreenX;
-    private double startScreenY;
+    private double startWorldX;
+    private double startWorldY;
     private final Map<String, CanvasState.Position> startPositions = new HashMap<>();
 
     public boolean isDragging() {
@@ -35,12 +35,13 @@ public final class DragController {
      * Begins a drag operation for the given target element.
      * Captures the starting positions of all currently selected elements.
      */
-    public void start(String target, double screenX, double screenY, CanvasState state) {
+    public void start(String target, double screenX, double screenY,
+              CanvasState state, Viewport viewport) {
         dragging = true;
         dragTarget = target;
         undoSaved = false;
-        startScreenX = screenX;
-        startScreenY = screenY;
+        startWorldX = viewport.toWorldX(screenX);
+        startWorldY = viewport.toWorldY(screenY);
         startPositions.clear();
         for (String name : state.getSelection()) {
             startPositions.put(name,
@@ -61,8 +62,10 @@ public final class DragController {
             saveUndo.run();
             undoSaved = true;
         }
-        double worldDx = (screenX - startScreenX) / viewport.getScale();
-        double worldDy = (screenY - startScreenY) / viewport.getScale();
+        double worldX = viewport.toWorldX(screenX);
+        double worldY = viewport.toWorldY(screenY);
+        double worldDx = worldX - startWorldX;
+        double worldDy = worldY - startWorldY;
         for (Map.Entry<String, CanvasState.Position> entry : startPositions.entrySet()) {
             CanvasState.Position startPos = entry.getValue();
             state.setPosition(entry.getKey(),

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/DragControllerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/DragControllerTest.java
@@ -58,7 +58,7 @@ class DragControllerTest {
         @Test
         void shouldSetDraggingTrue() {
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             assertThat(controller.isDragging()).isTrue();
         }
@@ -66,7 +66,7 @@ class DragControllerTest {
         @Test
         void shouldSetDragTarget() {
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             assertThat(controller.getDragTarget()).isEqualTo("A");
         }
@@ -74,7 +74,7 @@ class DragControllerTest {
         @Test
         void shouldNotHaveMoved() {
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             assertThat(controller.hasMoved()).isFalse();
         }
@@ -87,7 +87,7 @@ class DragControllerTest {
         @Test
         void shouldMoveSelectedElementByWorldDelta() {
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             controller.drag(70, 80, state, viewport, () -> {});
 
@@ -100,7 +100,7 @@ class DragControllerTest {
         void shouldMoveAllSelectedElements() {
             state.select("A");
             state.addToSelection("B");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             controller.drag(70, 80, state, viewport, () -> {});
 
@@ -114,7 +114,7 @@ class DragControllerTest {
         void shouldApplyScaleToWorldDelta() {
             viewport.zoomAt(0, 0, 2.0); // scale = 2.0
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             controller.drag(70, 80, state, viewport, () -> {});
 
@@ -124,10 +124,26 @@ class DragControllerTest {
         }
 
         @Test
+        void shouldNotJumpWhenScaleChangesMidDrag() {
+            state.select("A");
+            controller.start("A", 100, 100, state, viewport);
+
+            // Zoom in to 2x at the pivot (100,100)
+            viewport.zoomAt(100, 100, 2.0);
+
+            // Continue dragging at screen (120, 120)
+            controller.drag(120, 120, state, viewport, () -> {});
+
+            // World delta = toWorldX(120) - 100 = 10 at scale 2.0
+            assertThat(state.getX("A")).isCloseTo(110, within(0.001));
+            assertThat(state.getY("A")).isCloseTo(210, within(0.001));
+        }
+
+        @Test
         void shouldSaveUndoOnFirstDrag() {
             AtomicInteger undoCount = new AtomicInteger(0);
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             controller.drag(60, 70, state, viewport, undoCount::incrementAndGet);
 
@@ -138,7 +154,7 @@ class DragControllerTest {
         void shouldNotSaveUndoOnSubsequentDrags() {
             AtomicInteger undoCount = new AtomicInteger(0);
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             controller.drag(60, 70, state, viewport, undoCount::incrementAndGet);
             controller.drag(80, 90, state, viewport, undoCount::incrementAndGet);
@@ -150,7 +166,7 @@ class DragControllerTest {
         @Test
         void shouldReportHasMoved() {
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             controller.drag(70, 80, state, viewport, () -> {});
 
@@ -170,7 +186,7 @@ class DragControllerTest {
         @Test
         void shouldComputeDeltaRelativeToStartPosition() {
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             // Multiple drag calls should all compute delta from original start
             controller.drag(60, 70, state, viewport, () -> {});
@@ -188,7 +204,7 @@ class DragControllerTest {
         @Test
         void shouldSetDraggingFalse() {
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
             controller.drag(70, 80, state, viewport, () -> {});
 
             controller.end();
@@ -199,7 +215,7 @@ class DragControllerTest {
         @Test
         void shouldClearDragTarget() {
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
 
             controller.end();
 
@@ -209,7 +225,7 @@ class DragControllerTest {
         @Test
         void shouldPreserveFinalPositions() {
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
             controller.drag(70, 80, state, viewport, () -> {});
 
             controller.end();
@@ -226,12 +242,12 @@ class DragControllerTest {
         @Test
         void shouldAllowRestartAfterEnd() {
             state.select("A");
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
             controller.drag(70, 80, state, viewport, () -> {});
             controller.end();
 
             // Start a new drag
-            controller.start("A", 0, 0, state);
+            controller.start("A", 0, 0, state, viewport);
 
             assertThat(controller.isDragging()).isTrue();
             assertThat(controller.getDragTarget()).isEqualTo("A");
@@ -242,11 +258,11 @@ class DragControllerTest {
             AtomicInteger undoCount = new AtomicInteger(0);
             state.select("A");
 
-            controller.start("A", 50, 60, state);
+            controller.start("A", 50, 60, state, viewport);
             controller.drag(70, 80, state, viewport, undoCount::incrementAndGet);
             controller.end();
 
-            controller.start("A", 0, 0, state);
+            controller.start("A", 0, 0, state, viewport);
             controller.drag(10, 10, state, viewport, undoCount::incrementAndGet);
 
             assertThat(undoCount.get()).isEqualTo(2);


### PR DESCRIPTION
## Summary
- Store drag start position in world coordinates instead of screen coordinates in `DragController`
- Compute world-space delta using `viewport.toWorldX/Y` in both `start()` and `drag()`, making the drag immune to mid-drag scale changes
- Add test for mid-drag zoom stability

Closes #892