### PR TITLE
Return NaN for division by zero in IndexedValue.divide

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/IndexedValue.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/IndexedValue.java
@@ -244,16 +244,10 @@ public final class IndexedValue {
     /**
      * Divides this value by {@code other} with automatic broadcasting.
      * Result dimensions: left dimensions first, then right-only dimensions.
-     *
-     * @throws ArithmeticException if any element of {@code other} is zero
+     * Division by zero returns {@code Double.NaN}, consistent with ExprCompiler.
      */
     public IndexedValue divide(IndexedValue other) {
-        return binaryOp(other, (a, b) -> {
-            if (b == 0) {
-                throw new ArithmeticException("Division by zero in IndexedValue");
-            }
-            return a / b;
-        });
+        return binaryOp(other, (a, b) -> b == 0 ? Double.NaN : a / b);
     }
 
     // --- Scalar convenience overloads ---
@@ -410,7 +404,7 @@ public final class IndexedValue {
     private IndexedValue binaryOp(IndexedValue other, DoubleBinaryOp op) {
         // Both scalar
         if (this.isScalar() && other.isScalar()) {
-            return scalar(op.apply(this.values[0], other.values[0]));
+            return new IndexedValue(null, new double[]{op.apply(this.values[0], other.values[0])}, true);
         }
         // One scalar, one indexed
         if (this.isScalar()) {

--- a/courant-engine/src/test/java/systems/courant/sd/model/IndexedValueTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/IndexedValueTest.java
@@ -164,9 +164,9 @@ class IndexedValueTest {
         }
 
         @Test
-        void shouldRejectDivisionByZero() {
-            assertThrows(ArithmeticException.class, () ->
-                    IndexedValue.scalar(1).divide(IndexedValue.scalar(0)));
+        void shouldReturnNaNForDivisionByZero() {
+            IndexedValue result = IndexedValue.scalar(1).divide(IndexedValue.scalar(0));
+            assertTrue(Double.isNaN(result.scalarValue()));
         }
     }
 
@@ -374,10 +374,13 @@ class IndexedValueTest {
         }
 
         @Test
-        void shouldRejectDivisionByZeroInBroadcast() {
+        void shouldReturnNaNForDivisionByZeroInBroadcast() {
             IndexedValue a = IndexedValue.of(region, 10, 20, 30);
             IndexedValue b = IndexedValue.of(region, 1, 0, 3);
-            assertThrows(ArithmeticException.class, () -> a.divide(b));
+            IndexedValue result = a.divide(b);
+            assertEquals(10.0, result.get(0));
+            assertTrue(Double.isNaN(result.get(1)));
+            assertEquals(10.0, result.get(2));
         }
     }
 
@@ -705,9 +708,12 @@ class IndexedValueTest {
         }
 
         @Test
-        void shouldRejectDivideByZeroDouble() {
+        void shouldReturnNaNForDivideByZeroDouble() {
             IndexedValue v = IndexedValue.of(region, 10, 20, 30);
-            assertThrows(ArithmeticException.class, () -> v.divide(0));
+            IndexedValue result = v.divide(0);
+            for (int i = 0; i < result.size(); i++) {
+                assertTrue(Double.isNaN(result.get(i)));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Change `IndexedValue.divide` to return `Double.NaN` on division by zero
- Align with `ExprCompiler` which already returns NaN for `/0`
- Use trusted constructor in `binaryOp` scalar path to allow NaN results

Closes #292