### PR TITLE
Clear causal trace when traced element is deleted from model

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CausalTraceController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CausalTraceController.java
@@ -39,8 +39,19 @@ public final class CausalTraceController {
      */
     public void invalidate(ModelDefinition model) {
         if (isActive() && model != null) {
+            if (!elementExists(tracedElement, model)) {
+                clearTrace();
+                return;
+            }
             this.traceAnalysis = CausalTraceAnalysis.trace(
                     tracedElement, tracedDirection, model);
         }
+    }
+
+    private static boolean elementExists(String name, ModelDefinition model) {
+        return model.stocks().stream().anyMatch(s -> s.name().equals(name))
+                || model.flows().stream().anyMatch(f -> f.name().equals(name))
+                || model.variables().stream().anyMatch(v -> v.name().equals(name))
+                || model.cldVariables().stream().anyMatch(c -> c.name().equals(name));
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/CausalTraceControllerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/CausalTraceControllerTest.java
@@ -107,6 +107,18 @@ class CausalTraceControllerTest {
         }
 
         @Test
+        void shouldClearTraceWhenTracedElementDeletedFromModel() {
+            CausalTraceController controller = new CausalTraceController();
+            controller.startTrace("B", TraceDirection.UPSTREAM, chainModel());
+            assertThat(controller.isActive()).isTrue();
+
+            // reducedModel() has no "B" — invalidate should clear the trace
+            controller.invalidate(reducedModel());
+            assertThat(controller.isActive()).isFalse();
+            assertThat(controller.getAnalysis()).isNull();
+        }
+
+        @Test
         void shouldPreserveDirectionAcrossInvalidate() {
             CausalTraceController controller = new CausalTraceController();
             controller.startTrace("S", TraceDirection.DOWNSTREAM, chainModel());


### PR DESCRIPTION
## Summary
- `CausalTraceController.invalidate()` now checks if the traced element still exists in the model before re-tracing; clears the trace if the element was deleted
- Added test verifying trace is cleared when the traced element no longer exists

Closes #950