### PR TITLE
Remove stale Constant reference from model package-info

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/package-info.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/package-info.java
@@ -9,7 +9,6 @@
  *       from a stock each timestep</li>
  *   <li>{@link systems.courant.sd.model.Variable} — a computed value defined by
  *       a {@link systems.courant.sd.model.Formula}, re-evaluated each timestep</li>
- *   <li>Constant — an immutable parameter</li>
  *   <li>{@link systems.courant.sd.model.Module} — a named grouping of stocks,
  *       flows, and variables for organizing large models hierarchically</li>
  *   <li>{@link systems.courant.sd.model.Model} — the top-level container that


### PR DESCRIPTION
## Summary
- Remove reference to deleted `Constant` class from `package-info.java`

Closes #315