### PR TITLE
Return Optional from getCldVariableByName

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/Clipboard.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/Clipboard.java
@@ -80,7 +80,7 @@ public class Clipboard {
                 case AUX -> editor.getVariableByName(name);
                 case MODULE -> editor.getModuleByName(name);
                 case LOOKUP -> editor.getLookupTableByName(name);
-                case CLD_VARIABLE -> Optional.ofNullable(editor.getCldVariableByName(name));
+                case CLD_VARIABLE -> editor.getCldVariableByName(name);
                 case COMMENT -> Optional.ofNullable(editor.getCommentByName(name));
             };
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
@@ -1072,13 +1072,13 @@ public class ModelEditor {
         return Collections.unmodifiableList(cldVariables);
     }
 
-    public CldVariableDef getCldVariableByName(String name) {
+    public Optional<CldVariableDef> getCldVariableByName(String name) {
         for (CldVariableDef v : cldVariables) {
             if (v.name().equals(name)) {
-                return v;
+                return Optional.of(v);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     /**
@@ -1197,10 +1197,11 @@ public class ModelEditor {
     public boolean classifyCldVariable(String name, ElementType targetType) {
         checkFxThread();
 
-        CldVariableDef variable = getCldVariableByName(name);
-        if (variable == null) {
+        Optional<CldVariableDef> opt = getCldVariableByName(name);
+        if (opt.isEmpty()) {
             return false;
         }
+        CldVariableDef variable = opt.get();
 
         // Remove the CLD variable
         cldVariables.removeIf(v -> v.name().equals(name));

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/CldVariableForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/CldVariableForm.java
@@ -26,7 +26,8 @@ public class CldVariableForm implements ElementForm {
 
     @Override
     public int build(int startRow) {
-        CldVariableDef variable = ctx.getEditor().getCldVariableByName(ctx.getElementName());
+        CldVariableDef variable = ctx.getEditor().getCldVariableByName(ctx.getElementName())
+                .orElse(null);
         if (variable == null) {
             ctx.addReadOnlyRow(startRow++, "Name", ctx.getElementName());
             return startRow;
@@ -52,7 +53,8 @@ public class CldVariableForm implements ElementForm {
 
     @Override
     public void updateValues() {
-        CldVariableDef variable = ctx.getEditor().getCldVariableByName(ctx.getElementName());
+        CldVariableDef variable = ctx.getEditor().getCldVariableByName(ctx.getElementName())
+                .orElse(null);
         if (variable == null || nameField == null) {
             return;
         }
@@ -63,7 +65,8 @@ public class CldVariableForm implements ElementForm {
     private void commitComment(TextArea area) {
         String text = area.getText().trim();
         String comment = text.isEmpty() ? null : text;
-        CldVariableDef variable = ctx.getEditor().getCldVariableByName(ctx.getElementName());
+        CldVariableDef variable = ctx.getEditor().getCldVariableByName(ctx.getElementName())
+                .orElse(null);
         if (variable == null || Objects.equals(comment, variable.comment())) {
             return;
         }


### PR DESCRIPTION
## Summary
- Change `getCldVariableByName` return type from nullable `CldVariableDef` to `Optional<CldVariableDef>`
- Update callers in `Clipboard`, `ModelEditor.classifyCldVariable`, and `CldVariableForm`

Closes #290