### PR TITLE
Print full stack trace for unexpected exceptions in ImportPipelineCli

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
@@ -38,6 +38,7 @@ public class ImportPipelineCli implements Closeable {
             System.exit(1);
         } catch (Exception e) {
             System.err.println("Error: " + e.getMessage());
+            e.printStackTrace(System.err);
             System.exit(1);
         }
     }


### PR DESCRIPTION
## Summary
- The broad `catch (Exception)` in `ImportPipelineCli.main()` now prints the full stack trace to stderr, preserving diagnostic information for unexpected exceptions (NPE, ClassCastException, etc.)

Closes #956