### PR TITLE
Fix ModelReport shared sub-module duplication

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/ModelReport.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/ModelReport.java
@@ -108,7 +108,7 @@ public class ModelReport {
         }
 
         for (Module sub : module.getSubModules().values()) {
-            appendModule(builder, sub, indent + "  ", new HashSet<>(visited));
+            appendModule(builder, sub, indent + "  ", visited);
         }
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/io/ModelReportTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/ModelReportTest.java
@@ -149,6 +149,27 @@ class ModelReportTest {
         }
 
         @Test
+        void shouldPrintSharedSubModuleOnlyOnce() {
+            Module parent = new Module("Parent");
+            Module siblingA = new Module("SiblingA");
+            Module siblingB = new Module("SiblingB");
+            Module shared = new Module("Shared");
+            shared.addStock(new Stock("SharedStock", 1, THING));
+            siblingA.addSubModule(shared);
+            siblingB.addSubModule(new Module("Shared"));
+            parent.addSubModule(siblingA);
+            parent.addSubModule(siblingB);
+            model.addModulePreserved(parent);
+
+            String report = ModelReport.create(model);
+
+            // "Module: Shared" should appear in the report, but the second occurrence
+            // should be detected as a cycle and skipped
+            assertThat(report).contains("Module: Shared");
+            assertThat(report).contains("cycle detected, skipping");
+        }
+
+        @Test
         void shouldDetectModuleCycle() {
             // Create a module that references itself via submodule with same name
             Module module = new Module("Loop");


### PR DESCRIPTION
## Summary
- Pass `visited` set directly to sibling sub-modules instead of copying per sibling
- Add test for shared sub-module deduplication

Closes #376