### PR TITLE
Validate setActiveIndex against filtered indices when type filter active

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/LoopHighlightController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/LoopHighlightController.java
@@ -91,8 +91,13 @@ public final class LoopHighlightController {
         if (analysis == null) {
             return false;
         }
-        int count = analysis.loopCount();
-        if (index < -1 || index >= count) {
+        if (index >= 0) {
+            if (index >= analysis.loopCount()) {
+                index = -1;
+            } else if (typeFilter != null && !filteredIndices().contains(index)) {
+                index = -1;
+            }
+        } else {
             index = -1;
         }
         this.activeIndex = index;

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/LoopHighlightControllerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/LoopHighlightControllerTest.java
@@ -161,6 +161,47 @@ class LoopHighlightControllerTest {
     }
 
     @Nested
+    @DisplayName("setActiveIndex validation (#951)")
+    class SetActiveIndexValidation {
+
+        @Test
+        void shouldRejectIndexOutsideFilteredSet() {
+            controller.setActive(true, LoopHighlightControllerTest.this::mixedModel);
+            controller.setTypeFilter(LoopType.REINFORCING);
+
+            // Find a balancing loop index
+            FeedbackAnalysis analysis = controller.getAnalysis();
+            int bIndex = -1;
+            for (int i = 0; i < analysis.loopCount(); i++) {
+                if (analysis.loopType(i) == LoopType.BALANCING) {
+                    bIndex = i;
+                    break;
+                }
+            }
+            assertThat(bIndex).as("model should have a balancing loop").isGreaterThanOrEqualTo(0);
+
+            // Setting a B index while R filter is active should reset to -1
+            controller.setActiveIndex(bIndex);
+            assertThat(controller.getActiveIndex()).isEqualTo(-1);
+        }
+
+        @Test
+        void shouldAcceptIndexInFilteredSet() {
+            controller.setActive(true, LoopHighlightControllerTest.this::mixedModel);
+            controller.setTypeFilter(LoopType.REINFORCING);
+
+            // Step forward to get a valid R index
+            controller.stepForward();
+            int rIndex = controller.getActiveIndex();
+            assertThat(rIndex).isGreaterThanOrEqualTo(0);
+
+            // Setting it again explicitly should keep it
+            controller.setActiveIndex(rIndex);
+            assertThat(controller.getActiveIndex()).isEqualTo(rIndex);
+        }
+    }
+
+    @Nested
     @DisplayName("filtered active analysis")
     class FilteredActiveAnalysis {
 


### PR DESCRIPTION
## Summary
- `setActiveIndex` now validates the index against `filteredIndices()` when a type filter is active, resetting to -1 if the index doesn't match the filter
- Added tests verifying rejection of out-of-filter indices and acceptance of valid ones

Closes #951