### PR TITLE
Replace exception control flow with supportsBaseConversion() in Quantity

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/measure/Quantity.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/Quantity.java
@@ -277,12 +277,11 @@ public final class Quantity {
         if (unit.equals(quantity.unit)) {
             return Double.compare(value, quantity.value) == 0;
         }
-        try {
-            return Double.compare(quantity.inBaseUnits().getValue(), inBaseUnits().getValue()) == 0;
-        } catch (UnsupportedOperationException e) {
+        if (!unit.supportsBaseConversion() || !quantity.unit.supportsBaseConversion()) {
             // Units that don't support base-unit conversion (e.g., Fahrenheit vs Celsius)
             return false;
         }
+        return Double.compare(quantity.inBaseUnits().getValue(), inBaseUnits().getValue()) == 0;
     }
 
     /**
@@ -292,13 +291,12 @@ public final class Quantity {
      */
     @Override
     public int hashCode() {
-        try {
+        if (unit.supportsBaseConversion()) {
             double baseValue = inBaseUnits().getValue();
             return 31 * Double.hashCode(baseValue) + getDimension().hashCode();
-        } catch (UnsupportedOperationException e) {
-            // Units that don't support base-unit conversion (e.g., Fahrenheit)
-            return 31 * Double.hashCode(value) + unit.hashCode();
         }
+        // Units that don't support base-unit conversion (e.g., Fahrenheit)
+        return 31 * Double.hashCode(value) + unit.hashCode();
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/measure/Unit.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/Unit.java
@@ -76,4 +76,15 @@ public interface Unit {
     default double toBaseUnits(double amount) {
         return amount * ratioToBaseUnit();
     }
+
+    /**
+     * Returns whether this unit supports ratio-based conversion to/from the dimension's base unit.
+     * Most units return {@code true}; units like Fahrenheit return {@code false} because their
+     * conversion requires an offset that cannot be expressed as a simple ratio.
+     *
+     * @return {@code true} if {@link #toBaseUnits} and {@link #fromBaseUnits} are supported
+     */
+    default boolean supportsBaseConversion() {
+        return true;
+    }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/measure/units/temperature/TemperatureUnits.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/units/temperature/TemperatureUnits.java
@@ -62,6 +62,11 @@ public enum TemperatureUnits implements Unit {
         public double fromBaseUnits(double inBaseUnits) {
             throw conversionError();
         }
+
+        @Override
+        public boolean supportsBaseConversion() {
+            return false;
+        }
     };
 
     private final String name;

--- a/courant-engine/src/test/java/systems/courant/sd/measure/TemperatureUnitsTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/TemperatureUnitsTest.java
@@ -122,4 +122,14 @@ public class TemperatureUnitsTest {
         Quantity m = new Quantity(100, Units.METER);
         assertFalse(f.isCompatibleWith(m));
     }
+
+    @Test
+    public void celsiusShouldSupportBaseConversion() {
+        assertTrue(TemperatureUnits.CELSIUS.supportsBaseConversion());
+    }
+
+    @Test
+    public void fahrenheitShouldNotSupportBaseConversion() {
+        assertFalse(TemperatureUnits.FAHRENHEIT.supportsBaseConversion());
+    }
 }


### PR DESCRIPTION
## Summary
- Add `Unit.supportsBaseConversion()` default method (returns `true`)
- Override to return `false` in `TemperatureUnits.FAHRENHEIT`
- Replace try-catch in `Quantity.hashCode()` and `equals()` with the new check

Closes #576