### PR TITLE
Remove default branch from SvgExporter ElementType switch

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
@@ -131,7 +131,6 @@ public final class SvgExporter {
                             LayoutMetrics.effectiveWidth(canvasState, name),
                             LayoutMetrics.effectiveHeight(canvasState, name));
                 }
-                default -> { }
             }
         }
 


### PR DESCRIPTION
## Summary
- Remove empty `default -> { }` from exhaustive `ElementType` switch
- Enables compiler warnings when new enum values are added

Closes #289