### PR TITLE
Treat near-constant Monte Carlo data as constant in FanChart axis range

### DIFF
--- a/courant-ui/src/main/java/systems/courant/sd/ui/FanChart.java
+++ b/courant-ui/src/main/java/systems/courant/sd/ui/FanChart.java
@@ -256,11 +256,14 @@ public class FanChart extends Application {
      */
     static double[] padAxisRange(double rawMin, double rawMax) {
         double range = rawMax - rawMin;
-        if (range != 0) {
+        double magnitude = Math.max(Math.abs(rawMin), Math.abs(rawMax));
+        // Treat near-constant data the same as constant to avoid extreme y-coordinates
+        if (range > 0 && range > magnitude * 1e-10) {
             return new double[]{rawMin - range * 0.05, rawMax + range * 0.05};
         }
-        // All values are constant — use 10% of |value| as half-range, or 1 if value is 0
-        double halfRange = (rawMin == 0) ? 1.0 : Math.abs(rawMin) * 0.1;
-        return new double[]{rawMin - halfRange, rawMax + halfRange};
+        // All values are (near-)constant — use 10% of |value| as half-range, or 1 if value is ~0
+        double mid = (rawMin + rawMax) / 2;
+        double halfRange = (mid == 0) ? 1.0 : Math.abs(mid) * 0.1;
+        return new double[]{mid - halfRange, mid + halfRange};
     }
 }

--- a/courant-ui/src/test/java/systems/courant/sd/ui/FanChartTest.java
+++ b/courant-ui/src/test/java/systems/courant/sd/ui/FanChartTest.java
@@ -116,6 +116,19 @@ class FanChartTest {
         }
 
         @Test
+        @DisplayName("near-constant data uses constant-value logic to avoid extreme y-coordinates (#955)")
+        void shouldTreatNearConstantDataAsConstant() {
+            // Range of 1e-12 relative to values around 1000 is negligible
+            double[] result = FanChart.padAxisRange(1000.0, 1000.0 + 1e-12);
+
+            // Should use constant-value logic: halfRange = |1000| * 0.1 = 100
+            assertThat(result[0]).isCloseTo(900.0, within(1.0));
+            assertThat(result[1]).isCloseTo(1100.0, within(1.0));
+            // Crucially, the final range must be large enough to avoid division issues
+            assertThat(result[1] - result[0]).isGreaterThan(1.0);
+        }
+
+        @Test
         @DisplayName("padded min is always less than padded max")
         void shouldAlwaysProducePaddedMinLessThanPaddedMax() {
             double[][] testCases = {


### PR DESCRIPTION
## Summary
- `padAxisRange` now detects near-constant data (range < magnitude * 1e-10) and uses the same constant-value logic instead of 5% padding, preventing extreme/Infinity y-coordinates in chart rendering

Closes #955