### PR TITLE
Fix CI: TestFX race condition with background auto-layout

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -76,6 +76,7 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
@@ -119,13 +120,14 @@ public class ModelWindow {
     private FileController fileController;
     private SimulationController simulationController;
     private ModelEditListener dirtyListener;
+    private volatile CompletableFuture<Void> pendingLayout = CompletableFuture.completedFuture(null);
 
     private SplitPane editorSplitPane;
     private VBox topContainer;
     private CanvasToolBar toolBar;
     private MenuBar menuBar;
     private LoopNavigatorBar loopNavigatorBar;
-    private boolean editorShown;
+    private volatile boolean editorShown;
     private final List<MenuItem> editorOnlyItems = new ArrayList<>();
     private MenuItem validationIssuesItem;
 
@@ -769,10 +771,13 @@ public class ModelWindow {
                 view = new ViewDef("Main", List.of(), List.of(), List.of());
             }
             applyView(editorSnapshot, view, displayName);
+            pendingLayout = CompletableFuture.completedFuture(null);
         } else {
             // Run auto-layout on a background thread to keep the UI responsive.
             // ELK initialization on first use and layout of large models can
             // take over a second on a cold JVM.
+            var layoutFuture = new CompletableFuture<Void>();
+            pendingLayout = layoutFuture;
             statusBar.showProgress("Computing layout\u2026");
             canvas.setDisable(true);
             Thread layoutThread = new Thread(() -> {
@@ -784,6 +789,7 @@ public class ModelWindow {
                         canvas.setDisable(false);
                         statusBar.clearProgress();
                         applyView(editorSnapshot, view, displayName);
+                        layoutFuture.complete(null);
                     });
                 } catch (Exception e) {
                     log.error("Auto-layout failed", e);
@@ -793,6 +799,7 @@ public class ModelWindow {
                         showError("Layout Error",
                                 "Auto-layout failed: " + e.getMessage());
                     });
+                    layoutFuture.completeExceptionally(e);
                 }
             }, "auto-layout");
             layoutThread.setDaemon(true);
