### PR TITLE
Add iteration bound to VensimImporter equivalence resolution loop

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
@@ -251,8 +251,13 @@ public class VensimImporter implements ModelImporter {
     }
 
     private void resolveEquivalences(SubscriptContext subscripts) {
+        int maxIterations = subscripts.equivalences.size() + 1;
         boolean changed = true;
         while (changed) {
+            if (--maxIterations < 0) {
+                throw new IllegalArgumentException(
+                        "Circular dimension equivalences detected — cannot resolve subscript mappings");
+            }
             changed = false;
             for (var entry : subscripts.equivalences.entrySet()) {
                 String dimName = entry.getKey();


### PR DESCRIPTION
## Summary
- Added a maximum iteration bound (`equivalences.size() + 1`) to the `resolveEquivalences` loop, preventing infinite loops from circular dimension equivalences in malformed .mdl files

Closes #945