### PR TITLE
Rename CanvasRendererTest to FlowGeometryTest

### DIFF
--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/renderers/FlowGeometryTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/renderers/FlowGeometryTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.within;
 import systems.courant.sd.app.canvas.FlowGeometry;
 
 @DisplayName("FlowGeometry")
-class CanvasRendererTest {
+class FlowGeometryTest {
 
     @Nested
     @DisplayName("clipToBorder")


### PR DESCRIPTION
## Summary
- Rename `CanvasRendererTest` to `FlowGeometryTest` to match actual test subject
- Update class name inside the file

Closes #391