### PR TITLE
Fix TIME, STEP, RAMP, PULSE, PULSE_TRAIN to use simulation time

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -254,7 +254,8 @@ public class ExprCompiler {
         return switch (name) {
             case "TIME" -> {
                 requireArgs(name, args, 0);
-                yield () -> context.getCurrentStep().getAsLong();
+                double[] dtH = context.getDtHolder();
+                yield () -> context.getCurrentStep().getAsLong() * dtH[0];
             }
             case "DT" -> {
                 requireArgs(name, args, 0);
@@ -774,7 +775,8 @@ public class ExprCompiler {
         requireArgs("STEP", args, 2);
         double height = evaluateConstant(args.get(0), "STEP height");
         double time = evaluateConstant(args.get(1), "STEP time");
-        Step step = Step.of(height, Math.round(time), context.getCurrentStep());
+        double dt = context.getDt();
+        Step step = Step.of(height, Math.round(time / dt), context.getCurrentStep());
         return step::getCurrentValue;
     }
 
@@ -784,14 +786,15 @@ public class ExprCompiler {
                     "RAMP requires 2-3 arguments, got " + args.size(), "RAMP");
         }
         double slope = evaluateConstant(args.get(0), "RAMP slope");
-        double start = evaluateConstant(args.get(1), "RAMP startStep");
+        double start = evaluateConstant(args.get(1), "RAMP startTime");
+        double dt = context.getDt();
         Ramp ramp;
         if (args.size() == 3) {
-            double end = evaluateConstant(args.get(2), "RAMP endStep");
-            ramp = Ramp.of(slope, Math.round(start), Math.round(end),
+            double end = evaluateConstant(args.get(2), "RAMP endTime");
+            ramp = Ramp.of(slope * dt, Math.round(start / dt), Math.round(end / dt),
                     context.getCurrentStep());
         } else {
-            ramp = Ramp.of(slope, Math.round(start), context.getCurrentStep());
+            ramp = Ramp.of(slope * dt, Math.round(start / dt), context.getCurrentStep());
         }
         return ramp::getCurrentValue;
     }
@@ -803,13 +806,14 @@ public class ExprCompiler {
         }
         double magnitude = evaluateConstant(args.get(0), "PULSE magnitude");
         double start = evaluateConstant(args.get(1), "PULSE startTime");
+        double dt = context.getDt();
         Pulse pulse;
         if (args.size() == 3) {
             double interval = evaluateConstant(args.get(2), "PULSE interval");
-            pulse = Pulse.of(magnitude, Math.round(start),
-                    Math.round(interval), context.getCurrentStep());
+            pulse = Pulse.of(magnitude, Math.round(start / dt),
+                    Math.round(interval / dt), context.getCurrentStep());
         } else {
-            pulse = Pulse.of(magnitude, Math.round(start), context.getCurrentStep());
+            pulse = Pulse.of(magnitude, Math.round(start / dt), context.getCurrentStep());
         }
         return pulse::getCurrentValue;
     }
@@ -820,8 +824,9 @@ public class ExprCompiler {
         DoubleSupplier duration = compileExpr(args.get(1));
         DoubleSupplier repeatInterval = compileExpr(args.get(2));
         DoubleSupplier endTime = compileExpr(args.get(3));
+        double[] dtH = context.getDtHolder();
         return () -> {
-            double t = context.getCurrentStep().getAsLong();
+            double t = context.getCurrentStep().getAsLong() * dtH[0];
             double start = startTime.getAsDouble();
             double end = endTime.getAsDouble();
             double dur = duration.getAsDouble();

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
@@ -1457,4 +1457,86 @@ class ExprCompilerTest {
             assertThat(afterFormula.getCurrentValue()).isEqualTo(5.0);
         }
     }
+
+    @Nested
+    @DisplayName("Fractional DT (#858)")
+    class FractionalDt {
+
+        private CompilationContext fracCtx;
+        private ExprCompiler fracCompiler;
+        private long[] fracStep;
+
+        @BeforeEach
+        void setUp() {
+            fracStep = new long[]{0};
+            UnitRegistry registry = new UnitRegistry();
+            double[] dtHolder = {0.25};
+            fracCtx = new CompilationContext(registry, () -> fracStep[0], null, dtHolder);
+            fracCompiler = new ExprCompiler(fracCtx, new ArrayList<>());
+            fracCtx.addLiteralConstant("Rate", 0.05);
+        }
+
+        @Test
+        void shouldReturnSimulationTimeNotStepIndex() {
+            Formula formula = fracCompiler.compile("TIME");
+            fracStep[0] = 0;
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+            fracStep[0] = 4;  // 4 steps * 0.25 = time 1.0
+            assertThat(formula.getCurrentValue()).isEqualTo(1.0);
+            fracStep[0] = 40; // 40 steps * 0.25 = time 10.0
+            assertThat(formula.getCurrentValue()).isEqualTo(10.0);
+        }
+
+        @Test
+        void shouldFireStepAtCorrectTime() {
+            Formula formula = fracCompiler.compile("STEP(10, 5)");
+            // time 5 = step 20 (5 / 0.25)
+            fracStep[0] = 19;
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+            fracStep[0] = 20;
+            assertThat(formula.getCurrentValue()).isEqualTo(10.0);
+        }
+
+        @Test
+        void shouldFirePulseAtCorrectTime() {
+            Formula formula = fracCompiler.compile("PULSE(100, 3)");
+            // time 3 = step 12 (3 / 0.25)
+            fracStep[0] = 11;
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+            fracStep[0] = 12;
+            assertThat(formula.getCurrentValue()).isEqualTo(100.0);
+            fracStep[0] = 13;
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+        }
+
+        @Test
+        void shouldRampAtCorrectRate() {
+            Formula formula = fracCompiler.compile("RAMP(2, 4)");
+            // time 4 = step 16, slope=2 per time unit, so 2 * dt = 0.5 per step
+            fracStep[0] = 15;
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+            fracStep[0] = 16; // time 4, ramp starts
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+            fracStep[0] = 20; // time 5, elapsed = 4 steps, value = 0.5 * 4 = 2.0
+            assertThat(formula.getCurrentValue()).isCloseTo(2.0, within(1e-10));
+        }
+
+        @Test
+        void shouldComputePulseTrainWithCorrectTiming() {
+            fracCtx.addLiteralConstant("start", 2);
+            fracCtx.addLiteralConstant("dur", 1);
+            fracCtx.addLiteralConstant("repeat", 4);
+            fracCtx.addLiteralConstant("fin", 20);
+            Formula formula = fracCompiler.compile("PULSE_TRAIN(start, dur, repeat, fin)");
+            // At time 2 (step 8): inside pulse (2 <= 2 < 3)
+            fracStep[0] = 8;
+            assertThat(formula.getCurrentValue()).isEqualTo(1.0);
+            // At time 3.5 (step 14): outside pulse
+            fracStep[0] = 14;
+            assertThat(formula.getCurrentValue()).isEqualTo(0.0);
+            // At time 6 (step 24): second pulse (6 <= 6 < 7)
+            fracStep[0] = 24;
+            assertThat(formula.getCurrentValue()).isEqualTo(1.0);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- TIME now returns `step * DT` instead of the raw step counter
- STEP, RAMP, PULSE convert time parameters to step numbers by dividing by DT
- RAMP slope is scaled by DT so output is per time unit
- PULSE_TRAIN uses `step * DT` for correct timing with fractional DT

## Test plan
- [x] New fractional DT tests verify TIME, STEP, PULSE, RAMP, PULSE_TRAIN with DT=0.25
- [x] Existing DT=1 tests still pass (no behavioral change when DT=1)
- [x] Full reactor compile and test pass
- [x] SpotBugs clean

Closes #858