### PR TITLE
Fix unsafe double-to-long cast in SensitivitySummary.formatValue

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/sweep/SensitivitySummary.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/SensitivitySummary.java
@@ -379,8 +379,8 @@ public final class SensitivitySummary {
 
     private static String formatValue(double value) {
         if (value == Math.floor(value) && Double.isFinite(value)
-                && Math.abs(value) <= Long.MAX_VALUE) {
-            return String.valueOf((long) value);
+                && Math.abs(value) < 9.0e18) {
+            return String.format(Locale.US, "%.0f", value);
         }
         return String.format(Locale.US, "%.2f", value);
     }


### PR DESCRIPTION
## Summary
- Replace `(long) value` cast with `String.format("%.0f", value)`
- Use `Math.abs(value) < 9.0e18` guard to avoid double precision issues near `Long.MAX_VALUE`

Closes #374