@@ -1183,6 +1190,15 @@ public class ModelWindow {
 
     ModelCanvas getCanvas() {
         return canvas;
+    }
+
+    /**
+     * Returns a future that completes when the most recent background
+     * auto-layout finishes and {@code applyView} has been called on the
+     * FX thread.  Already-complete if the last load used the synchronous path.
+     */
+    CompletableFuture<Void> layoutFuture() {
+        return pendingLayout;
     }
 
     private void buildRegistry() {

--- a/courant-app/src/test/java/systems/courant/sd/app/FileControllerSaveFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/FileControllerSaveFxTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,7 +50,7 @@ class FileControllerSaveFxTest {
         }
     }
 
-    private void loadTeacupModel() throws IOException {
+    private void loadTeacupModel() throws Exception {
         ImportResult result = new VensimImporter()
                 .importModel(resourcePath("vensim/teacup.mdl"));
         Platform.runLater(() -> {
@@ -57,11 +58,13 @@ class FileControllerSaveFxTest {
             window.setCurrentFile(null);
         });
         WaitForAsyncUtils.waitForFxEvents();
+        window.layoutFuture().get(10, TimeUnit.SECONDS);
+        WaitForAsyncUtils.waitForFxEvents();
     }
 
     @Test
     @DisplayName("saveToChosenFile with .mdl clears dirty flag and updates currentFile")
-    void shouldClearDirtyAfterVensimExport(FxRobot robot, @TempDir Path tempDir) throws IOException {
+    void shouldClearDirtyAfterVensimExport(FxRobot robot, @TempDir Path tempDir) throws Exception {
         loadTeacupModel();
 
         Platform.runLater(() -> window.getFileController().markDirty());
@@ -80,7 +83,7 @@ class FileControllerSaveFxTest {
 
     @Test
     @DisplayName("saveToChosenFile with .xmile clears dirty flag and updates currentFile")
-    void shouldClearDirtyAfterXmileExport(FxRobot robot, @TempDir Path tempDir) throws IOException {
+    void shouldClearDirtyAfterXmileExport(FxRobot robot, @TempDir Path tempDir) throws Exception {
         loadTeacupModel();
 
         Platform.runLater(() -> window.getFileController().markDirty());
@@ -99,7 +102,7 @@ class FileControllerSaveFxTest {
 
     @Test
     @DisplayName("saveToChosenFile with .stmx clears dirty flag")
-    void shouldClearDirtyAfterStmxExport(FxRobot robot, @TempDir Path tempDir) throws IOException {
+    void shouldClearDirtyAfterStmxExport(FxRobot robot, @TempDir Path tempDir) throws Exception {
         loadTeacupModel();
 
         Platform.runLater(() -> window.getFileController().markDirty());
@@ -116,7 +119,7 @@ class FileControllerSaveFxTest {
 
     @Test
     @DisplayName("saveToChosenFile with .json clears dirty flag and updates currentFile")
-    void shouldClearDirtyAfterJsonSave(FxRobot robot, @TempDir Path tempDir) throws IOException {
+    void shouldClearDirtyAfterJsonSave(FxRobot robot, @TempDir Path tempDir) throws Exception {
         loadTeacupModel();
 
         Platform.runLater(() -> window.getFileController().markDirty());
@@ -134,7 +137,7 @@ class FileControllerSaveFxTest {
 
     @Test
     @DisplayName("window title drops dirty indicator after export")
-    void shouldUpdateTitleAfterExport(FxRobot robot, @TempDir Path tempDir) throws IOException {
+    void shouldUpdateTitleAfterExport(FxRobot robot, @TempDir Path tempDir) throws Exception {
         loadTeacupModel();
 
         Platform.runLater(() -> window.getFileController().markDirty());
@@ -150,7 +153,7 @@ class FileControllerSaveFxTest {
 
     @Test
     @DisplayName("exported Vensim file can be reimported after saveToChosenFile")
-    void shouldProduceValidVensimFile(FxRobot robot, @TempDir Path tempDir) throws IOException {
+    void shouldProduceValidVensimFile(FxRobot robot, @TempDir Path tempDir) throws Exception {
         loadTeacupModel();
 
         File mdlFile = tempDir.resolve("roundtrip.mdl").toFile();
@@ -165,7 +168,7 @@ class FileControllerSaveFxTest {
 
     @Test
     @DisplayName("exported XMILE file can be reimported after saveToChosenFile")
-    void shouldProduceValidXmileFile(FxRobot robot, @TempDir Path tempDir) throws IOException {
+    void shouldProduceValidXmileFile(FxRobot robot, @TempDir Path tempDir) throws Exception {
         loadTeacupModel();
 
         File xmileFile = tempDir.resolve("roundtrip.xmile").toFile();

--- a/courant-app/src/test/java/systems/courant/sd/app/ModelWindowImportExportFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/ModelWindowImportExportFxTest.java
@@ -28,6 +28,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -54,6 +55,15 @@ class ModelWindowImportExportFxTest {
         }
     }
 
+    private void awaitLayout() {
+        try {
+            window.layoutFuture().get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("Layout did not complete", e);
+        }
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
     // --- Vensim Import ---
 
     @Test
@@ -66,6 +76,7 @@ class ModelWindowImportExportFxTest {
             window.setCurrentFile(null);
         });
         WaitForAsyncUtils.waitForFxEvents();
+        awaitLayout();
 
         ModelEditor editor = window.getEditor();
         assertThat(editor.getStocks()).hasSize(1);
@@ -81,6 +92,7 @@ class ModelWindowImportExportFxTest {
 
         Platform.runLater(() -> window.loadDefinition(result.definition(), "sir.mdl"));
         WaitForAsyncUtils.waitForFxEvents();
+        awaitLayout();
 
         ModelEditor editor = window.getEditor();
         assertThat(editor.getStocks()).hasSize(3);
@@ -101,6 +113,7 @@ class ModelWindowImportExportFxTest {
             window.setCurrentFile(null);
         });
         WaitForAsyncUtils.waitForFxEvents();
+        awaitLayout();
 
         ModelEditor editor = window.getEditor();
         assertThat(editor.getStocks()).hasSize(1);
@@ -118,6 +131,7 @@ class ModelWindowImportExportFxTest {
 
         Platform.runLater(() -> window.loadDefinition(result.definition(), "sir.xmile"));
         WaitForAsyncUtils.waitForFxEvents();
+        awaitLayout();
 
         ModelEditor editor = window.getEditor();
         assertThat(editor.getStocks()).hasSize(3);
@@ -134,6 +148,7 @@ class ModelWindowImportExportFxTest {
 
         Platform.runLater(() -> window.loadDefinition(initial.definition(), "teacup.xmile"));
         WaitForAsyncUtils.waitForFxEvents();
+        awaitLayout();
 
         ModelDefinition canvasDef = window.getCanvas().toModelDefinition();
         Path mdlFile = tempDir.resolve("teacup-export.mdl");
@@ -155,6 +170,7 @@ class ModelWindowImportExportFxTest {
 
         Platform.runLater(() -> window.loadDefinition(initial.definition(), "teacup.mdl"));
         WaitForAsyncUtils.waitForFxEvents();
+        awaitLayout();
 
         ModelDefinition canvasDef = window.getCanvas().toModelDefinition();
         Path xmileFile = tempDir.resolve("teacup-export.xmile");
@@ -181,6 +197,7 @@ class ModelWindowImportExportFxTest {
             window.setCurrentFile(null);
         });
         WaitForAsyncUtils.waitForFxEvents();
+        awaitLayout();
 
         assertThat(stage.getTitle()).contains("teacup");
     }
@@ -193,6 +210,7 @@ class ModelWindowImportExportFxTest {
 
         Platform.runLater(() -> window.loadDefinition(result.definition(), "sir.mdl"));
         WaitForAsyncUtils.waitForFxEvents();
+        awaitLayout();
 
         Label elementsLabel = robot.lookup("#statusElements").queryAs(Label.class);
         assertThat(elementsLabel.getText()).contains("3 stocks");
@@ -206,12 +224,14 @@ class ModelWindowImportExportFxTest {
                 .importModel(resourcePath("vensim/sir.mdl"));
         Platform.runLater(() -> window.loadDefinition(sir.definition(), "sir.mdl"));
         WaitForAsyncUtils.waitForFxEvents();
+        awaitLayout();
         assertThat(window.getEditor().getStocks()).hasSize(3);
 
         ImportResult teacup = new XmileImporter()
                 .importModel(resourcePath("xmile/teacup.xmile"));
         Platform.runLater(() -> window.loadDefinition(teacup.definition(), "teacup.xmile"));
         WaitForAsyncUtils.waitForFxEvents();
+        awaitLayout();
         assertThat(window.getEditor().getStocks()).hasSize(1);
     }
 

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowComplexModelFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowComplexModelFxTest.java
@@ -16,6 +16,8 @@ import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -40,6 +42,12 @@ class WorkflowComplexModelFxTest {
     private void loadExample(String name, String resourcePath) {
         Platform.runLater(() ->
                 window.getFileController().openExample(name, resourcePath));
+        WaitForAsyncUtils.waitForFxEvents();
+        try {
+            window.layoutFuture().get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("Layout did not complete", e);
+        }
         WaitForAsyncUtils.waitForFxEvents();
     }
 

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowFileOperationsFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowFileOperationsFxTest.java
@@ -17,6 +17,8 @@ import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -41,6 +43,12 @@ class WorkflowFileOperationsFxTest {
     private void loadExample(String name, String resourcePath) {
         Platform.runLater(() ->
                 window.getFileController().openExample(name, resourcePath));
+        WaitForAsyncUtils.waitForFxEvents();
+        try {
+            window.layoutFuture().get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("Layout did not complete", e);
+        }
         WaitForAsyncUtils.waitForFxEvents();
     }
 

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowSimulationFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowSimulationFxTest.java
@@ -16,6 +16,8 @@ import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -40,6 +42,12 @@ class WorkflowSimulationFxTest {
     private void loadExample(String name, String resourcePath) {
         Platform.runLater(() ->
                 window.getFileController().openExample(name, resourcePath));
+        WaitForAsyncUtils.waitForFxEvents();
+        try {
+            window.layoutFuture().get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("Layout did not complete", e);
+        }
         WaitForAsyncUtils.waitForFxEvents();
     }
 

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowSimulationSettingsFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowSimulationSettingsFxTest.java
@@ -19,6 +19,8 @@ import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -43,6 +45,12 @@ class WorkflowSimulationSettingsFxTest {
     private void loadExample(String name, String resourcePath) {
         Platform.runLater(() ->
                 window.getFileController().openExample(name, resourcePath));
+        WaitForAsyncUtils.waitForFxEvents();
+        try {
+            window.layoutFuture().get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("Layout did not complete", e);
+        }
         WaitForAsyncUtils.waitForFxEvents();
     }
 

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowViewNavigationFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowViewNavigationFxTest.java
@@ -17,6 +17,8 @@ import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -41,6 +43,12 @@ class WorkflowViewNavigationFxTest {
     private void loadExample(String name, String resourcePath) {
         Platform.runLater(() ->
                 window.getFileController().openExample(name, resourcePath));
+        WaitForAsyncUtils.waitForFxEvents();
+        try {
+            window.layoutFuture().get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("Layout did not complete", e);
+        }
         WaitForAsyncUtils.waitForFxEvents();
     }
 


### PR DESCRIPTION
## Summary
- CI has been failing since the workflow was introduced due to a race condition between the background auto-layout thread in `ModelWindow.loadDefinition` and TestFX assertions
- `WaitForAsyncUtils.waitForFxEvents()` only drains queued FX events but doesn't wait for the background ELK layout thread to complete and post its `Platform.runLater(applyView)` callback
- Added `CompletableFuture<Void> pendingLayout` to `ModelWindow` so tests can await layout completion before asserting on canvas state, dirty flags, title, or status bar counts
- Fixed all 7 test files that load models via `loadDefinition` or `openExample`
- Also marked `editorShown` volatile to fix SpotBugs MT_CORRECTNESS finding