### PR TITLE
Deduplicate ZOOM_FACTOR constant into Viewport

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/InputDispatcher.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/InputDispatcher.java
@@ -28,7 +28,6 @@ import systems.courant.sd.app.canvas.controllers.ResizeController;
  */
 final class InputDispatcher {
 
-    private static final double ZOOM_FACTOR = 1.1;
     private static final double MIN_REATTACH_DRAG_SQ = 5 * 5;
 
     private final DragController dragController;
@@ -99,7 +98,7 @@ final class InputDispatcher {
     // --- Scroll ---
 
     void handleScroll(ScrollEvent event, Viewport viewport, Runnable redraw) {
-        double factor = event.getDeltaY() > 0 ? ZOOM_FACTOR : 1.0 / ZOOM_FACTOR;
+        double factor = event.getDeltaY() > 0 ? Viewport.ZOOM_FACTOR : 1.0 / Viewport.ZOOM_FACTOR;
         viewport.zoomAt(event.getX(), event.getY(), factor);
         redraw.run();
         event.consume();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
@@ -56,8 +56,6 @@ import systems.courant.sd.app.canvas.renderers.CanvasRenderer;
  */
 public class ModelCanvas extends Canvas {
 
-    private static final double ZOOM_FACTOR = 1.1;
-
     private ModelEditor editor;
     private List<ConnectorRoute> connectors = List.of();
 
@@ -919,14 +917,14 @@ public class ModelCanvas extends Canvas {
     }
 
     public void zoomIn() {
-        viewport.zoomAt(getWidth() / 2, getHeight() / 2, ZOOM_FACTOR);
+        viewport.zoomAt(getWidth() / 2, getHeight() / 2, Viewport.ZOOM_FACTOR);
         redraw();
         inputDispatcher.updateCursor(this);
         fireStatusChanged();
     }
 
     public void zoomOut() {
-        viewport.zoomAt(getWidth() / 2, getHeight() / 2, 1.0 / ZOOM_FACTOR);
+        viewport.zoomAt(getWidth() / 2, getHeight() / 2, 1.0 / Viewport.ZOOM_FACTOR);
         redraw();
         inputDispatcher.updateCursor(this);
         fireStatusChanged();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/Viewport.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/Viewport.java
@@ -8,6 +8,7 @@ import javafx.scene.canvas.GraphicsContext;
  */
 public class Viewport {
 
+    public static final double ZOOM_FACTOR = 1.1;
     private static final double MIN_SCALE = 0.1;
     private static final double MAX_SCALE = 5.0;
 


### PR DESCRIPTION
## Summary
- Move `ZOOM_FACTOR = 1.1` to `Viewport.ZOOM_FACTOR`
- Remove duplicate definitions from `ModelCanvas` and `InputDispatcher`

Closes #386