### PR TITLE
Enable FEATURE_SECURE_PROCESSING on XmileImporter XML parser

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileImporter.java
@@ -20,6 +20,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -554,6 +555,7 @@ public class XmileImporter implements ModelImporter {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
         // Disable external entities for security
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);


### PR DESCRIPTION
## Summary
- Added `XMLConstants.FEATURE_SECURE_PROCESSING` to the XML parser in `XmileImporter` for defense-in-depth alongside existing XXE protections

Closes #947