### PR TITLE
Fix operator replacement ordering in VensimExporter toVensimExpr

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -504,11 +504,11 @@ public final class VensimExporter {
         // ** → ^ (Courant uses ** for power, Vensim uses ^)
         expr = DOUBLE_STAR_PATTERN.matcher(expr).replaceAll("^");
 
+        // == → = (must precede != to avoid mangling malformed !==)
+        expr = DOUBLE_EQ_PATTERN.matcher(expr).replaceAll("=");
+
         // != → <>
         expr = NOT_EQ_PATTERN.matcher(expr).replaceAll("<>");
-
-        // == → =
-        expr = DOUBLE_EQ_PATTERN.matcher(expr).replaceAll("=");
 
         // TIME → Time
         expr = TIME_PATTERN.matcher(expr).replaceAll("Time");

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
@@ -268,6 +268,13 @@ class VensimExporterTest {
         }
 
         @Test
+        void shouldNotMangleAdjacentOperators() {
+            // Malformed !== should not produce invalid <>=
+            assertThat(VensimExporter.toVensimExpr("x !== 0"))
+                    .doesNotContain("<>=");
+        }
+
+        @Test
         void shouldTranslateTimeVariable() {
             assertThat(VensimExporter.toVensimExpr("TIME + 1"))
                     .isEqualTo("Time + 1");


### PR DESCRIPTION
## Summary
- Swapped `==` and `!=` replacement order so `==` is replaced before `!=`, preventing malformed `!==` from producing invalid `<>=` syntax

Closes #946