### PR TITLE
Handle backtick-quoted identifiers in SubscriptExpander (#859)

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/SubscriptExpander.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/SubscriptExpander.java
@@ -157,18 +157,31 @@ public class SubscriptExpander {
         Matcher matcher = namePattern.matcher(equation);
         StringBuilder result = new StringBuilder();
         while (matcher.find()) {
-            String matchedName = matcher.group();
-            if (subscriptedNames.contains(matchedName)) {
+            String matchedText = matcher.group();
+            // Strip backticks to get the raw element name
+            String rawName;
+            boolean wasQuoted;
+            if (matchedText.startsWith("`") && matchedText.endsWith("`")) {
+                rawName = matchedText.substring(1, matchedText.length() - 1);
+                wasQuoted = true;
+            } else {
+                rawName = matchedText;
+                wasQuoted = false;
+            }
+            if (subscriptedNames.contains(rawName)) {
                 // Check if already has a bracket suffix (don't double-expand)
                 int afterMatch = matcher.end();
                 if (afterMatch < equation.length() && equation.charAt(afterMatch) == '[') {
-                    matcher.appendReplacement(result, Matcher.quoteReplacement(matchedName));
+                    matcher.appendReplacement(result, Matcher.quoteReplacement(matchedText));
                 } else {
-                    matcher.appendReplacement(result,
-                            Matcher.quoteReplacement(matchedName + "[" + label + "]"));
+                    // Place [label] after the closing backtick if quoted
+                    String replacement = wasQuoted
+                            ? "`" + rawName + "`[" + label + "]"
+                            : rawName + "[" + label + "]";
+                    matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
                 }
             } else {
-                matcher.appendReplacement(result, Matcher.quoteReplacement(matchedName));
+                matcher.appendReplacement(result, Matcher.quoteReplacement(matchedText));
             }
         }
         matcher.appendTail(result);
@@ -247,9 +260,12 @@ public class SubscriptExpander {
             if (i > 0) {
                 sb.append('|');
             }
-            // Use lookahead/lookbehind for identifier boundaries
+            String quoted = Pattern.quote(sorted.get(i));
+            // Match backtick-quoted form first, then unquoted with word boundaries
+            sb.append("`").append(quoted).append("`");
+            sb.append("|");
             sb.append("(?<![\\w])");
-            sb.append(Pattern.quote(sorted.get(i)));
+            sb.append(quoted);
             sb.append("(?![\\w])");
         }
         return Pattern.compile(sb.toString());

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/SubscriptExpanderTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/SubscriptExpanderTest.java
@@ -241,6 +241,48 @@ class SubscriptExpanderTest {
         }
     }
 
+    @Nested
+    @DisplayName("Backtick-quoted identifiers (#859)")
+    class BacktickQuotedIdentifiers {
+
+        @Test
+        @DisplayName("should place [label] after closing backtick, not inside")
+        void shouldHandleBacktickQuotedName() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Quoted Ref")
+                    .subscript("Region", List.of("North", "South"))
+                    .stock("Population Growth", 100, "Person", List.of("Region"))
+                    .variable("net rate", "`Population Growth` * 0.02", "Person/Year",
+                            List.of("Region"))
+                    .build();
+
+            ModelDefinition expanded = SubscriptExpander.expand(def);
+
+            assertThat(expanded.variables().get(0).equation())
+                    .isEqualTo("`Population Growth`[North] * 0.02");
+            assertThat(expanded.variables().get(1).equation())
+                    .isEqualTo("`Population Growth`[South] * 0.02");
+        }
+
+        @Test
+        @DisplayName("should handle mix of quoted and unquoted subscripted refs")
+        void shouldHandleMixedQuotedAndUnquoted() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Mixed Quoting")
+                    .subscript("Region", List.of("A"))
+                    .stock("Population Growth", 100, "Person", List.of("Region"))
+                    .stock("Pop", 50, "Person", List.of("Region"))
+                    .variable("total", "`Population Growth` + Pop", "Person",
+                            List.of("Region"))
+                    .build();
+
+            ModelDefinition expanded = SubscriptExpander.expand(def);
+
+            assertThat(expanded.variables().get(0).equation())
+                    .isEqualTo("`Population Growth`[A] + Pop[A]");
+        }
+    }
+
     @Test
     void shouldThrowOnUnknownSubscriptDimension() {
         ModelDefinition def = new ModelDefinitionBuilder()


### PR DESCRIPTION
## Summary
- Extend the name-matching regex to also match backtick-quoted forms (`` `Name` ``), placing `[label]` after the closing backtick rather than inside the quotes
- Previously, `` `Population Growth` `` would become `` `Population Growth[North]` `` (invalid); now produces `` `Population Growth`[North] ``

Closes #859