### PR TITLE
Fix CsvSubscriber resource leak with lazy writer initialization

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/CsvSubscriber.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/CsvSubscriber.java
@@ -32,25 +32,35 @@ public class CsvSubscriber implements EventHandler, Closeable {
 
     private static final Logger logger = LoggerFactory.getLogger(CsvSubscriber.class);
 
+    private final String filePath;
     private CSVWriter csvWriter;
+    private boolean closed;
 
     /**
      * Creates a new CSV subscriber that writes to the specified file path.
-     * Parent directories are created if they do not exist.
+     * Parent directories are created if they do not exist. The file itself is
+     * not opened until the first simulation event is received (lazy initialization),
+     * so no file handle is leaked if the subscriber is never used.
      *
      * @param fileName the path of the CSV file to write
      */
     public CsvSubscriber(String fileName) {
+        this.filePath = fileName;
         File file = Paths.get(fileName).toFile();
         File parent = file.getParentFile();
         if (parent != null && !parent.mkdirs() && !parent.isDirectory()) {
             throw new CsvOutputException("Failed to create directory: " + parent.getAbsolutePath());
         }
-        try {
-            csvWriter = new CSVWriter(new OutputStreamWriter(
-                    Files.newOutputStream(Paths.get(fileName)), StandardCharsets.UTF_8));
-        } catch (IOException e) {
-            throw new CsvOutputException("Failed to open CSV file: " + fileName, e);
+    }
+
+    private void ensureWriter() {
+        if (csvWriter == null && !closed) {
+            try {
+                csvWriter = new CSVWriter(new OutputStreamWriter(
+                        Files.newOutputStream(Paths.get(filePath)), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new CsvOutputException("Failed to open CSV file: " + filePath, e);
+            }
         }
     }
 
@@ -60,6 +70,7 @@ public class CsvSubscriber implements EventHandler, Closeable {
      */
     @Override
     public void handleTimeStepEvent(TimeStepEvent event) {
+        ensureWriter();
         if (csvWriter == null) {
             return;
         }
@@ -90,6 +101,7 @@ public class CsvSubscriber implements EventHandler, Closeable {
      */
     @Override
     public void handleSimulationStartEvent(SimulationStartEvent event) {
+        ensureWriter();
         if (csvWriter == null) {
             return;
         }
@@ -124,6 +136,7 @@ public class CsvSubscriber implements EventHandler, Closeable {
      */
     @Override
     public void close() {
+        closed = true;
         if (csvWriter != null) {
             try {
                 csvWriter.flush();

--- a/courant-engine/src/test/java/systems/courant/sd/io/CsvSubscriberTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/CsvSubscriberTest.java
@@ -100,6 +100,17 @@ public class CsvSubscriberTest {
     }
 
     @Test
+    public void shouldNotOpenFileUntilFirstSimulationEvent() throws IOException {
+        Path csvFile = tempDir.resolve("lazy.csv");
+        CsvSubscriber csv = new CsvSubscriber(csvFile.toString());
+        // File should not exist yet — writer is lazily initialized
+        assertTrue(!Files.exists(csvFile), "File should not be created until first write");
+        csv.close();
+        // After close without any simulation, file should still not exist
+        assertTrue(!Files.exists(csvFile), "File should not be created when closed without use");
+    }
+
+    @Test
     public void shouldCreateParentDirectories() throws IOException {
         Path nested = tempDir.resolve("a/b/c/output.csv");
         CsvSubscriber csv = new CsvSubscriber(nested.toString());


### PR DESCRIPTION
## Summary
- CsvSubscriber now lazily initializes the CSVWriter on first simulation event instead of eagerly in the constructor
- Adds a `closed` flag to prevent reopening after close()
- No file handle is leaked when the subscriber is created but never used

Closes #939

## Test plan
- [x] New test: `shouldNotOpenFileUntilFirstSimulationEvent` verifies lazy init
- [x] All existing CsvSubscriber tests pass (header, data rows, close, double-close, post-close events)
- [x] Full reactor build and test suite green (131 tests)
- [x] SpotBugs clean