### PR TITLE
Move setImplicitExit into Platform.startup callback to close race window

### DIFF
--- a/courant-ui/src/main/java/systems/courant/sd/ui/ChartViewerApplication.java
+++ b/courant-ui/src/main/java/systems/courant/sd/ui/ChartViewerApplication.java
@@ -137,14 +137,14 @@ public class ChartViewerApplication extends Application {
     static void ensureFxRunning() {
         if (FX_STARTED.compareAndSet(false, true)) {
             try {
-                Platform.startup(() -> {});
+                Platform.startup(() -> Platform.setImplicitExit(false));
             } catch (IllegalStateException e) {
                 // Toolkit already initialized (e.g., by the app or TestFX)
+                Platform.setImplicitExit(false);
             } catch (RuntimeException e) {
                 FX_STARTED.set(false);
                 throw e;
             }
-            Platform.setImplicitExit(false);
         }
     }
 


### PR DESCRIPTION
## Summary
- Moved `Platform.setImplicitExit(false)` into the `Platform.startup()` callback so it executes on the FX thread before any `runLater` tasks, closing the race window where another thread could post to a FX thread about to exit

Closes #954