### PR TITLE
Use streaming InputStream for JSON deserialization in fromFile

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -130,8 +130,10 @@ public class ModelDefinitionSerializer {
             throw new IOException("JSON file exceeds "
                     + (MAX_FILE_SIZE / (1024 * 1024)) + " MB: " + path);
         }
-        String json = Files.readString(path);
-        return fromJson(json);
+        try (var in = Files.newInputStream(path)) {
+            JsonNode root = mapper.readTree(in);
+            return fromJsonNode(root);
+        }
     }
 
     // === Serialization ===


### PR DESCRIPTION
## Summary
- Replaced `Files.readString()` + `mapper.readTree(String)` with `mapper.readTree(InputStream)` in `ModelDefinitionSerializer.fromFile()`, halving peak memory usage for large model files

Closes #948