### PR TITLE
Defensively copy varargs array in FlowChartViewer

### DIFF
--- a/courant-ui/src/main/java/systems/courant/sd/ui/FlowChartViewer.java
+++ b/courant-ui/src/main/java/systems/courant/sd/ui/FlowChartViewer.java
@@ -19,7 +19,7 @@ public class FlowChartViewer implements EventHandler {
     private final Flow[] flows;
 
     public FlowChartViewer(Flow... flows) {
-        this.flows = flows;
+        this.flows = flows.clone();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Clone the `flows` varargs array in the constructor

Closes #288