### PR TITLE
Fix wrong keyboard shortcuts in QuickstartDialog

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/QuickstartDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/QuickstartDialog.java
@@ -273,9 +273,9 @@ public class QuickstartDialog extends Stage {
                 plain("  \u2022 "),
                 bold("Sketch a causal loop diagram"),
                 plain(" \u2014 press "),
-                mono("8"),
+                mono("7"),
                 plain(" for CLD variables and "),
-                mono("9"),
+                mono("8"),
                 plain(" for causal links. Map out your system's feedback "
                         + "structure before formalizing it\n\n"),
                 plain("  \u2022 "),


### PR DESCRIPTION
## Summary
- Fix CLD variable shortcut from `8` to `7`
- Fix causal link shortcut from `9` to `8`
- Matches actual key bindings in `InputDispatcher` (DIGIT7, DIGIT8)

Closes #316