### PR TITLE
Add division-by-zero validation for delay demo parameters

### DIFF
--- a/courant-demos/src/main/java/systems/courant/sd/demo/FirstOrderMaterialDelayDemo.java
+++ b/courant-demos/src/main/java/systems/courant/sd/demo/FirstOrderMaterialDelayDemo.java
@@ -5,6 +5,8 @@
 
 package systems.courant.sd.demo;
 
+import com.google.common.base.Preconditions;
+
 import systems.courant.sd.Simulation;
 import systems.courant.sd.measure.units.time.TimeUnits;
 import systems.courant.sd.measure.units.time.Times;
@@ -47,6 +49,8 @@ public class FirstOrderMaterialDelayDemo {
     }
 
     public Model getModel(double initialCustomers, double averageDelayDays) {
+        Preconditions.checkArgument(averageDelayDays > 0, "averageDelayDays must be > 0");
+
         Model model = new Model("First order material delay");
         model.setMetadata(ModelMetadata.builder()
                 .license("CC-BY-SA-4.0")

--- a/courant-demos/src/main/java/systems/courant/sd/demo/InventoryModelDemo.java
+++ b/courant-demos/src/main/java/systems/courant/sd/demo/InventoryModelDemo.java
@@ -5,6 +5,8 @@
 
 package systems.courant.sd.demo;
 
+import com.google.common.base.Preconditions;
+
 import systems.courant.sd.Simulation;
 import systems.courant.sd.measure.Quantity;
 import systems.courant.sd.model.Flow;
@@ -53,6 +55,10 @@ public class InventoryModelDemo {
                                        double baseDemand, double stepDemand, int demandStepChangeDay,
                                        double perceptionDelay, double responseDelay, double deliveryDelay,
                                        double desiredInventoryMultiplier, double durationDays) {
+
+        Preconditions.checkArgument(perceptionDelay > 0, "perceptionDelay must be > 0");
+        Preconditions.checkArgument(responseDelay > 0, "responseDelay must be > 0");
+        Preconditions.checkArgument(deliveryDelay > 0, "deliveryDelay must be > 0");
 
         Model model = new Model("Inventory Model");
         model.setMetadata(ModelMetadata.builder()

--- a/courant-demos/src/main/java/systems/courant/sd/demo/ThirdOrderMaterialDelayDemo.java
+++ b/courant-demos/src/main/java/systems/courant/sd/demo/ThirdOrderMaterialDelayDemo.java
@@ -5,6 +5,8 @@
 
 package systems.courant.sd.demo;
 
+import com.google.common.base.Preconditions;
+
 import systems.courant.sd.Simulation;
 import systems.courant.sd.io.CsvSubscriber;
 import systems.courant.sd.measure.Quantity;
@@ -66,6 +68,10 @@ public class ThirdOrderMaterialDelayDemo {
     public Model getModel(double initialStep1, double initialStep2, double initialStep3,
                            double processDemandPerDay, double step1DelayHours,
                            double step2DelayHours, double step3DelayHours) {
+
+        Preconditions.checkArgument(step1DelayHours > 0, "step1DelayHours must be > 0");
+        Preconditions.checkArgument(step2DelayHours > 0, "step2DelayHours must be > 0");
+        Preconditions.checkArgument(step3DelayHours > 0, "step3DelayHours must be > 0");
 
         Model model = new Model("Third order material delay");
         model.setMetadata(ModelMetadata.builder()

--- a/courant-demos/src/test/java/systems/courant/sd/demo/DemoSmokeTest.java
+++ b/courant-demos/src/test/java/systems/courant/sd/demo/DemoSmokeTest.java
@@ -29,6 +29,7 @@ import static systems.courant.sd.measure.Units.DAY;
 import static systems.courant.sd.measure.Units.MINUTE;
 import static systems.courant.sd.measure.Units.WEEK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Smoke tests for all demo models. Each test verifies that the actual demo class
@@ -436,6 +437,53 @@ class DemoSmokeTest {
                 }
             }
         }
+    }
+
+    // ---- Division-by-zero validation tests ----
+
+    @Test
+    @DisplayName("InventoryModelDemo rejects zero perceptionDelay")
+    void inventoryDemoZeroPerceptionDelay() {
+        assertThatThrownBy(() -> new InventoryModelDemo()
+                .createSimulation(200, 20, 20, 22, 25, 0, 3, 5, 10, 100))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("InventoryModelDemo rejects zero responseDelay")
+    void inventoryDemoZeroResponseDelay() {
+        assertThatThrownBy(() -> new InventoryModelDemo()
+                .createSimulation(200, 20, 20, 22, 25, 5, 0, 5, 10, 100))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("InventoryModelDemo rejects zero deliveryDelay")
+    void inventoryDemoZeroDeliveryDelay() {
+        assertThatThrownBy(() -> new InventoryModelDemo()
+                .createSimulation(200, 20, 20, 22, 25, 5, 3, 0, 10, 100))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("FirstOrderMaterialDelayDemo rejects zero averageDelayDays")
+    void firstOrderDelayDemoZeroDelay() {
+        assertThatThrownBy(() -> new FirstOrderMaterialDelayDemo().getModel(1000, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("ThirdOrderMaterialDelayDemo rejects zero step delays")
+    void thirdOrderDelayDemoZeroDelays() {
+        assertThatThrownBy(() -> new ThirdOrderMaterialDelayDemo()
+                .getModel(100, 0, 0, 48, 0, 6.3, 3.2))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ThirdOrderMaterialDelayDemo()
+                .getModel(100, 0, 0, 48, 7.0, 0, 3.2))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ThirdOrderMaterialDelayDemo()
+                .getModel(100, 0, 0, 48, 7.0, 6.3, 0))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     // ---- Helpers ----


### PR DESCRIPTION
## Summary
- Add `Preconditions.checkArgument(delay > 0)` in `InventoryModelDemo`, `FirstOrderMaterialDelayDemo`, and `ThirdOrderMaterialDelayDemo`
- Add validation tests in `DemoSmokeTest`

Closes #573