### PR TITLE
Decompose ModelCanvas god object into four facades (#972)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/FileController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/FileController.java
@@ -218,7 +218,7 @@ final class FileController {
         String ext = name.contains(".") ? name.substring(name.lastIndexOf('.')).toLowerCase() : "";
 
         try {
-            ModelDefinition def = canvas.toModelDefinition();
+            ModelDefinition def = canvas.navigation().toModelDefinition();
             switch (ext) {
                 case ".mdl" -> VensimExporter.toFile(def, file.toPath());
                 case ".xmile", ".stmx", ".itmx" -> XmileExporter.toFile(def, file.toPath());
@@ -324,7 +324,7 @@ final class FileController {
 
     private void saveToFile(Path path) {
         try {
-            ModelDefinition def = canvas.toModelDefinition();
+            ModelDefinition def = canvas.navigation().toModelDefinition();
             serializer.toFile(def, path);
             dirty = false;
             updateTitle.run();

--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -140,7 +140,7 @@ public class ModelWindow {
 
     private void buildUI() {
         canvas = new ModelCanvas(clipboard);
-        canvas.setUndoManager(undoManager);
+        canvas.undo().setUndoManager(undoManager);
 
         statusBar = new StatusBar();
         analysisRunner = new AnalysisRunner(statusBar, this::showError);
@@ -168,7 +168,7 @@ public class ModelWindow {
 
         dashboardPanel.setRerunAction(simulationController::runSimulation);
         dashboardPanel.setOnVariableClicked(name -> {
-            canvas.selectElement(name);
+            canvas.elements().selectElement(name);
             canvas.requestFocus();
         });
         dashboardPanel.setOnReferenceDataImported(dataset -> {
@@ -244,27 +244,27 @@ public class ModelWindow {
         loopNavigatorBar.setVisible(false);
         loopNavigatorBar.setManaged(false);
         loopNavigatorBar.setOnPrev(() -> {
-            canvas.stepLoopBack();
+            canvas.analysis().stepLoopBack();
             updateLoopNavigator();
             canvas.requestFocus();
         });
         loopNavigatorBar.setOnNext(() -> {
-            canvas.stepLoopForward();
+            canvas.analysis().stepLoopForward();
             updateLoopNavigator();
             canvas.requestFocus();
         });
         loopNavigatorBar.setOnShowAll(() -> {
-            canvas.setActiveLoopIndex(-1);
+            canvas.analysis().setActiveLoopIndex(-1);
             updateLoopNavigator();
             canvas.requestFocus();
         });
         loopNavigatorBar.setOnFilterChanged(filter -> {
-            canvas.setLoopTypeFilter(filter);
+            canvas.analysis().setLoopTypeFilter(filter);
             updateLoopNavigator();
             canvas.requestFocus();
         });
         toolBar.setOnLoopToggleChanged(active -> {
-            canvas.setLoopHighlightActive(active);
+            canvas.analysis().setLoopHighlightActive(active);
             loopNavigatorBar.setVisible(active);
             loopNavigatorBar.setManaged(active);
             if (!active) {
@@ -281,7 +281,7 @@ public class ModelWindow {
         canvas.setToolBar(toolBar);
         canvas.setOnStatusChanged(() -> {
             updateStatusBar();
-            if (canvas.isLoopHighlightActive()) {
+            if (canvas.analysis().isLoopHighlightActive()) {
                 updateLoopNavigator();
             }
             if (propertiesPanel != null) {
@@ -295,7 +295,7 @@ public class ModelWindow {
                     + (replaced.size() == 1 ? "" : "s")
                     + " replaced with 0 (" + names + ")");
         });
-        canvas.setOnValidationChanged(result -> {
+        canvas.analysis().setOnValidationChanged(result -> {
             statusBar.updateValidation(result.errorCount(), result.warningCount());
             if (validationIssuesItem != null) {
                 validationIssuesItem.setDisable(result.isClean());
@@ -305,10 +305,10 @@ public class ModelWindow {
 
         breadcrumbBar = new BreadcrumbBar();
         breadcrumbBar.setOnNavigateTo(depth -> {
-            canvas.navigateToDepth(depth);
+            canvas.navigation().navigateToDepth(depth);
             canvas.requestFocus();
         });
-        canvas.setOnNavigationChanged(this::updateBreadcrumb);
+        canvas.navigation().setOnNavigationChanged(this::updateBreadcrumb);
     }
 
     private void createRightPanel() {
@@ -464,14 +464,14 @@ public class ModelWindow {
         exportItem.setAccelerator(new KeyCodeCombination(KeyCode.E, KeyCombination.SHORTCUT_DOWN));
         exportItem.setOnAction(e -> DiagramExporter.exportDiagram(
                 canvas.getCanvasState(), canvas.getEditor(),
-                canvas.getConnectors(), canvas.getActiveLoopAnalysis(), stage,
+                canvas.getConnectors(), canvas.analysis().getActiveLoopAnalysis(), stage,
                 editor != null ? editor.getModelName() : null));
 
         MenuItem exportReportItem = new MenuItem("Export Report...");
         exportReportItem.setId("menuExportReport");
         exportReportItem.setOnAction(e -> ReportExporter.exportReport(
                 canvas.getCanvasState(), canvas.getEditor(),
-                canvas.getConnectors(), canvas.getActiveLoopAnalysis(), stage,
+                canvas.getConnectors(), canvas.analysis().getActiveLoopAnalysis(), stage,
                 editor != null ? editor.getModelName() : null));
 
         MenuItem closeItem = new MenuItem("Close");
@@ -524,7 +524,7 @@ public class ModelWindow {
         undoItem.setId("menuUndo");
         undoItem.setAccelerator(new KeyCodeCombination(KeyCode.Z, KeyCombination.SHORTCUT_DOWN));
         undoItem.setOnAction(e -> {
-            canvas.performUndo();
+            canvas.undo().performUndo();
             canvas.requestFocus();
         });
         undoItem.setDisable(true);
@@ -534,7 +534,7 @@ public class ModelWindow {
         redoItem.setAccelerator(new KeyCodeCombination(KeyCode.Z,
                 KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN));
         redoItem.setOnAction(e -> {
-            canvas.performRedo();
+            canvas.undo().performRedo();
             canvas.requestFocus();
         });
         redoItem.setDisable(true);
@@ -546,28 +546,28 @@ public class ModelWindow {
         MenuItem cutItem = new MenuItem("Cut");
         cutItem.setAccelerator(new KeyCodeCombination(KeyCode.X, KeyCombination.SHORTCUT_DOWN));
         cutItem.setOnAction(e -> {
-            canvas.cutSelection();
+            canvas.elements().cutSelection();
             canvas.requestFocus();
         });
 
         MenuItem copyItem = new MenuItem("Copy");
         copyItem.setAccelerator(new KeyCodeCombination(KeyCode.C, KeyCombination.SHORTCUT_DOWN));
         copyItem.setOnAction(e -> {
-            canvas.copySelection();
+            canvas.elements().copySelection();
             canvas.requestFocus();
         });
 
         MenuItem pasteItem = new MenuItem("Paste");
         pasteItem.setAccelerator(new KeyCodeCombination(KeyCode.V, KeyCombination.SHORTCUT_DOWN));
         pasteItem.setOnAction(e -> {
-            canvas.pasteClipboard();
+            canvas.elements().pasteClipboard();
             canvas.requestFocus();
         });
 
         MenuItem selectAllItem = new MenuItem("Select All");
         selectAllItem.setAccelerator(new KeyCodeCombination(KeyCode.A, KeyCombination.SHORTCUT_DOWN));
         selectAllItem.setOnAction(e -> {
-            canvas.selectAll();
+            canvas.elements().selectAll();
             canvas.requestFocus();
         });
 
@@ -808,7 +808,7 @@ public class ModelWindow {
     }
 
     private void applyView(ModelEditor ed, ViewDef view, String displayName) {
-        canvas.clearNavigation();
+        canvas.navigation().clearNavigation();
         canvas.clearSparklines();
         canvas.setModel(ed, view);
         undoManager.clear();
@@ -930,13 +930,13 @@ public class ModelWindow {
     }
 
     private void showUndoHistoryPopup() {
-        UndoManager activeUndo = canvas.getUndoManager();
+        UndoManager activeUndo = canvas.undo().getUndoManager();
         if (activeUndo == null || !activeUndo.canUndo()) {
             return;
         }
         List<String> labels = activeUndo.undoLabels();
         UndoHistoryPopup popup = new UndoHistoryPopup(labels, depth -> {
-            canvas.performUndoTo(depth);
+            canvas.undo().performUndoTo(depth);
             canvas.requestFocus();
             updateStatusBar();
         });
@@ -973,7 +973,7 @@ public class ModelWindow {
             zoomOverlay.updateZoom(canvas.getZoomScale());
         }
 
-        UndoManager activeUndo = canvas.getUndoManager();
+        UndoManager activeUndo = canvas.undo().getUndoManager();
         if (undoItem != null) {
             undoItem.setDisable(activeUndo == null || !activeUndo.canUndo());
         }
@@ -986,8 +986,8 @@ public class ModelWindow {
         if (statusBar == null) {
             return;
         }
-        if (canvas.isLoopHighlightActive()) {
-            FeedbackAnalysis analysis = canvas.getLoopAnalysis();
+        if (canvas.analysis().isLoopHighlightActive()) {
+            FeedbackAnalysis analysis = canvas.analysis().getLoopAnalysis();
             int count = analysis != null ? analysis.loopCount() : 0;
             statusBar.updateLoops(count);
         } else {
@@ -999,16 +999,16 @@ public class ModelWindow {
         if (loopNavigatorBar == null) {
             return;
         }
-        loopNavigatorBar.update(canvas.getLoopAnalysis(), canvas.getActiveLoopIndex(),
-                canvas.getLoopTypeFilter(), canvas.getFilteredLoopCount());
+        loopNavigatorBar.update(canvas.analysis().getLoopAnalysis(), canvas.analysis().getActiveLoopIndex(),
+                canvas.analysis().getLoopTypeFilter(), canvas.analysis().getFilteredLoopCount());
     }
 
     private void showValidationDialog() {
-        ValidationResult result = canvas.getLastValidationResult();
+        ValidationResult result = canvas.analysis().getLastValidationResult();
         if (result.isClean()) {
             return;
         }
-        ValidationDialog.showOrUpdate(result, canvas::selectElement, stage);
+        ValidationDialog.showOrUpdate(result, canvas.elements()::selectElement, stage);
     }
 
     private void importReferenceData() {
@@ -1151,8 +1151,8 @@ public class ModelWindow {
             name = "Untitled";
         }
         String dirtySuffix = (fileController != null && fileController.isDirty()) ? " \u2022" : "";
-        String moduleSuffix = canvas != null && canvas.isInsideModule()
-                ? " [" + canvas.getCurrentModuleName() + "]"
+        String moduleSuffix = canvas != null && canvas.navigation().isInsideModule()
+                ? " [" + canvas.navigation().getCurrentModuleName() + "]"
                 : "";
         stage.setTitle("Courant \u2014 " + name + dirtySuffix + moduleSuffix);
         if (dashboardStage != null) {
@@ -1162,7 +1162,7 @@ public class ModelWindow {
 
     private void updateBreadcrumb() {
         if (breadcrumbBar != null && canvas.getEditor() != null) {
-            breadcrumbBar.update(canvas.getNavigationPath());
+            breadcrumbBar.update(canvas.navigation().getNavigationPath());
         }
         updateTitle();
         updateStatusBar();
@@ -1279,18 +1279,18 @@ public class ModelWindow {
 
     private void addEditCommands() {
         commandRegistry.add("Undo", "Edit", () -> {
-            canvas.performUndo(); canvas.requestFocus(); });
+            canvas.undo().performUndo(); canvas.requestFocus(); });
         commandRegistry.add("Redo", "Edit", () -> {
-            canvas.performRedo(); canvas.requestFocus(); });
+            canvas.undo().performRedo(); canvas.requestFocus(); });
         commandRegistry.add("Undo History", "Edit", this::showUndoHistoryPopup);
         commandRegistry.add("Cut", "Edit", () -> {
-            canvas.cutSelection(); canvas.requestFocus(); });
+            canvas.elements().cutSelection(); canvas.requestFocus(); });
         commandRegistry.add("Copy", "Edit", () -> {
-            canvas.copySelection(); canvas.requestFocus(); });
+            canvas.elements().copySelection(); canvas.requestFocus(); });
         commandRegistry.add("Paste", "Edit", () -> {
-            canvas.pasteClipboard(); canvas.requestFocus(); });
+            canvas.elements().pasteClipboard(); canvas.requestFocus(); });
         commandRegistry.add("Select All", "Edit", () -> {
-            canvas.selectAll(); canvas.requestFocus(); });
+            canvas.elements().selectAll(); canvas.requestFocus(); });
     }
 
     private void addFileCommands() {
@@ -1301,7 +1301,7 @@ public class ModelWindow {
         commandRegistry.add("Save As", "File", fileController::saveAs);
         commandRegistry.add("Export Diagram", "File", () -> DiagramExporter.exportDiagram(
                 canvas.getCanvasState(), canvas.getEditor(),
-                canvas.getConnectors(), canvas.getActiveLoopAnalysis(), stage,
+                canvas.getConnectors(), canvas.analysis().getActiveLoopAnalysis(), stage,
                 editor != null ? editor.getModelName() : null));
         commandRegistry.add("Model Info", "File", this::showModelInfoDialog);
     }
@@ -1347,7 +1347,7 @@ public class ModelWindow {
             ElementType type = canvas.getCanvasState().getType(name).orElse(null);
             String category = formatElementType(type);
             commands.add(new CommandPalette.Command(name, category, () -> {
-                canvas.selectElement(name);
+                canvas.elements().selectElement(name);
                 canvas.requestFocus();
             }));
         }
@@ -1404,7 +1404,7 @@ public class ModelWindow {
         }
 
         // Clear canvas and dashboard state
-        canvas.clearNavigation();
+        canvas.navigation().clearNavigation();
         canvas.clearSparklines();
         if (dashboardPanel != null) {
             dashboardPanel.clear();

--- a/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
@@ -94,7 +94,7 @@ final class SimulationController {
             return;
         }
 
-        ModelDefinition def = canvas.toModelDefinition();
+        ModelDefinition def = canvas.navigation().toModelDefinition();
         SimulationSettings finalSettings = settings;
 
         // Snapshot parameter values for ghost run labeling
@@ -144,7 +144,7 @@ final class SimulationController {
         }
 
         ParameterSweepDialog.Config config = configOpt.get();
-        ModelDefinition def = canvas.toModelDefinition();
+        ModelDefinition def = canvas.navigation().toModelDefinition();
         SimulationSettings finalSettings = settings;
 
         analysisRunner.run("Running sweep...",
@@ -193,7 +193,7 @@ final class SimulationController {
         }
 
         MultiParameterSweepDialog.Config config = configOpt.get();
-        ModelDefinition def = canvas.toModelDefinition();
+        ModelDefinition def = canvas.navigation().toModelDefinition();
         SimulationSettings finalSettings = settings;
 
         analysisRunner.run("Running multi-parameter sweep...",
@@ -254,7 +254,7 @@ final class SimulationController {
             return;
         }
 
-        ModelDefinition def = canvas.toModelDefinition();
+        ModelDefinition def = canvas.navigation().toModelDefinition();
         SimulationSettings finalSettings = settings;
 
         analysisRunner.run(
@@ -319,7 +319,7 @@ final class SimulationController {
         }
 
         OptimizerDialog.Config config = configOpt.get();
-        ModelDefinition def = canvas.toModelDefinition();
+        ModelDefinition def = canvas.navigation().toModelDefinition();
         SimulationSettings finalSettings = settings;
 
         analysisRunner.run(
@@ -395,7 +395,7 @@ final class SimulationController {
         }
 
         CalibrateDialog.Config config = configOpt.get();
-        ModelDefinition def = canvas.toModelDefinition();
+        ModelDefinition def = canvas.navigation().toModelDefinition();
         SimulationSettings finalSettings = settings;
 
         analysisRunner.run(
@@ -452,13 +452,13 @@ final class SimulationController {
     }
 
     void validateModel() {
-        ModelDefinition def = canvas.toModelDefinition();
+        ModelDefinition def = canvas.navigation().toModelDefinition();
 
         analysisRunner.run(
                 () -> ModelValidator.validate(def),
                 result -> {
                     statusBar.updateValidation(result.errorCount(), result.warningCount());
-                    ValidationDialog.showOrUpdate(result, canvas::selectElement);
+                    ValidationDialog.showOrUpdate(result, canvas.elements()::selectElement);
                     fireLogEvent.accept(l -> l.onValidation(result.errorCount(), result.warningCount()));
                 },
                 "Validation Error");
@@ -470,7 +470,7 @@ final class SimulationController {
             return;
         }
 
-        ModelDefinition def = canvas.toModelDefinition();
+        ModelDefinition def = canvas.navigation().toModelDefinition();
         List<VariableDef> params = def.parameters();
 
         if (params.isEmpty()) {
@@ -561,10 +561,10 @@ final class SimulationController {
     }
 
     private void computeLoopDominance(SimulationRunner.SimulationResult result) {
-        if (!canvas.isLoopHighlightActive()) {
+        if (!canvas.analysis().isLoopHighlightActive()) {
             return;
         }
-        FeedbackAnalysis analysis = canvas.getLoopAnalysis();
+        FeedbackAnalysis analysis = canvas.analysis().getLoopAnalysis();
         if (analysis == null || analysis.loopCount() == 0) {
             return;
         }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasAnalysisFacade.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasAnalysisFacade.java
@@ -1,0 +1,260 @@
+package systems.courant.sd.app.canvas;
+
+import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.ModelValidator;
+import systems.courant.sd.model.def.ValidationIssue;
+import systems.courant.sd.model.def.ValidationIssue.Severity;
+import systems.courant.sd.model.def.ValidationResult;
+import systems.courant.sd.model.graph.CausalTraceAnalysis;
+import systems.courant.sd.model.graph.DependencyGraph;
+import systems.courant.sd.model.graph.FeedbackAnalysis;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import systems.courant.sd.app.canvas.controllers.CausalTraceController;
+import systems.courant.sd.app.canvas.controllers.LoopHighlightController;
+
+/**
+ * Facade encapsulating model analysis responsibilities: loop highlighting,
+ * causal tracing, validation indicators, and dependency queries.
+ * Extracted from {@link ModelCanvas} to reduce its size and isolate
+ * a coherent set of analysis concerns.
+ */
+public final class CanvasAnalysisFacade {
+
+    private final CanvasState canvasState;
+    private final Supplier<ModelDefinition> modelDefSupplier;
+    private final Runnable onRedraw;
+    private final Runnable onStatusChanged;
+
+    // Feedback loop highlighting
+    private final LoopHighlightController loopController = new LoopHighlightController();
+
+    // Causal tracing
+    private final CausalTraceController traceController = new CausalTraceController();
+
+    // Validation issue indicators (element name -> highest severity)
+    private Map<String, Severity> elementIssues = Map.of();
+
+    // Full validation issues per element (for tooltips and dialog)
+    private Map<String, List<ValidationIssue>> elementIssueDetails = Map.of();
+
+    // Maturity analysis (missing equations, units, mismatches)
+    private MaturityAnalysis maturityAnalysis = MaturityAnalysis.EMPTY;
+
+    // Last validation result (for dialog access)
+    private ValidationResult lastValidationResult = new ValidationResult(List.of());
+
+    // Callback when validation counts change
+    private Consumer<ValidationResult> onValidationChanged;
+
+    CanvasAnalysisFacade(CanvasState canvasState,
+                         Supplier<ModelDefinition> modelDefSupplier,
+                         Runnable onRedraw,
+                         Runnable onStatusChanged) {
+        this.canvasState = canvasState;
+        this.modelDefSupplier = modelDefSupplier;
+        this.onRedraw = onRedraw;
+        this.onStatusChanged = onStatusChanged;
+    }
+
+    // --- Loop analysis (delegated to LoopHighlightController) ---
+
+    public void setLoopHighlightActive(boolean active) {
+        loopController.setActive(active, modelDefSupplier);
+        onRedraw.run();
+    }
+
+    public boolean isLoopHighlightActive() {
+        return loopController.isActive();
+    }
+
+    public FeedbackAnalysis getLoopAnalysis() {
+        return loopController.getAnalysis();
+    }
+
+    public int getActiveLoopIndex() {
+        return loopController.getActiveIndex();
+    }
+
+    public void setActiveLoopIndex(int index) {
+        if (loopController.setActiveIndex(index)) {
+            onRedraw.run();
+            onStatusChanged.run();
+        }
+    }
+
+    public void stepLoopForward() {
+        if (loopController.stepForward()) {
+            onRedraw.run();
+            onStatusChanged.run();
+        }
+    }
+
+    public void stepLoopBack() {
+        if (loopController.stepBack()) {
+            onRedraw.run();
+            onStatusChanged.run();
+        }
+    }
+
+    public FeedbackAnalysis.LoopType getLoopTypeFilter() {
+        return loopController.getTypeFilter();
+    }
+
+    public void setLoopTypeFilter(FeedbackAnalysis.LoopType filter) {
+        if (loopController.setTypeFilter(filter)) {
+            onRedraw.run();
+            onStatusChanged.run();
+        }
+    }
+
+    public int getFilteredLoopCount() {
+        return loopController.filteredLoopCount();
+    }
+
+    public FeedbackAnalysis getActiveLoopAnalysis() {
+        return loopController.getActiveAnalysis();
+    }
+
+    // --- Causal tracing ---
+
+    public void traceUpstream(String elementName) {
+        ModelDefinition def = modelDefSupplier.get();
+        if (def == null) {
+            return;
+        }
+        traceController.startTrace(elementName,
+                CausalTraceAnalysis.TraceDirection.UPSTREAM, def);
+        onRedraw.run();
+    }
+
+    public void traceDownstream(String elementName) {
+        ModelDefinition def = modelDefSupplier.get();
+        if (def == null) {
+            return;
+        }
+        traceController.startTrace(elementName,
+                CausalTraceAnalysis.TraceDirection.DOWNSTREAM, def);
+        onRedraw.run();
+    }
+
+    public boolean isTraceActive() {
+        return traceController.isActive();
+    }
+
+    public void clearTrace() {
+        traceController.clearTrace();
+    }
+
+    CausalTraceAnalysis getTraceAnalysis() {
+        return traceController.getAnalysis();
+    }
+
+    // --- Dependency queries ---
+
+    public Set<String> whereUsed(String elementName) {
+        ModelDefinition def = modelDefSupplier.get();
+        if (def == null) {
+            return Set.of();
+        }
+        DependencyGraph graph = DependencyGraph.fromDefinition(def);
+        return graph.dependentsOf(elementName);
+    }
+
+    public Set<String> uses(String elementName) {
+        ModelDefinition def = modelDefSupplier.get();
+        if (def == null) {
+            return Set.of();
+        }
+        DependencyGraph graph = DependencyGraph.fromDefinition(def);
+        return graph.dependenciesOf(elementName);
+    }
+
+    public void showWhereUsed(String elementName) {
+        Set<String> dependents = whereUsed(elementName);
+        canvasState.clearSelection();
+        dependents.forEach(canvasState::addToSelection);
+        onStatusChanged.run();
+        onRedraw.run();
+    }
+
+    public void showUses(String elementName) {
+        Set<String> dependencies = uses(elementName);
+        canvasState.clearSelection();
+        dependencies.forEach(canvasState::addToSelection);
+        onStatusChanged.run();
+        onRedraw.run();
+    }
+
+    // --- Validation ---
+
+    public void setOnValidationChanged(Consumer<ValidationResult> callback) {
+        this.onValidationChanged = callback;
+    }
+
+    public ValidationResult getLastValidationResult() {
+        return lastValidationResult;
+    }
+
+    public List<ValidationIssue> getValidationIssues(String elementName) {
+        return elementIssueDetails.getOrDefault(elementName, List.of());
+    }
+
+    // --- Render accessors (package-private) ---
+
+    Map<String, Severity> elementIssues() {
+        return elementIssues;
+    }
+
+    Map<String, List<ValidationIssue>> elementIssueDetails() {
+        return elementIssueDetails;
+    }
+
+    MaturityAnalysis maturityAnalysis() {
+        return maturityAnalysis;
+    }
+
+    // --- Invalidation ---
+
+    void invalidate() {
+        ModelDefinition def = modelDefSupplier.get();
+        loopController.invalidate(def);
+        traceController.invalidate(def);
+        recomputeValidation(def);
+    }
+
+    private void recomputeValidation(ModelDefinition def) {
+        if (def == null) {
+            elementIssues = Map.of();
+            elementIssueDetails = Map.of();
+            lastValidationResult = new ValidationResult(List.of());
+            maturityAnalysis = MaturityAnalysis.EMPTY;
+            return;
+        }
+        ValidationResult result = ModelValidator.validate(def);
+        Map<String, Severity> issues = new LinkedHashMap<>();
+        Map<String, List<ValidationIssue>> details = new LinkedHashMap<>();
+        for (ValidationIssue issue : result.issues()) {
+            if (issue.elementName() != null) {
+                issues.merge(issue.elementName(), issue.severity(),
+                        (existing, incoming) ->
+                                existing == Severity.ERROR ? existing : incoming);
+                details.computeIfAbsent(issue.elementName(), k -> new ArrayList<>()).add(issue);
+            }
+        }
+        elementIssues = issues;
+        elementIssueDetails = details;
+        lastValidationResult = result;
+        maturityAnalysis = MaturityAnalysis.analyze(def);
+        if (onValidationChanged != null) {
+            onValidationChanged.accept(result);
+        }
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasCallbacks.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasCallbacks.java
@@ -22,7 +22,7 @@ final class CanvasCallbacks implements InlineEditController.Callbacks,
 
     @Override
     public void applyRename(String oldName, String newName) {
-        canvas.applyRename(oldName, newName);
+        canvas.elements().applyRename(oldName, newName);
     }
 
     @Override
@@ -57,32 +57,32 @@ final class CanvasCallbacks implements InlineEditController.Callbacks,
 
     @Override
     public void startInlineEdit(String name) {
-        canvas.startInlineEdit(name);
+        canvas.elements().startInlineEdit(name);
     }
 
     @Override
     public void deleteSelectedElements() {
-        canvas.deleteSelectedElements();
+        canvas.elements().deleteSelectedElements();
     }
 
     @Override
     public void cutSelection() {
-        canvas.cutSelection();
+        canvas.elements().cutSelection();
     }
 
     @Override
     public void copySelection() {
-        canvas.copySelection();
+        canvas.elements().copySelection();
     }
 
     @Override
     public void pasteClipboard() {
-        canvas.pasteClipboard();
+        canvas.elements().pasteClipboard();
     }
 
     @Override
     public void selectAll() {
-        canvas.selectAll();
+        canvas.elements().selectAll();
     }
 
     @Override
@@ -122,56 +122,56 @@ final class CanvasCallbacks implements InlineEditController.Callbacks,
 
     @Override
     public String createElementAt(double wx, double wy, CanvasToolBar.Tool tool) {
-        return canvas.createElementAtForCallback(wx, wy, tool);
+        return canvas.elements().createElementAtForCallback(wx, wy, tool);
     }
 
     @Override
     public boolean deleteConnection(ConnectionId conn, boolean isCausal) {
-        return canvas.deleteConnectionForCallback(conn, isCausal);
+        return canvas.elements().deleteConnectionForCallback(conn, isCausal);
     }
 
     @Override
     public boolean canPaste() {
-        return canvas.canPasteForCallback();
+        return canvas.elements().canPasteForCallback();
     }
 
     @Override
     public void classifyCldVariable(String name, ElementType type) {
-        canvas.classifyCldVariableInternal(name, type);
+        canvas.elements().classifyCldVariable(name, type);
     }
 
     @Override
     public void drillInto(String moduleName) {
-        canvas.drillInto(moduleName);
+        canvas.navigation().drillInto(moduleName);
     }
 
     @Override
     public void openDefinePortsDialog(String moduleName) {
-        canvas.openDefinePortsDialogInternal(moduleName);
+        canvas.navigation().openDefinePortsDialog(moduleName);
     }
 
     @Override
     public void openBindingsDialog(String moduleName) {
-        canvas.openBindingsDialogInternal(moduleName);
+        canvas.navigation().openBindingsDialog(moduleName);
     }
 
     @Override
     public void traceUpstream(String name) {
-        canvas.traceUpstream(name);
+        canvas.analysis().traceUpstream(name);
     }
 
     @Override
     public void traceDownstream(String name) {
-        canvas.traceDownstream(name);
+        canvas.analysis().traceDownstream(name);
     }
 
     @Override
     public void showWhereUsed(String name) {
-        canvas.showWhereUsed(name);
+        canvas.analysis().showWhereUsed(name);
     }
 
     @Override
     public void showUses(String name) {
-        canvas.showUses(name);
+        canvas.analysis().showUses(name);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasElementController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasElementController.java
@@ -1,0 +1,275 @@
+package systems.courant.sd.app.canvas;
+
+import systems.courant.sd.model.def.ElementType;
+
+import java.util.Set;
+
+import systems.courant.sd.app.canvas.controllers.CausalLinkCreationController;
+import systems.courant.sd.app.canvas.controllers.FlowCreationController;
+import systems.courant.sd.app.canvas.controllers.InfoLinkCreationController;
+
+/**
+ * Facade encapsulating element mutation operations: create, delete, rename,
+ * copy/cut/paste, connection creation, and inline editing.
+ * Extracted from {@link ModelCanvas} to isolate element CRUD concerns.
+ */
+public final class CanvasElementController {
+
+    private final ModelCanvas canvas;
+
+    CanvasElementController(ModelCanvas canvas) {
+        this.canvas = canvas;
+    }
+
+    public void deleteSelectedElements() {
+        if (canvas.editor == null) {
+            return;
+        }
+        canvas.selectionController.deleteSelected(canvas.editor, canvas.canvasState(),
+                () -> canvas.saveUndoState("Delete " + canvas.undo().describeSelection()));
+        canvas.regenerateConnectors();
+        canvas.requestRedraw();
+        canvas.fireStatusChanged();
+        canvas.inputDispatcher.updateCursor(canvas);
+    }
+
+    public void renameElement(String oldName, String newName) {
+        applyRename(oldName, newName);
+    }
+
+    public void triggerBindingConfig(String moduleName) {
+        canvas.navigation().openBindingsDialog(moduleName);
+    }
+
+    public void selectAll() {
+        canvas.canvasState().selectAll();
+        canvas.requestRedraw();
+        canvas.fireStatusChanged();
+    }
+
+    public void selectElement(String name) {
+        canvas.selectionController.selectAndCenter(name, canvas.canvasState(),
+                canvas.viewport(), canvas.getWidth(), canvas.getHeight());
+        canvas.fireStatusChanged();
+        canvas.requestRedraw();
+    }
+
+    public void copySelection() {
+        if (canvas.editor == null) {
+            return;
+        }
+        canvas.selectionController.copy(canvas.editor, canvas.canvasState());
+    }
+
+    public void cutSelection() {
+        if (canvas.editor == null) {
+            return;
+        }
+        canvas.selectionController.cut(canvas.editor, canvas.canvasState(),
+                () -> canvas.saveUndoState("Cut " + canvas.undo().describeSelection()));
+        canvas.regenerateConnectors();
+        canvas.requestRedraw();
+        canvas.fireStatusChanged();
+        canvas.inputDispatcher.updateCursor(canvas);
+    }
+
+    public Set<String> pasteClipboard() {
+        if (canvas.editor == null) {
+            return Set.of();
+        }
+        double centerWorldX = canvas.viewport().toWorldX(canvas.getWidth() / 2.0);
+        double centerWorldY = canvas.viewport().toWorldY(canvas.getHeight() / 2.0);
+        var viewportCenter = new CanvasState.Position(centerWorldX, centerWorldY);
+        Set<String> replaced = canvas.selectionController.paste(
+                canvas.editor, canvas.canvasState(),
+                () -> canvas.saveUndoState("Paste elements"),
+                viewportCenter);
+        if (replaced == null) {
+            return Set.of();
+        }
+        canvas.regenerateConnectors();
+        canvas.requestRedraw();
+        canvas.fireStatusChanged();
+        if (!replaced.isEmpty() && canvas.onPasteWarning != null) {
+            canvas.onPasteWarning.accept(replaced);
+        }
+        return replaced;
+    }
+
+    public void deleteSelectedOrConnection() {
+        if (canvas.editor == null) {
+            return;
+        }
+        if (canvas.selectedConnection != null && canvas.canvasState().getSelection().isEmpty()) {
+            if (canvas.selectionController.deleteConnection(
+                    canvas.selectedConnection, canvas.selectedIsCausalLink, canvas.editor,
+                    () -> canvas.saveUndoState("Delete " + canvas.selectedConnection.from()
+                            + " \u2192 " + canvas.selectedConnection.to() + " connection"))) {
+                if (!canvas.selectedIsCausalLink) {
+                    canvas.connectors = canvas.editor.generateConnectors();
+                }
+                canvas.clearSelectedConnection();
+                canvas.invalidateAnalysis();
+                canvas.requestRedraw();
+                canvas.fireStatusChanged();
+                canvas.inputDispatcher.updateCursor(canvas);
+            }
+        } else {
+            deleteSelectedElements();
+        }
+    }
+
+    public void handleFlowClick(double worldX, double worldY) {
+        if (canvas.editor == null) {
+            return;
+        }
+        var snapshot = canvas.undo().captureSnapshot();
+        FlowCreationController.FlowResult result = canvas.flowCreation.handleClick(
+                worldX, worldY, canvas.canvasState(), canvas.editor);
+        if (result.isCreated()) {
+            canvas.undo().pushUndoSnapshot(snapshot, "Add flow");
+            canvas.regenerateConnectors();
+            canvas.canvasState().clearSelection();
+            canvas.canvasState().select(result.flowName());
+        }
+        canvas.requestRedraw();
+        canvas.fireStatusChanged();
+    }
+
+    public void handleCausalLinkClick(double worldX, double worldY) {
+        if (canvas.editor == null) {
+            return;
+        }
+        var snapshot = canvas.undo().captureSnapshot();
+        CausalLinkCreationController.LinkResult result = canvas.causalLinkCreation.handleClick(
+                worldX, worldY, canvas.canvasState(), canvas.editor);
+        if (result.isCreated()) {
+            canvas.undo().pushUndoSnapshot(snapshot, "Add causal link");
+            canvas.regenerateConnectors();
+        }
+        canvas.requestRedraw();
+        canvas.fireStatusChanged();
+    }
+
+    public void handleInfoLinkClick(double worldX, double worldY) {
+        if (canvas.editor == null) {
+            return;
+        }
+        var snapshot = canvas.undo().captureSnapshot();
+        InfoLinkCreationController.LinkResult result = canvas.infoLinkCreation.handleClick(
+                worldX, worldY, canvas.canvasState(), canvas.editor);
+        if (result.isCreated()) {
+            canvas.undo().pushUndoSnapshot(snapshot, "Bind module port");
+            canvas.regenerateConnectors();
+        }
+        canvas.requestRedraw();
+        canvas.fireStatusChanged();
+    }
+
+    public void createElementAt(double worldX, double worldY) {
+        if (canvas.editor == null) {
+            return;
+        }
+        String name = canvas.selectionController.createElementAt(
+                worldX, worldY, canvas.activeTool, canvas.editor, canvas.canvasState(),
+                () -> canvas.saveUndoState("Add " + canvas.activeTool.label()));
+        if (name != null) {
+            canvas.regenerateConnectors();
+            canvas.requestRedraw();
+            canvas.fireStatusChanged();
+            if (canvas.activeTool == CanvasToolBar.Tool.PLACE_COMMENT) {
+                startInlineEdit(name);
+            }
+        }
+    }
+
+    public void startInlineEdit(String elementName) {
+        if (canvas.editor == null) {
+            return;
+        }
+        canvas.inlineEdit.startEdit(elementName, canvas.canvasState(),
+                canvas.editor, canvas.viewport(), canvas.callbacks);
+    }
+
+    void applyRename(String oldName, String newName) {
+        if (canvas.editor == null) {
+            return;
+        }
+        if (canvas.selectionController.applyRename(oldName, newName, canvas.editor,
+                canvas.canvasState(),
+                () -> canvas.saveUndoState("Rename " + oldName + " \u2192 " + newName))) {
+            canvas.regenerateAndRedraw();
+        }
+    }
+
+    void classifyCldVariable(String name, ElementType targetType) {
+        if (canvas.editor == null) {
+            return;
+        }
+        if (canvas.selectionController.classifyCldVariable(name, targetType, canvas.editor,
+                canvas.canvasState(),
+                () -> canvas.saveUndoState(
+                        "Classify " + name + " as " + targetType.name().toLowerCase()))) {
+            canvas.regenerateAndRedraw();
+            canvas.fireStatusChanged();
+        }
+    }
+
+    // --- Context menu wrappers ---
+
+    public void showElementContextMenu(String elementName, double screenX, double screenY) {
+        canvas.contextMenuController.showElementContextMenu(
+                canvas, elementName, canvas.canvasState(), screenX, screenY, canvas.callbacks);
+    }
+
+    public void showGeneralElementContextMenu(String elementName,
+                                               double screenX, double screenY) {
+        canvas.contextMenuController.showGeneralElementContextMenu(
+                canvas, elementName, canvas.canvasState(), screenX, screenY, canvas.callbacks);
+    }
+
+    public void showCausalLinkContextMenu(ConnectionId link,
+                                           double screenX, double screenY) {
+        if (canvas.editor == null) {
+            return;
+        }
+        canvas.contextMenuController.showCausalLinkContextMenu(
+                canvas, link, canvas.editor, screenX, screenY, canvas.callbacks);
+    }
+
+    public void showInfoLinkContextMenu(ConnectionId link,
+                                         double screenX, double screenY) {
+        canvas.contextMenuController.showInfoLinkContextMenu(
+                canvas, link, screenX, screenY, canvas.callbacks);
+    }
+
+    public void showCanvasContextMenu(double worldX, double worldY,
+                                       double screenX, double screenY) {
+        canvas.contextMenuController.showCanvasContextMenu(
+                canvas, worldX, worldY, screenX, screenY, canvas.callbacks);
+    }
+
+    // --- Callback helpers ---
+
+    String createElementAtForCallback(double wx, double wy, CanvasToolBar.Tool tool) {
+        String name = canvas.selectionController.createElementAt(
+                wx, wy, tool, canvas.editor, canvas.canvasState(),
+                () -> canvas.saveUndoState("Add " + tool.label()));
+        if (name != null) {
+            canvas.regenerateConnectors();
+            canvas.requestRedraw();
+            canvas.fireStatusChanged();
+        }
+        return name;
+    }
+
+    boolean deleteConnectionForCallback(ConnectionId conn, boolean isCausal) {
+        return canvas.selectionController.deleteConnection(conn, isCausal, canvas.editor,
+                () -> canvas.saveUndoState(
+                        "Delete " + conn.from() + " \u2192 " + conn.to() + " connection"));
+    }
+
+    boolean canPasteForCallback() {
+        return canvas.selectionController.canPaste();
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasNavigationFacade.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasNavigationFacade.java
@@ -1,0 +1,206 @@
+package systems.courant.sd.app.canvas;
+
+import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.ModuleInstanceDef;
+import systems.courant.sd.model.def.ViewDef;
+import systems.courant.sd.model.graph.AutoLayout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import systems.courant.sd.app.canvas.controllers.ModuleNavigationController;
+
+/**
+ * Facade encapsulating module navigation responsibilities: drill-into,
+ * navigate-back, breadcrumb path, and model definition composition.
+ * Extracted from {@link ModelCanvas} to isolate navigation concerns.
+ */
+public final class CanvasNavigationFacade {
+
+    private final ModelCanvas canvas;
+    private final ModuleNavigationController navController = new ModuleNavigationController();
+
+    CanvasNavigationFacade(ModelCanvas canvas) {
+        this.canvas = canvas;
+    }
+
+    ModuleNavigationController navController() {
+        return navController;
+    }
+
+    public void setOnNavigationChanged(Runnable callback) {
+        navController.setOnNavigationChanged(callback);
+    }
+
+    public ModelDefinition toModelDefinition() {
+        if (canvas.editor == null) {
+            throw new IllegalStateException("No model loaded");
+        }
+        if (!navController.isInsideModule()) {
+            return canvas.editor.toModelDefinition(canvas.canvasState().toViewDef());
+        }
+
+        ModelDefinition childDef = canvas.editor.toModelDefinition(canvas.canvasState().toViewDef());
+
+        List<NavigationStack.Frame> frames = new ArrayList<>(navController.frames());
+        for (int i = frames.size() - 1; i >= 0; i--) {
+            NavigationStack.Frame frame = frames.get(i);
+            ModelEditor parentEditor = new ModelEditor();
+            parentEditor.loadFrom(frame.editor().toModelDefinition(frame.viewSnapshot()));
+            parentEditor.updateModuleDefinition(frame.moduleIndex(), childDef);
+            childDef = parentEditor.toModelDefinition(frame.viewSnapshot());
+        }
+
+        return childDef;
+    }
+
+    public void drillInto(String moduleName) {
+        if (canvas.editor == null) {
+            return;
+        }
+        Optional<ModuleInstanceDef> moduleOpt = canvas.editor.getModuleByName(moduleName);
+        if (moduleOpt.isEmpty()) {
+            return;
+        }
+        ModuleInstanceDef module = moduleOpt.get();
+        int moduleIndex = canvas.editor.getModuleIndex(moduleName);
+
+        navController.push(new NavigationStack.Frame(
+                moduleName, moduleIndex, canvas.editor, canvas.canvasState().toViewDef(),
+                canvas.viewport().getTranslateX(), canvas.viewport().getTranslateY(),
+                canvas.viewport().getScale(), canvas.undoManager, canvas.activeTool));
+
+        ModelEditor moduleEditor = new ModelEditor();
+        moduleEditor.loadFrom(module.definition());
+
+        ViewDef moduleView;
+        if (!module.definition().views().isEmpty()) {
+            moduleView = module.definition().views().getFirst();
+        } else {
+            var sizeOverrides = LayoutMetrics.computeSizeOverrides(module.definition());
+            moduleView = AutoLayout.layout(module.definition(), sizeOverrides);
+        }
+
+        canvas.undoManager = new UndoManager();
+        canvas.setModel(moduleEditor, moduleView);
+        canvas.viewport().reset();
+
+        if (canvas.toolBar != null) {
+            canvas.toolBar.resetToSelect();
+        } else {
+            canvas.activeTool = CanvasToolBar.Tool.SELECT;
+        }
+
+        navController.fireNavigationChanged();
+        canvas.fireStatusChanged();
+    }
+
+    public void navigateBack() {
+        if (!navController.isInsideModule() || canvas.editor == null) {
+            return;
+        }
+
+        popNavigationLevel(true);
+
+        canvas.connectors = canvas.editor.generateConnectors();
+        canvas.invalidateAnalysis();
+        canvas.requestRedraw();
+
+        navController.fireNavigationChanged();
+        canvas.fireStatusChanged();
+    }
+
+    public void navigateToDepth(int targetDepth) {
+        int levelsToNavigate = navController.depth() - targetDepth;
+        if (levelsToNavigate <= 0 || canvas.editor == null) {
+            return;
+        }
+
+        if (levelsToNavigate == 1) {
+            navigateBack();
+            return;
+        }
+
+        popNavigationLevel(false);
+        for (int i = 1; i < levelsToNavigate; i++) {
+            popNavigationLevel(i == levelsToNavigate - 1);
+        }
+
+        canvas.connectors = canvas.editor.generateConnectors();
+        canvas.invalidateAnalysis();
+        canvas.requestRedraw();
+
+        navController.fireNavigationChanged();
+        canvas.fireStatusChanged();
+    }
+
+    private void popNavigationLevel(boolean saveUndo) {
+        ModelDefinition childDef = canvas.editor.toModelDefinition(canvas.canvasState().toViewDef());
+        NavigationStack.Frame frame = navController.pop();
+
+        canvas.undoManager.close();
+        canvas.editor = frame.editor();
+        canvas.undoManager = frame.undoManager();
+
+        if (saveUndo) {
+            canvas.saveUndoState("Edit module " + frame.moduleName());
+        }
+        canvas.editor.updateModuleDefinition(frame.moduleIndex(), childDef);
+
+        canvas.canvasState().loadFrom(frame.viewSnapshot());
+        canvas.viewport().restoreState(frame.viewportTranslateX(),
+                frame.viewportTranslateY(), frame.viewportScale());
+
+        if (canvas.toolBar != null) {
+            canvas.toolBar.selectTool(frame.activeTool());
+        } else {
+            canvas.activeTool = frame.activeTool();
+        }
+    }
+
+    public boolean isInsideModule() {
+        return navController.isInsideModule();
+    }
+
+    public List<String> getNavigationPath() {
+        String rootName = navController.isInsideModule()
+                ? navController.frames().getFirst().editor().getModelName()
+                : canvas.editor.getModelName();
+        return navController.getPath(rootName);
+    }
+
+    public String getCurrentModuleName() {
+        return navController.getCurrentModuleName();
+    }
+
+    public void clearNavigation() {
+        if (navController.isInsideModule()) {
+            canvas.undoManager.close();
+            List<NavigationStack.Frame> frames = navController.frames();
+            canvas.undoManager = frames.getFirst().undoManager();
+            for (int i = 1; i < frames.size(); i++) {
+                frames.get(i).undoManager().close();
+            }
+        }
+        navController.clear();
+    }
+
+    void openDefinePortsDialog(String moduleName) {
+        if (canvas.editor == null) {
+            return;
+        }
+        navController.openDefinePortsDialog(moduleName, canvas.editor,
+                () -> canvas.saveUndoState("Define " + moduleName + " ports"),
+                canvas::fireStatusChanged);
+    }
+
+    void openBindingsDialog(String moduleName) {
+        if (canvas.editor == null) {
+            return;
+        }
+        navController.openBindingsDialog(moduleName, canvas.editor,
+                () -> canvas.saveUndoState("Edit " + moduleName + " bindings"),
+                canvas::fireStatusChanged);
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasUndoFacade.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasUndoFacade.java
@@ -1,0 +1,93 @@
+package systems.courant.sd.app.canvas;
+
+import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.ViewDef;
+
+import java.util.Set;
+
+/**
+ * Facade encapsulating undo/redo state management: snapshot capture,
+ * undo/redo operations, and undo manager lifecycle.
+ * Extracted from {@link ModelCanvas} to isolate undo concerns.
+ */
+public final class CanvasUndoFacade {
+
+    private final ModelCanvas canvas;
+
+    CanvasUndoFacade(ModelCanvas canvas) {
+        this.canvas = canvas;
+    }
+
+    public void setUndoManager(UndoManager undoManager) {
+        canvas.undoManager = undoManager;
+    }
+
+    public UndoManager getUndoManager() {
+        return canvas.undoManager;
+    }
+
+    UndoManager.Snapshot captureSnapshot() {
+        return new UndoManager.Snapshot(
+                canvas.editor.toModelDefinition(canvas.canvasState().toViewDef()),
+                canvas.canvasState().toViewDef());
+    }
+
+    public void saveUndoState(String label) {
+        if (canvas.undoManager != null && canvas.editor != null) {
+            canvas.undoManager.pushUndo(captureSnapshot(), label);
+        }
+    }
+
+    public void saveUndoStateTentative(String label) {
+        if (canvas.undoManager != null && canvas.editor != null) {
+            canvas.undoManager.pushUndoTentative(captureSnapshot(), label);
+        }
+    }
+
+    void pushUndoSnapshot(UndoManager.Snapshot snapshot, String label) {
+        if (canvas.undoManager != null) {
+            canvas.undoManager.pushUndo(snapshot, label);
+        }
+    }
+
+    String describeSelection() {
+        Set<String> sel = canvas.canvasState().getSelection();
+        if (sel.isEmpty()) {
+            return "elements";
+        }
+        if (sel.size() == 1) {
+            return sel.iterator().next();
+        }
+        return sel.size() + " elements";
+    }
+
+    private void restoreSnapshot(UndoManager.Snapshot snapshot) {
+        canvas.editor.loadFrom(snapshot.model());
+        canvas.canvasState().loadFrom(snapshot.view());
+        canvas.connectors = canvas.editor.generateConnectors();
+        canvas.invalidateAnalysis();
+        canvas.requestRedraw();
+        canvas.fireStatusChanged();
+    }
+
+    public void performUndo() {
+        if (canvas.undoManager == null || canvas.editor == null) {
+            return;
+        }
+        canvas.undoManager.undo(captureSnapshot()).ifPresent(this::restoreSnapshot);
+    }
+
+    public void performRedo() {
+        if (canvas.undoManager == null || canvas.editor == null) {
+            return;
+        }
+        canvas.undoManager.redo(captureSnapshot()).ifPresent(this::restoreSnapshot);
+    }
+
+    public void performUndoTo(int depth) {
+        if (canvas.undoManager == null || canvas.editor == null) {
+            return;
+        }
+        canvas.undoManager.undoTo(captureSnapshot(), depth).ifPresent(this::restoreSnapshot);
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContextResolver.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContextResolver.java
@@ -73,9 +73,9 @@ public final class HelpContextResolver {
                 isEquationFieldFocused(focusOwner),
                 selectedType,
                 canvas.getActiveTool(),
-                canvas.isLoopHighlightActive(),
-                canvas.isTraceActive(),
-                canvas.isInsideModule(),
+                canvas.analysis().isLoopHighlightActive(),
+                canvas.analysis().isTraceActive(),
+                canvas.navigation().isInsideModule(),
                 dashboardSelected);
     }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/InputDispatcher.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/InputDispatcher.java
@@ -260,9 +260,9 @@ final class InputDispatcher {
             return false;
         }
         if (canvasState.getType(hit).orElse(null) == ElementType.MODULE) {
-            canvas.drillInto(hit);
+            canvas.navigation().drillInto(hit);
         } else {
-            canvas.startInlineEdit(hit);
+            canvas.elements().startInlineEdit(hit);
         }
         event.consume();
         return true;
@@ -323,11 +323,11 @@ final class InputDispatcher {
                                               CanvasToolBar.Tool activeTool,
                                               double worldX, double worldY) {
         if (activeTool == CanvasToolBar.Tool.PLACE_FLOW) {
-            canvas.handleFlowClick(worldX, worldY);
+            canvas.elements().handleFlowClick(worldX, worldY);
         } else if (activeTool == CanvasToolBar.Tool.PLACE_CAUSAL_LINK) {
-            canvas.handleCausalLinkClick(worldX, worldY);
+            canvas.elements().handleCausalLinkClick(worldX, worldY);
         } else if (activeTool == CanvasToolBar.Tool.PLACE_INFO_LINK) {
-            canvas.handleInfoLinkClick(worldX, worldY);
+            canvas.elements().handleInfoLinkClick(worldX, worldY);
         } else {
             return false;
         }
@@ -348,7 +348,7 @@ final class InputDispatcher {
         if (hit != null) {
             return false;
         }
-        canvas.createElementAt(worldX, worldY);
+        canvas.elements().createElementAt(worldX, worldY);
         updateCursor(canvas);
         event.consume();
         return true;
@@ -507,7 +507,7 @@ final class InputDispatcher {
                 }
             } else {
                 String flowLabel = reattachController.flowName();
-                UndoManager um = canvas.getUndoManager();
+                UndoManager um = canvas.undo().getUndoManager();
                 boolean reconnected = reattachController.complete(
                         viewport.toWorldX(event.getX()),
                         viewport.toWorldY(event.getY()),
@@ -602,9 +602,9 @@ final class InputDispatcher {
         if (hit != null) {
             ElementType hitType = canvasState.getType(hit).orElse(null);
             if (hitType == ElementType.MODULE || hitType == ElementType.CLD_VARIABLE) {
-                canvas.showElementContextMenu(hit, sx, sy);
+                canvas.elements().showElementContextMenu(hit, sx, sy);
             } else {
-                canvas.showGeneralElementContextMenu(hit, sx, sy);
+                canvas.elements().showGeneralElementContextMenu(hit, sx, sy);
             }
             updateCursor(canvas);
             return true;
@@ -618,7 +618,7 @@ final class InputDispatcher {
         ConnectionId causalHit = HitTester.hitTestCausalLink(canvasState,
                 editor.getCausalLinks(), worldX, worldY, hideAux);
         if (causalHit != null) {
-            canvas.showCausalLinkContextMenu(causalHit, sx, sy);
+            canvas.elements().showCausalLinkContextMenu(causalHit, sx, sy);
             updateCursor(canvas);
             return true;
         }
@@ -627,13 +627,13 @@ final class InputDispatcher {
         ConnectionId infoHit = HitTester.hitTestInfoLink(canvasState,
                 canvas.getConnectors(), worldX, worldY, hideAux);
         if (infoHit != null) {
-            canvas.showInfoLinkContextMenu(infoHit, sx, sy);
+            canvas.elements().showInfoLinkContextMenu(infoHit, sx, sy);
             updateCursor(canvas);
             return true;
         }
 
         // 4. Empty canvas
-        canvas.showCanvasContextMenu(worldX, worldY, sx, sy);
+        canvas.elements().showCanvasContextMenu(worldX, worldY, sx, sy);
         updateCursor(canvas);
         return true;
     }
@@ -659,19 +659,19 @@ final class InputDispatcher {
             updateCursor(canvas);
             event.consume();
         } else if (event.getCode() == KeyCode.DELETE || event.getCode() == KeyCode.BACK_SPACE) {
-            canvas.deleteSelectedOrConnection();
+            canvas.elements().deleteSelectedOrConnection();
             event.consume();
         } else if (event.isShortcutDown() && event.getCode() == KeyCode.A) {
-            canvas.selectAll();
+            canvas.elements().selectAll();
             event.consume();
         } else if (event.isShortcutDown() && event.getCode() == KeyCode.C) {
-            canvas.copySelection();
+            canvas.elements().copySelection();
             event.consume();
         } else if (event.isShortcutDown() && event.getCode() == KeyCode.X) {
-            canvas.cutSelection();
+            canvas.elements().cutSelection();
             event.consume();
         } else if (event.isShortcutDown() && event.getCode() == KeyCode.V) {
-            canvas.pasteClipboard();
+            canvas.elements().pasteClipboard();
             event.consume();
         } else if (event.isShortcutDown()
                 && (event.getCode() == KeyCode.PLUS || event.getCode() == KeyCode.EQUALS
@@ -698,14 +698,14 @@ final class InputDispatcher {
                 case DIGIT9 -> { canvas.switchTool(CanvasToolBar.Tool.PLACE_COMMENT); event.consume(); }
                 case DIGIT0 -> { canvas.switchTool(CanvasToolBar.Tool.PLACE_INFO_LINK); event.consume(); }
                 case OPEN_BRACKET -> {
-                    if (canvas.isLoopHighlightActive()) {
-                        canvas.stepLoopBack();
+                    if (canvas.analysis().isLoopHighlightActive()) {
+                        canvas.analysis().stepLoopBack();
                         event.consume();
                     }
                 }
                 case CLOSE_BRACKET -> {
-                    if (canvas.isLoopHighlightActive()) {
-                        canvas.stepLoopForward();
+                    if (canvas.analysis().isLoopHighlightActive()) {
+                        canvas.analysis().stepLoopForward();
                         event.consume();
                     }
                 }
@@ -748,11 +748,11 @@ final class InputDispatcher {
 
         CanvasToolBar.Tool activeTool = canvas.getActiveTool();
         if (activeTool == CanvasToolBar.Tool.PLACE_FLOW) {
-            canvas.handleFlowClick(worldX, worldY);
+            canvas.elements().handleFlowClick(worldX, worldY);
         } else if (activeTool == CanvasToolBar.Tool.PLACE_CAUSAL_LINK) {
-            canvas.handleCausalLinkClick(worldX, worldY);
+            canvas.elements().handleCausalLinkClick(worldX, worldY);
         } else if (activeTool == CanvasToolBar.Tool.PLACE_INFO_LINK) {
-            canvas.handleInfoLinkClick(worldX, worldY);
+            canvas.elements().handleInfoLinkClick(worldX, worldY);
         }
         updateCursor(canvas);
     }
@@ -797,11 +797,11 @@ final class InputDispatcher {
     }
 
     private void handleEscape(ModelCanvas canvas) {
-        if (canvas.isTraceActive()) {
-            canvas.clearTrace();
+        if (canvas.analysis().isTraceActive()) {
+            canvas.analysis().clearTrace();
             canvas.requestRedraw();
         } else if (resizeController.isActive()) {
-            resizeController.cancel(canvas::performUndo);
+            resizeController.cancel(canvas.undo()::performUndo);
             canvas.requestRedraw();
         } else if (marqueeController.isActive()) {
             marqueeController.cancel(canvas.canvasState());
@@ -831,8 +831,8 @@ final class InputDispatcher {
             canvas.canvasState().clearSelection();
             canvas.requestRedraw();
             canvas.fireStatusChanged();
-        } else if (canvas.isInsideModule()) {
-            canvas.navigateBack();
+        } else if (canvas.navigation().isInsideModule()) {
+            canvas.navigation().navigateBack();
         }
         updateCursor(canvas);
     }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
@@ -2,42 +2,27 @@ package systems.courant.sd.app.canvas;
 
 import systems.courant.sd.model.def.ConnectorRoute;
 import systems.courant.sd.model.def.ElementType;
-import systems.courant.sd.model.def.ModelDefinition;
-import systems.courant.sd.model.def.ModelValidator;
-import systems.courant.sd.model.def.ModuleInstanceDef;
 import systems.courant.sd.model.def.ValidationIssue;
-import systems.courant.sd.model.def.ValidationIssue.Severity;
-import systems.courant.sd.model.def.ValidationResult;
 import systems.courant.sd.model.def.ViewDef;
-import systems.courant.sd.model.graph.AutoLayout;
-import systems.courant.sd.model.graph.CausalTraceAnalysis;
-import systems.courant.sd.model.graph.DependencyGraph;
-import systems.courant.sd.model.graph.FeedbackAnalysis;
 
 import javafx.application.Platform;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import systems.courant.sd.app.canvas.controllers.CanvasContextMenuController;
 import systems.courant.sd.app.canvas.controllers.CausalLinkCreationController;
-import systems.courant.sd.app.canvas.controllers.CausalTraceController;
 import systems.courant.sd.app.canvas.controllers.ConnectionRerouteController;
 import systems.courant.sd.app.canvas.controllers.CopyPasteController;
 import systems.courant.sd.app.canvas.controllers.DragController;
 import systems.courant.sd.app.canvas.controllers.FlowCreationController;
 import systems.courant.sd.app.canvas.controllers.InfoLinkCreationController;
 import systems.courant.sd.app.canvas.controllers.InlineEditController;
-import systems.courant.sd.app.canvas.controllers.LoopHighlightController;
 import systems.courant.sd.app.canvas.controllers.MarqueeController;
-import systems.courant.sd.app.canvas.controllers.ModuleNavigationController;
 import systems.courant.sd.app.canvas.controllers.ReattachController;
 import systems.courant.sd.app.canvas.controllers.ResizeController;
 import systems.courant.sd.app.canvas.controllers.SelectionController;
@@ -46,103 +31,83 @@ import systems.courant.sd.app.canvas.renderers.CanvasRenderer;
 
 /**
  * Canvas component that renders a model using the Layered Flow Diagram visual language.
- * Supports pan (Space+drag, middle/right drag), zoom (scroll wheel),
- * click-to-select, drag-to-move, element creation (toolbar placement mode),
- * two-click flow connection, inline name/value editing, and element deletion.
+ * Supports pan, zoom, click-to-select, drag-to-move, element creation, two-click flow
+ * connection, inline editing, and element deletion.
  *
- * <p>Delegates input handling to {@link InputDispatcher}, selection/mutation
- * operations to {@link SelectionController}, and tooltips to
- * {@link TooltipController}.
+ * <p>Delegates to extracted facades: {@link CanvasAnalysisFacade} (analysis),
+ * {@link CanvasNavigationFacade} (module navigation), {@link CanvasUndoFacade} (undo/redo),
+ * and {@link CanvasElementController} (element CRUD).
  */
 public class ModelCanvas extends Canvas {
 
-    private ModelEditor editor;
-    private List<ConnectorRoute> connectors = List.of();
+    // --- Mutable model state (package-private for facade access) ---
+    ModelEditor editor;
+    List<ConnectorRoute> connectors = List.of();
+    UndoManager undoManager;
+    CanvasToolBar.Tool activeTool = CanvasToolBar.Tool.SELECT;
+    CanvasToolBar toolBar;
 
-    // Resize redraw coalescing (#203)
+    // Coalescing flags
     private boolean resizeRedrawScheduled;
-
-    // Connector regeneration coalescing (#204)
     private boolean connectorRegenerationScheduled;
 
+    // Core canvas state
     private final Viewport viewport = new Viewport();
     private final CanvasState canvasState = new CanvasState();
     private final CanvasRenderer renderer = new CanvasRenderer(canvasState, viewport);
 
-    // Tool state
-    private CanvasToolBar.Tool activeTool = CanvasToolBar.Tool.SELECT;
-    private CanvasToolBar toolBar;
-
-    // Interaction controllers
+    // Interaction controllers (package-private for facade access)
     private final DragController dragController = new DragController();
     private final MarqueeController marqueeController = new MarqueeController();
     private final ResizeController resizeController = new ResizeController();
     private final ReattachController reattachController = new ReattachController();
-    private final FlowCreationController flowCreation = new FlowCreationController();
-    private final CausalLinkCreationController causalLinkCreation = new CausalLinkCreationController();
-    private final InfoLinkCreationController infoLinkCreation = new InfoLinkCreationController();
-    private final CopyPasteController copyPaste;
+    final FlowCreationController flowCreation = new FlowCreationController();
+    final CausalLinkCreationController causalLinkCreation = new CausalLinkCreationController();
+    final InfoLinkCreationController infoLinkCreation = new InfoLinkCreationController();
     private final ConnectionRerouteController rerouteController = new ConnectionRerouteController();
-    private final InlineEditController inlineEdit = new InlineEditController();
-    private final ModuleNavigationController navController = new ModuleNavigationController();
-
-    // Extracted controllers
-    private final SelectionController selectionController;
-    private final InputDispatcher inputDispatcher;
+    final InlineEditController inlineEdit = new InlineEditController();
+    final SelectionController selectionController;
+    final InputDispatcher inputDispatcher;
     private final TooltipController tooltipController = new TooltipController();
-    private final CanvasContextMenuController contextMenuController;
+    final CanvasContextMenuController contextMenuController;
 
-    // Undo/redo
-    private UndoManager undoManager;
-
-    // Status change callback
+    // Callbacks
     private Runnable onStatusChanged;
-    private Consumer<Set<String>> onPasteWarning;
+    Consumer<Set<String>> onPasteWarning;
 
-    // Connection selection
-    private ConnectionId selectedConnection;
-    private boolean selectedIsCausalLink;
+    // Connection selection (package-private for facade access)
+    ConnectionId selectedConnection;
+    boolean selectedIsCausalLink;
 
-    // Feedback loop highlighting
-    private final LoopHighlightController loopController = new LoopHighlightController();
-
-    // Causal tracing
-    private final CausalTraceController traceController = new CausalTraceController();
-
-    // Validation issue indicators (element name → highest severity)
-    private Map<String, Severity> elementIssues = Map.of();
-
-    // Full validation issues per element (for tooltips and dialog)
-    private Map<String, List<ValidationIssue>> elementIssueDetails = Map.of();
-
-    // Maturity analysis (missing equations, units, mismatches)
-    private MaturityAnalysis maturityAnalysis = MaturityAnalysis.EMPTY;
-
-    // Last validation result (for dialog access)
-    private ValidationResult lastValidationResult = new ValidationResult(List.of());
-
-    // Callback when validation counts change
-    private Consumer<ValidationResult> onValidationChanged;
+    // Extracted facades
+    private final CanvasAnalysisFacade analysis;
+    private final CanvasNavigationFacade navigation;
+    private final CanvasUndoFacade undoFacade;
+    private final CanvasElementController elements;
 
     // Sparkline data from last simulation run
     private CanvasRenderer.SparklineData sparklineData;
 
-    // View mode: hide variables
+    // View modes
     private boolean hideVariables;
-
-    // View mode: show delay indicator badges
     private boolean showDelayBadges;
-
-    // View mode: hide info links
     private boolean hideInfoLinks;
 
     // Unified callbacks for inline edit and context menu controllers
-    private final CanvasCallbacks callbacks = new CanvasCallbacks(this);
+    final CanvasCallbacks callbacks = new CanvasCallbacks(this);
 
     public ModelCanvas(Clipboard clipboard) {
-        this.copyPaste = new CopyPasteController(clipboard);
+        var copyPaste = new CopyPasteController(clipboard);
         this.selectionController = new SelectionController(copyPaste);
-        this.contextMenuController = new CanvasContextMenuController(navController);
+        this.navigation = new CanvasNavigationFacade(this);
+        this.contextMenuController = new CanvasContextMenuController(navigation.navController());
+        this.analysis = new CanvasAnalysisFacade(
+                canvasState,
+                () -> editor != null ? editor.toModelDefinition(canvasState.toViewDef()) : null,
+                this::redraw,
+                this::fireStatusChanged);
+        this.undoFacade = new CanvasUndoFacade(this);
+        this.elements = new CanvasElementController(this);
         this.inputDispatcher = new InputDispatcher(
                 dragController, marqueeController, resizeController,
                 reattachController, flowCreation, causalLinkCreation,
@@ -169,10 +134,6 @@ public class ModelCanvas extends Canvas {
         });
     }
 
-    /**
-     * Coalesces width/height resize events into a single redraw per frame (#203).
-     * When both dimensions change during a resize, only one redraw fires.
-     */
     private void scheduleResizeRedraw() {
         if (!resizeRedrawScheduled) {
             resizeRedrawScheduled = true;
@@ -183,9 +144,6 @@ public class ModelCanvas extends Canvas {
         }
     }
 
-    /**
-     * Returns whether a resize redraw is pending (visible for testing).
-     */
     public boolean isResizeRedrawScheduled() {
         return resizeRedrawScheduled;
     }
@@ -209,33 +167,26 @@ public class ModelCanvas extends Canvas {
         return editor;
     }
 
-    /**
-     * Returns whether a model has been loaded into this canvas.
-     */
     public boolean isModelLoaded() {
         return editor != null;
     }
 
-    public ModelDefinition toModelDefinition() {
-        if (editor == null) {
-            throw new IllegalStateException("No model loaded");
-        }
-        if (!navController.isInsideModule()) {
-            return editor.toModelDefinition(canvasState.toViewDef());
-        }
+    // --- Facade accessors ---
 
-        ModelDefinition childDef = editor.toModelDefinition(canvasState.toViewDef());
+    public CanvasAnalysisFacade analysis() {
+        return analysis;
+    }
 
-        List<NavigationStack.Frame> frames = new ArrayList<>(navController.frames());
-        for (int i = frames.size() - 1; i >= 0; i--) {
-            NavigationStack.Frame frame = frames.get(i);
-            ModelEditor parentEditor = new ModelEditor();
-            parentEditor.loadFrom(frame.editor().toModelDefinition(frame.viewSnapshot()));
-            parentEditor.updateModuleDefinition(frame.moduleIndex(), childDef);
-            childDef = parentEditor.toModelDefinition(frame.viewSnapshot());
-        }
+    public CanvasNavigationFacade navigation() {
+        return navigation;
+    }
 
-        return childDef;
+    public CanvasUndoFacade undo() {
+        return undoFacade;
+    }
+
+    public CanvasElementController elements() {
+        return elements;
     }
 
     // --- Callbacks ---
@@ -248,100 +199,29 @@ public class ModelCanvas extends Canvas {
         this.onPasteWarning = callback;
     }
 
-    public void setOnValidationChanged(Consumer<ValidationResult> callback) {
-        this.onValidationChanged = callback;
-    }
-
-    /**
-     * Returns the most recent validation result from live validation.
-     */
-    public ValidationResult getLastValidationResult() {
-        return lastValidationResult;
-    }
-
-    /**
-     * Returns the validation issues for a specific element, or an empty list.
-     */
-    public List<ValidationIssue> getValidationIssues(String elementName) {
-        return elementIssueDetails.getOrDefault(elementName, List.of());
-    }
-
     void fireStatusChanged() {
         if (onStatusChanged != null) {
             onStatusChanged.run();
         }
     }
 
-    // --- Loop analysis (delegated to LoopHighlightController) ---
+    // --- Undo forwarders (used by CanvasCallbacks / InputDispatcher) ---
 
-    public void setLoopHighlightActive(boolean active) {
-        loopController.setActive(active,
-                () -> editor != null ? editor.toModelDefinition(canvasState.toViewDef()) : null);
-        redraw();
+    void saveUndoState(String label) {
+        undoFacade.saveUndoState(label);
     }
 
-    public boolean isLoopHighlightActive() {
-        return loopController.isActive();
-    }
-
-    public FeedbackAnalysis getLoopAnalysis() {
-        return loopController.getAnalysis();
-    }
-
-    public int getActiveLoopIndex() {
-        return loopController.getActiveIndex();
-    }
-
-    public void setActiveLoopIndex(int index) {
-        if (loopController.setActiveIndex(index)) {
-            redraw();
-            fireStatusChanged();
-        }
-    }
-
-    public void stepLoopForward() {
-        if (loopController.stepForward()) {
-            redraw();
-            fireStatusChanged();
-        }
-    }
-
-    public void stepLoopBack() {
-        if (loopController.stepBack()) {
-            redraw();
-            fireStatusChanged();
-        }
-    }
-
-    public FeedbackAnalysis.LoopType getLoopTypeFilter() {
-        return loopController.getTypeFilter();
-    }
-
-    public void setLoopTypeFilter(FeedbackAnalysis.LoopType filter) {
-        if (loopController.setTypeFilter(filter)) {
-            redraw();
-            fireStatusChanged();
-        }
-    }
-
-    public int getFilteredLoopCount() {
-        return loopController.filteredLoopCount();
+    void saveUndoStateTentative(String label) {
+        undoFacade.saveUndoStateTentative(label);
     }
 
     // --- Sparklines ---
 
-    /**
-     * Sets the sparkline data extracted from a simulation result.
-     * Called by the simulation controller after a successful run.
-     */
     public void setSparklineData(CanvasRenderer.SparklineData data) {
         this.sparklineData = data;
         redraw();
     }
 
-    /**
-     * Marks sparkline data as stale (model changed since last simulation).
-     */
     public void markSparklinesStale() {
         if (sparklineData != null && !sparklineData.stale()) {
             sparklineData = new CanvasRenderer.SparklineData(
@@ -350,16 +230,10 @@ public class ModelCanvas extends Canvas {
         }
     }
 
-    /**
-     * Clears sparkline data (e.g. when loading a new model).
-     */
     public void clearSparklines() {
         sparklineData = null;
     }
 
-    /**
-     * Extracts stock time series from a simulation result into a sparkline-ready map.
-     */
     public static Map<String, double[]> extractStockSeries(
             SimulationRunner.SimulationResult result) {
         List<String> columns = result.columnNames();
@@ -368,10 +242,6 @@ public class ModelCanvas extends Canvas {
 
         for (int col = 1; col < columns.size(); col++) {
             String name = columns.get(col);
-            // Only extract stocks — they come first after "Step" in the column order.
-            // We check by seeing if the unit map contains the name (all stocks are in units).
-            // But simpler: just extract all columns; the renderer only draws for elements
-            // that exist in canvasState with STOCK type (checked externally).
             double[] values = new double[rows.size()];
             for (int row = 0; row < rows.size(); row++) {
                 values[row] = rows.get(row)[col];
@@ -381,7 +251,7 @@ public class ModelCanvas extends Canvas {
         return series;
     }
 
-    // --- Hide variables view mode ---
+    // --- View modes ---
 
     public boolean isHideVariables() {
         return hideVariables;
@@ -394,8 +264,6 @@ public class ModelCanvas extends Canvas {
         }
     }
 
-    // --- Show delay badges view mode ---
-
     public boolean isShowDelayBadges() {
         return showDelayBadges;
     }
@@ -406,8 +274,6 @@ public class ModelCanvas extends Canvas {
             redraw();
         }
     }
-
-    // --- Hide info links view mode ---
 
     public boolean isHideInfoLinks() {
         return hideInfoLinks;
@@ -420,140 +286,11 @@ public class ModelCanvas extends Canvas {
         }
     }
 
-    private void invalidateLoopAnalysis(ModelDefinition def) {
-        loopController.invalidate(def);
+    void invalidateAnalysis() {
+        analysis.invalidate();
     }
 
-    // --- Validation indicators ---
-
-    /**
-     * Recomputes validation issues for all elements in the model.
-     * Called from {@link #invalidateAnalysis()} on every structural mutation.
-     */
-    private void recomputeValidation(ModelDefinition def) {
-        if (def == null) {
-            elementIssues = Map.of();
-            elementIssueDetails = Map.of();
-            lastValidationResult = new ValidationResult(List.of());
-            maturityAnalysis = MaturityAnalysis.EMPTY;
-            return;
-        }
-        ValidationResult result = ModelValidator.validate(def);
-        Map<String, Severity> issues = new LinkedHashMap<>();
-        Map<String, List<ValidationIssue>> details = new LinkedHashMap<>();
-        for (ValidationIssue issue : result.issues()) {
-            if (issue.elementName() != null) {
-                issues.merge(issue.elementName(), issue.severity(),
-                        (existing, incoming) ->
-                                existing == Severity.ERROR ? existing : incoming);
-                details.computeIfAbsent(issue.elementName(), k -> new ArrayList<>()).add(issue);
-            }
-        }
-        elementIssues = issues;
-        elementIssueDetails = details;
-        lastValidationResult = result;
-        maturityAnalysis = MaturityAnalysis.analyze(def);
-        if (onValidationChanged != null) {
-            onValidationChanged.accept(result);
-        }
-    }
-
-    /**
-     * Invalidates all cached analysis (loop highlighting, causal trace, validation indicators).
-     * Must be called after any structural model mutation.
-     */
-    private void invalidateAnalysis() {
-        ModelDefinition def = editor != null ? editor.toModelDefinition(canvasState.toViewDef()) : null;
-        invalidateLoopAnalysis(def);
-        traceController.invalidate(def);
-        recomputeValidation(def);
-    }
-
-    // --- Undo/redo ---
-
-    public void setUndoManager(UndoManager undoManager) {
-        this.undoManager = undoManager;
-    }
-
-    public UndoManager getUndoManager() {
-        return undoManager;
-    }
-
-    private UndoManager.Snapshot captureSnapshot() {
-        return new UndoManager.Snapshot(
-                editor.toModelDefinition(canvasState.toViewDef()),
-                canvasState.toViewDef());
-    }
-
-    public void saveUndoState(String label) {
-        if (undoManager != null && editor != null) {
-            undoManager.pushUndo(captureSnapshot(), label);
-        }
-    }
-
-    /**
-     * Saves undo state tentatively without clearing the redo stack.
-     * Call {@link UndoManager#confirmLastUndo()} on success or
-     * {@link UndoManager#discardLastUndo()} on failure.
-     */
-    public void saveUndoStateTentative(String label) {
-        if (undoManager != null && editor != null) {
-            undoManager.pushUndoTentative(captureSnapshot(), label);
-        }
-    }
-
-    private void pushUndoSnapshot(UndoManager.Snapshot snapshot, String label) {
-        if (undoManager != null) {
-            undoManager.pushUndo(snapshot, label);
-        }
-    }
-
-    /**
-     * Returns a short description of the current selection for undo labels.
-     * Single element: its name. Multiple: "N elements". Empty: "elements".
-     */
-    private String describeSelection() {
-        Set<String> sel = canvasState.getSelection();
-        if (sel.isEmpty()) {
-            return "elements";
-        }
-        if (sel.size() == 1) {
-            return sel.iterator().next();
-        }
-        return sel.size() + " elements";
-    }
-
-    private void restoreSnapshot(UndoManager.Snapshot snapshot) {
-        editor.loadFrom(snapshot.model());
-        canvasState.loadFrom(snapshot.view());
-        connectors = editor.generateConnectors();
-        invalidateAnalysis();
-        redraw();
-        fireStatusChanged();
-    }
-
-    public void performUndo() {
-        if (undoManager == null || editor == null) {
-            return;
-        }
-        undoManager.undo(captureSnapshot()).ifPresent(this::restoreSnapshot);
-    }
-
-    public void performRedo() {
-        if (undoManager == null || editor == null) {
-            return;
-        }
-        undoManager.redo(captureSnapshot()).ifPresent(this::restoreSnapshot);
-    }
-
-    public void performUndoTo(int depth) {
-        if (undoManager == null || editor == null) {
-            return;
-        }
-        undoManager.undoTo(captureSnapshot(), depth).ifPresent(this::restoreSnapshot);
-    }
-
-    // --- Selection state (public API) ---
+    // --- Selection state (read-only) ---
 
     public int getSelectionCount() {
         return canvasState.getSelection().size();
@@ -575,82 +312,7 @@ public class ModelCanvas extends Canvas {
         return canvasState.getType(name).orElse(null);
     }
 
-    // --- Selection operations (public API, delegate to SelectionController) ---
-
-    public void deleteSelectedElements() {
-        if (editor == null) {
-            return;
-        }
-        selectionController.deleteSelected(editor, canvasState,
-                () -> saveUndoState("Delete " + describeSelection()));
-        regenerateConnectors();
-        redraw();
-        fireStatusChanged();
-        inputDispatcher.updateCursor(this);
-    }
-
-    public void renameElement(String oldName, String newName) {
-        applyRename(oldName, newName);
-    }
-
-    public void triggerBindingConfig(String moduleName) {
-        openBindingsDialogInternal(moduleName);
-    }
-
-    public void selectAll() {
-        canvasState.selectAll();
-        redraw();
-        fireStatusChanged();
-    }
-
-    public void selectElement(String name) {
-        selectionController.selectAndCenter(name, canvasState, viewport, getWidth(), getHeight());
-        fireStatusChanged();
-        redraw();
-    }
-
-    public void copySelection() {
-        if (editor == null) {
-            return;
-        }
-        selectionController.copy(editor, canvasState);
-    }
-
-    public void cutSelection() {
-        if (editor == null) {
-            return;
-        }
-        selectionController.cut(editor, canvasState,
-                () -> saveUndoState("Cut " + describeSelection()));
-        regenerateConnectors();
-        redraw();
-        fireStatusChanged();
-        inputDispatcher.updateCursor(this);
-    }
-
-    public Set<String> pasteClipboard() {
-        if (editor == null) {
-            return Set.of();
-        }
-        double centerWorldX = viewport.toWorldX(getWidth() / 2.0);
-        double centerWorldY = viewport.toWorldY(getHeight() / 2.0);
-        var viewportCenter = new CanvasState.Position(centerWorldX, centerWorldY);
-        Set<String> replaced = selectionController.paste(
-                editor, canvasState, () -> saveUndoState("Paste elements"),
-                viewportCenter);
-        if (replaced == null) {
-            return Set.of();
-        }
-        regenerateConnectors();
-        redraw();
-        fireStatusChanged();
-        if (!replaced.isEmpty() && onPasteWarning != null) {
-            onPasteWarning.accept(replaced);
-        }
-        return replaced;
-    }
-
-    // --- Package-private methods for InputDispatcher ---
+    // --- Canvas state accessors ---
 
     public CanvasState canvasState() {
         return canvasState;
@@ -668,6 +330,16 @@ public class ModelCanvas extends Canvas {
         return connectors;
     }
 
+    public CanvasState getCanvasState() {
+        return canvasState;
+    }
+
+    public double getZoomScale() {
+        return viewport.getScale();
+    }
+
+    // --- Connector management ---
+
     public void requestRedraw() {
         redraw();
     }
@@ -680,10 +352,6 @@ public class ModelCanvas extends Canvas {
         invalidateAnalysis();
     }
 
-    /**
-     * Schedules connector regeneration to coalesce rapid-fire model mutations (#204).
-     * Multiple calls within the same frame result in a single regeneration + redraw.
-     */
     public void scheduleRegenerateConnectors() {
         if (!connectorRegenerationScheduled) {
             connectorRegenerationScheduled = true;
@@ -696,12 +364,26 @@ public class ModelCanvas extends Canvas {
         }
     }
 
-    /**
-     * Returns whether a connector regeneration is pending (visible for testing).
-     */
     public boolean isConnectorRegenerationScheduled() {
         return connectorRegenerationScheduled;
     }
+
+    void regenerateAndRedraw() {
+        if (editor == null) {
+            return;
+        }
+        connectors = editor.generateConnectors();
+        invalidateAnalysis();
+        redraw();
+        fireStatusChanged();
+    }
+
+    public void applyMutation(Runnable mutation) {
+        mutation.run();
+        regenerateAndRedraw();
+    }
+
+    // --- Connection selection ---
 
     public void setSelectedConnection(ConnectionId connection, boolean isCausal) {
         this.selectedConnection = connection;
@@ -713,103 +395,11 @@ public class ModelCanvas extends Canvas {
         this.selectedIsCausalLink = false;
     }
 
-    public void deleteSelectedOrConnection() {
-        if (editor == null) {
-            return;
-        }
-        if (selectedConnection != null && canvasState.getSelection().isEmpty()) {
-            if (selectionController.deleteConnection(
-                    selectedConnection, selectedIsCausalLink, editor,
-                    () -> saveUndoState("Delete " + selectedConnection.from()
-                            + " \u2192 " + selectedConnection.to() + " connection"))) {
-                if (!selectedIsCausalLink) {
-                    connectors = editor.generateConnectors();
-                }
-                clearSelectedConnection();
-                invalidateAnalysis();
-                redraw();
-                fireStatusChanged();
-                inputDispatcher.updateCursor(this);
-            }
-        } else {
-            deleteSelectedElements();
-        }
-    }
-
-    public void handleFlowClick(double worldX, double worldY) {
-        if (editor == null) {
-            return;
-        }
-        var snapshot = captureSnapshot();
-        FlowCreationController.FlowResult result = flowCreation.handleClick(
-                worldX, worldY, canvasState, editor);
-        if (result.isCreated()) {
-            pushUndoSnapshot(snapshot, "Add flow");
-            regenerateConnectors();
-            canvasState.clearSelection();
-            canvasState.select(result.flowName());
-        }
-        redraw();
-        fireStatusChanged();
-    }
-
-    public void handleCausalLinkClick(double worldX, double worldY) {
-        if (editor == null) {
-            return;
-        }
-        var snapshot = captureSnapshot();
-        CausalLinkCreationController.LinkResult result = causalLinkCreation.handleClick(
-                worldX, worldY, canvasState, editor);
-        if (result.isCreated()) {
-            pushUndoSnapshot(snapshot, "Add causal link");
-            regenerateConnectors();
-        }
-        redraw();
-        fireStatusChanged();
-    }
-
-    public void handleInfoLinkClick(double worldX, double worldY) {
-        if (editor == null) {
-            return;
-        }
-        var snapshot = captureSnapshot();
-        InfoLinkCreationController.LinkResult result = infoLinkCreation.handleClick(
-                worldX, worldY, canvasState, editor);
-        if (result.isCreated()) {
-            pushUndoSnapshot(snapshot, "Bind module port");
-            regenerateConnectors();
-        }
-        redraw();
-        fireStatusChanged();
-    }
-
-    public void createElementAt(double worldX, double worldY) {
-        if (editor == null) {
-            return;
-        }
-        String name = selectionController.createElementAt(
-                worldX, worldY, activeTool, editor, canvasState,
-                () -> saveUndoState("Add " + activeTool.label()));
-        if (name != null) {
-            regenerateConnectors();
-            redraw();
-            fireStatusChanged();
-            if (activeTool == CanvasToolBar.Tool.PLACE_COMMENT) {
-                startInlineEdit(name);
-            }
-        }
-    }
-
-    public void startInlineEdit(String elementName) {
-        if (editor == null) {
-            return;
-        }
-        inlineEdit.startEdit(elementName, canvasState, editor, viewport, callbacks);
-    }
+    // --- Tooltip ---
 
     public void updateTooltip(String elementName, MouseEvent event) {
         List<ValidationIssue> issues = elementName != null
-                ? elementIssueDetails.getOrDefault(elementName, List.of())
+                ? analysis.getValidationIssues(elementName)
                 : List.of();
         tooltipController.update(elementName, event, this, canvasState, editor, issues);
     }
@@ -818,13 +408,7 @@ public class ModelCanvas extends Canvas {
         tooltipController.updateCloud(cloudHit, event, this);
     }
 
-    public void resetToolToSelect() {
-        if (toolBar != null) {
-            toolBar.resetToSelect();
-        } else {
-            activeTool = CanvasToolBar.Tool.SELECT;
-        }
-    }
+    // --- Zoom ---
 
     public void zoomIn() {
         viewport.zoomAt(getWidth() / 2, getHeight() / 2, Viewport.ZOOM_FACTOR);
@@ -847,10 +431,6 @@ public class ModelCanvas extends Canvas {
         fireStatusChanged();
     }
 
-    /**
-     * Zooms and pans so that all model elements fit within the visible canvas
-     * with a small margin. Does not zoom beyond 1.0 (100%) for small models.
-     */
     public void zoomToFit() {
         if (editor == null || canvasState.getDrawOrder().isEmpty()) {
             resetZoom();
@@ -866,7 +446,7 @@ public class ModelCanvas extends Canvas {
         }
 
         double fitScale = Math.min(canvasW / bounds.width(), canvasH / bounds.height());
-        fitScale = Math.min(fitScale, 1.0); // don't magnify beyond 100%
+        fitScale = Math.min(fitScale, 1.0);
 
         double worldCenterX = bounds.minX() + bounds.width() / 2;
         double worldCenterY = bounds.minY() + bounds.height() / 2;
@@ -878,47 +458,6 @@ public class ModelCanvas extends Canvas {
         redraw();
         inputDispatcher.updateCursor(this);
         fireStatusChanged();
-    }
-
-    // --- Rendering ---
-
-    void regenerateAndRedraw() {
-        if (editor == null) {
-            return;
-        }
-        connectors = editor.generateConnectors();
-        invalidateAnalysis();
-        redraw();
-        fireStatusChanged();
-    }
-
-    public void applyMutation(Runnable mutation) {
-        mutation.run();
-        regenerateAndRedraw(); // includes recomputeValidation()
-    }
-
-    private CanvasRenderer.RerouteState rerouteRenderState() {
-        if (!rerouteController.isActive()) {
-            return CanvasRenderer.RerouteState.IDLE;
-        }
-        return new CanvasRenderer.RerouteState(
-                true,
-                rerouteController.getAnchorX(),
-                rerouteController.getAnchorY(),
-                rerouteController.getRubberBandX(),
-                rerouteController.getRubberBandY());
-    }
-
-    public CanvasState getCanvasState() {
-        return canvasState;
-    }
-
-    public FeedbackAnalysis getActiveLoopAnalysis() {
-        return loopController.getActiveAnalysis();
-    }
-
-    public double getZoomScale() {
-        return viewport.getScale();
     }
 
     // --- Tool state ---
@@ -954,6 +493,16 @@ public class ModelCanvas extends Canvas {
         fireStatusChanged();
     }
 
+    public void resetToolToSelect() {
+        if (toolBar != null) {
+            toolBar.resetToSelect();
+        } else {
+            activeTool = CanvasToolBar.Tool.SELECT;
+        }
+    }
+
+    // --- Canvas overrides ---
+
     @Override
     public boolean isResizable() {
         return true;
@@ -980,9 +529,9 @@ public class ModelCanvas extends Canvas {
                         reattachController.toRenderState(),
                         rerouteRenderState(),
                         marqueeController.toRenderState(),
-                        getActiveLoopAnalysis(),
-                        traceController.getAnalysis(),
-                        elementIssues,
+                        analysis.getActiveLoopAnalysis(),
+                        analysis.getTraceAnalysis(),
+                        analysis.elementIssues(),
                         sparklineData,
                         inputDispatcher.getHoveredElement(),
                         inputDispatcher.getHoveredConnection(),
@@ -990,329 +539,22 @@ public class ModelCanvas extends Canvas {
                         hideVariables,
                         showDelayBadges,
                         hideInfoLinks,
-                        maturityAnalysis));
+                        analysis.maturityAnalysis()));
     }
 
-    // --- Rename ---
-
-    void applyRename(String oldName, String newName) {
-        if (editor == null) {
-            return;
+    private CanvasRenderer.RerouteState rerouteRenderState() {
+        if (!rerouteController.isActive()) {
+            return CanvasRenderer.RerouteState.IDLE;
         }
-        if (selectionController.applyRename(oldName, newName, editor, canvasState,
-                () -> saveUndoState("Rename " + oldName + " \u2192 " + newName))) {
-            regenerateAndRedraw();
-        }
+        return new CanvasRenderer.RerouteState(
+                true,
+                rerouteController.getAnchorX(),
+                rerouteController.getAnchorY(),
+                rerouteController.getRubberBandX(),
+                rerouteController.getRubberBandY());
     }
-
-    // --- Module navigation ---
-
-    public void setOnNavigationChanged(Runnable callback) {
-        navController.setOnNavigationChanged(callback);
-    }
-
-    public void drillInto(String moduleName) {
-        if (editor == null) {
-            return;
-        }
-        Optional<ModuleInstanceDef> moduleOpt = editor.getModuleByName(moduleName);
-        if (moduleOpt.isEmpty()) {
-            return;
-        }
-        ModuleInstanceDef module = moduleOpt.get();
-        int moduleIndex = editor.getModuleIndex(moduleName);
-
-        navController.push(new NavigationStack.Frame(
-                moduleName, moduleIndex, editor, canvasState.toViewDef(),
-                viewport.getTranslateX(), viewport.getTranslateY(),
-                viewport.getScale(), undoManager, activeTool));
-
-        ModelEditor moduleEditor = new ModelEditor();
-        moduleEditor.loadFrom(module.definition());
-
-        ViewDef moduleView;
-        if (!module.definition().views().isEmpty()) {
-            moduleView = module.definition().views().getFirst();
-        } else {
-            var sizeOverrides = LayoutMetrics.computeSizeOverrides(module.definition());
-            moduleView = AutoLayout.layout(module.definition(), sizeOverrides);
-        }
-
-        this.editor = moduleEditor;
-        this.undoManager = new UndoManager();
-        setModel(editor, moduleView);
-        viewport.reset();
-
-        if (toolBar != null) {
-            toolBar.resetToSelect();
-        } else {
-            activeTool = CanvasToolBar.Tool.SELECT;
-        }
-
-        navController.fireNavigationChanged();
-        fireStatusChanged();
-    }
-
-    public void navigateBack() {
-        if (!navController.isInsideModule() || editor == null) {
-            return;
-        }
-
-        popNavigationLevel(true);
-
-        connectors = editor.generateConnectors();
-        invalidateAnalysis();
-        redraw();
-
-        navController.fireNavigationChanged();
-        fireStatusChanged();
-    }
-
-    public void navigateToDepth(int targetDepth) {
-        int levelsToNavigate = navController.depth() - targetDepth;
-        if (levelsToNavigate <= 0 || editor == null) {
-            return;
-        }
-
-        if (levelsToNavigate == 1) {
-            navigateBack();
-            return;
-        }
-
-        // Navigate multiple levels: push a single undo state at the target level
-        // rather than one per level.
-        popNavigationLevel(false);
-        for (int i = 1; i < levelsToNavigate; i++) {
-            popNavigationLevel(i == levelsToNavigate - 1);
-        }
-
-        connectors = editor.generateConnectors();
-        invalidateAnalysis();
-        redraw();
-
-        navController.fireNavigationChanged();
-        fireStatusChanged();
-    }
-
-    /**
-     * Pops one navigation level: restores the parent editor and undo manager,
-     * merges the child module definition back into the parent, and restores
-     * the canvas/viewport/tool state.
-     *
-     * @param saveUndo if true, pushes an undo state on the restored parent's
-     *                 undo manager before applying the child module update
-     */
-    private void popNavigationLevel(boolean saveUndo) {
-        ModelDefinition childDef = editor.toModelDefinition(canvasState.toViewDef());
-        NavigationStack.Frame frame = navController.pop();
-
-        this.undoManager.close();
-        this.editor = frame.editor();
-        this.undoManager = frame.undoManager();
-
-        if (saveUndo) {
-            saveUndoState("Edit module " + frame.moduleName());
-        }
-        editor.updateModuleDefinition(frame.moduleIndex(), childDef);
-
-        canvasState.loadFrom(frame.viewSnapshot());
-        viewport.restoreState(frame.viewportTranslateX(),
-                frame.viewportTranslateY(), frame.viewportScale());
-
-        if (toolBar != null) {
-            toolBar.selectTool(frame.activeTool());
-        } else {
-            activeTool = frame.activeTool();
-        }
-    }
-
-    public boolean isInsideModule() {
-        return navController.isInsideModule();
-    }
-
-    public List<String> getNavigationPath() {
-        String rootName = navController.isInsideModule()
-                ? navController.frames().getFirst().editor().getModelName()
-                : editor.getModelName();
-        return navController.getPath(rootName);
-    }
-
-    public String getCurrentModuleName() {
-        return navController.getCurrentModuleName();
-    }
-
-    public void clearNavigation() {
-        if (navController.isInsideModule()) {
-            // Close the current module-level UndoManager
-            this.undoManager.close();
-            // Restore the root UndoManager and close all intermediate ones
-            List<NavigationStack.Frame> frames = navController.frames();
-            this.undoManager = frames.getFirst().undoManager();
-            for (int i = 1; i < frames.size(); i++) {
-                frames.get(i).undoManager().close();
-            }
-        }
-        navController.clear();
-    }
-
-    // --- Context menus (delegated to CanvasContextMenuController) ---
-
-    public void showElementContextMenu(String elementName, double screenX, double screenY) {
-        contextMenuController.showElementContextMenu(
-                this, elementName, canvasState, screenX, screenY, callbacks);
-    }
-
-    public void showGeneralElementContextMenu(String elementName,
-                                       double screenX, double screenY) {
-        contextMenuController.showGeneralElementContextMenu(
-                this, elementName, canvasState, screenX, screenY, callbacks);
-    }
-
-    public void showCausalLinkContextMenu(ConnectionId link,
-                                   double screenX, double screenY) {
-        if (editor == null) {
-            return;
-        }
-        contextMenuController.showCausalLinkContextMenu(
-                this, link, editor, screenX, screenY, callbacks);
-    }
-
-    public void showInfoLinkContextMenu(ConnectionId link,
-                                 double screenX, double screenY) {
-        contextMenuController.showInfoLinkContextMenu(
-                this, link, screenX, screenY, callbacks);
-    }
-
-    public void showCanvasContextMenu(double worldX, double worldY,
-                               double screenX, double screenY) {
-        contextMenuController.showCanvasContextMenu(
-                this, worldX, worldY, screenX, screenY, callbacks);
-    }
-
-    void classifyCldVariableInternal(String name, ElementType targetType) {
-        if (editor == null) {
-            return;
-        }
-        if (selectionController.classifyCldVariable(name, targetType, editor, canvasState,
-                () -> saveUndoState("Classify " + name + " as " + targetType.name().toLowerCase()))) {
-            regenerateAndRedraw();
-            fireStatusChanged();
-        }
-    }
-
-    void openDefinePortsDialogInternal(String moduleName) {
-        if (editor == null) {
-            return;
-        }
-        navController.openDefinePortsDialog(moduleName, editor,
-                () -> saveUndoState("Define " + moduleName + " ports"), this::fireStatusChanged);
-    }
-
-    void openBindingsDialogInternal(String moduleName) {
-        if (editor == null) {
-            return;
-        }
-        navController.openBindingsDialog(moduleName, editor,
-                () -> saveUndoState("Edit " + moduleName + " bindings"), this::fireStatusChanged);
-    }
-
-    // --- Causal tracing ---
-
-    public void traceUpstream(String elementName) {
-        if (editor == null) {
-            return;
-        }
-        traceController.startTrace(elementName,
-                CausalTraceAnalysis.TraceDirection.UPSTREAM,
-                editor.toModelDefinition(canvasState.toViewDef()));
-        redraw();
-    }
-
-    public void traceDownstream(String elementName) {
-        if (editor == null) {
-            return;
-        }
-        traceController.startTrace(elementName,
-                CausalTraceAnalysis.TraceDirection.DOWNSTREAM,
-                editor.toModelDefinition(canvasState.toViewDef()));
-        redraw();
-    }
-
-    public boolean isTraceActive() {
-        return traceController.isActive();
-    }
-
-    public void clearTrace() {
-        traceController.clearTrace();
-    }
-
-    /**
-     * Returns the set of elements whose equations reference the named element
-     * (direct dependents — "where used").
-     */
-    public Set<String> whereUsed(String elementName) {
-        if (editor == null) {
-            return Set.of();
-        }
-        DependencyGraph graph = DependencyGraph.fromDefinition(
-                editor.toModelDefinition(canvasState.toViewDef()));
-        return graph.dependentsOf(elementName);
-    }
-
-    /**
-     * Returns the set of elements that the named element's equation references
-     * (direct dependencies — "uses").
-     */
-    public Set<String> uses(String elementName) {
-        if (editor == null) {
-            return Set.of();
-        }
-        DependencyGraph graph = DependencyGraph.fromDefinition(
-                editor.toModelDefinition(canvasState.toViewDef()));
-        return graph.dependenciesOf(elementName);
-    }
-
-    public void showWhereUsed(String elementName) {
-        Set<String> dependents = whereUsed(elementName);
-        canvasState.clearSelection();
-        dependents.forEach(canvasState::addToSelection);
-        fireStatusChanged();
-        redraw();
-    }
-
-    public void showUses(String elementName) {
-        Set<String> dependencies = uses(elementName);
-        canvasState.clearSelection();
-        dependencies.forEach(canvasState::addToSelection);
-        fireStatusChanged();
-        redraw();
-    }
-
-    // --- Package-private helpers for CanvasCallbacks ---
 
     void updateCursorViaDispatcher() {
         inputDispatcher.updateCursor(this);
-    }
-
-    String createElementAtForCallback(double wx, double wy, CanvasToolBar.Tool tool) {
-        String name = selectionController.createElementAt(
-                wx, wy, tool, editor, canvasState,
-                () -> saveUndoState("Add " + tool.label()));
-        if (name != null) {
-            regenerateConnectors();
-            redraw();
-            fireStatusChanged();
-        }
-        return name;
-    }
-
-    boolean deleteConnectionForCallback(ConnectionId conn, boolean isCausal) {
-        return selectionController.deleteConnection(conn, isCausal, editor,
-                () -> saveUndoState(
-                        "Delete " + conn.from() + " \u2192 " + conn.to() + " connection"));
-    }
-
-    boolean canPasteForCallback() {
-        return selectionController.canPaste();
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/PropertiesPanel.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/PropertiesPanel.java
@@ -321,7 +321,7 @@ public class PropertiesPanel extends VBox {
         Button deleteBtn = createToolbarButton("Delete");
         deleteBtn.setOnAction(e -> {
             if (ctx.getCanvas() != null) {
-                ctx.getCanvas().deleteSelectedElements();
+                ctx.getCanvas().elements().deleteSelectedElements();
                 ctx.getCanvas().requestFocus();
             }
         });
@@ -458,7 +458,7 @@ public class PropertiesPanel extends VBox {
         deleteBtn.setId("propertiesDelete");
         deleteBtn.setOnAction(e -> {
             if (ctx.getCanvas() != null) {
-                ctx.getCanvas().deleteSelectedElements();
+                ctx.getCanvas().elements().deleteSelectedElements();
                 ctx.getCanvas().requestFocus();
             }
         });
@@ -470,7 +470,7 @@ public class PropertiesPanel extends VBox {
             drillBtn.setId("propertiesDrill");
             drillBtn.setOnAction(e -> {
                 if (ctx.getCanvas() != null) {
-                    ctx.getCanvas().drillInto(ctx.getElementName());
+                    ctx.getCanvas().navigation().drillInto(ctx.getElementName());
                     ctx.getCanvas().requestFocus();
                 }
             });
@@ -479,7 +479,7 @@ public class PropertiesPanel extends VBox {
             bindingsBtn.setId("propertiesBindings");
             bindingsBtn.setOnAction(e -> {
                 if (ctx.getCanvas() != null) {
-                    ctx.getCanvas().triggerBindingConfig(ctx.getElementName());
+                    ctx.getCanvas().elements().triggerBindingConfig(ctx.getElementName());
                     ctx.getCanvas().requestFocus();
                 }
             });
@@ -570,8 +570,8 @@ public class PropertiesPanel extends VBox {
     }
 
     private int buildDependencySection(int row, String elementName) {
-        Set<String> usedBy = ctx.getCanvas().whereUsed(elementName);
-        Set<String> uses = ctx.getCanvas().uses(elementName);
+        Set<String> usedBy = ctx.getCanvas().analysis().whereUsed(elementName);
+        Set<String> uses = ctx.getCanvas().analysis().uses(elementName);
 
         if (!usedBy.isEmpty()) {
             Label label = new Label("Used by");
@@ -607,7 +607,7 @@ public class PropertiesPanel extends VBox {
             link.setPadding(new Insets(0, 2, 0, 0));
             link.setOnAction(e -> {
                 if (ctx.getCanvas() != null) {
-                    ctx.getCanvas().selectElement(name);
+                    ctx.getCanvas().elements().selectElement(name);
                 }
             });
             pane.getChildren().add(link);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormContext.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormContext.java
@@ -515,7 +515,7 @@ public class FormContext {
             nameField.setText(oldName);
             return;
         }
-        canvas.renameElement(oldName, newName);
+        canvas.elements().renameElement(oldName, newName);
         elementName = newName;
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/ModelWindowImportExportFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/ModelWindowImportExportFxTest.java
@@ -150,7 +150,7 @@ class ModelWindowImportExportFxTest {
         WaitForAsyncUtils.waitForFxEvents();
         awaitLayout();
 
-        ModelDefinition canvasDef = window.getCanvas().toModelDefinition();
+        ModelDefinition canvasDef = window.getCanvas().navigation().toModelDefinition();
         Path mdlFile = tempDir.resolve("teacup-export.mdl");
         VensimExporter.toFile(canvasDef, mdlFile);
         assertThat(Files.exists(mdlFile)).isTrue();
@@ -172,7 +172,7 @@ class ModelWindowImportExportFxTest {
         WaitForAsyncUtils.waitForFxEvents();
         awaitLayout();
 
-        ModelDefinition canvasDef = window.getCanvas().toModelDefinition();
+        ModelDefinition canvasDef = window.getCanvas().navigation().toModelDefinition();
         Path xmileFile = tempDir.resolve("teacup-export.xmile");
         XmileExporter.toFile(canvasDef, xmileFile);
         assertThat(Files.exists(xmileFile)).isTrue();

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ClearNavigationUndoFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ClearNavigationUndoFxTest.java
@@ -33,7 +33,7 @@ class ClearNavigationUndoFxTest {
     void start(Stage stage) {
         canvas = new ModelCanvas(new Clipboard());
         rootUndoManager = new UndoManager();
-        canvas.setUndoManager(rootUndoManager);
+        canvas.undo().setUndoManager(rootUndoManager);
         stage.setScene(new Scene(new StackPane(canvas), 800, 600));
         stage.show();
     }
@@ -70,16 +70,16 @@ class ClearNavigationUndoFxTest {
     @DisplayName("clearNavigation after drill-in should close module UndoManager and restore root")
     void shouldCloseModuleUndoManagerOnClear() {
         loadNestedModules();
-        canvas.drillInto("Module 1");
+        canvas.navigation().drillInto("Module 1");
 
-        assertThat(canvas.isInsideModule()).isTrue();
-        UndoManager moduleUm = canvas.getUndoManager();
+        assertThat(canvas.navigation().isInsideModule()).isTrue();
+        UndoManager moduleUm = canvas.undo().getUndoManager();
         assertThat(moduleUm).isNotSameAs(rootUndoManager);
 
-        canvas.clearNavigation();
+        canvas.navigation().clearNavigation();
 
         assertThat(moduleUm.isClosed()).isTrue();
-        assertThat(canvas.getUndoManager()).isSameAs(rootUndoManager);
+        assertThat(canvas.undo().getUndoManager()).isSameAs(rootUndoManager);
         assertThat(rootUndoManager.isClosed()).isFalse();
     }
 
@@ -87,20 +87,20 @@ class ClearNavigationUndoFxTest {
     @DisplayName("clearNavigation after multi-level drill-in should close all module UndoManagers")
     void shouldCloseAllModuleUndoManagersOnClear() {
         loadNestedModules();
-        canvas.drillInto("Module 1");
-        UndoManager level1Um = canvas.getUndoManager();
+        canvas.navigation().drillInto("Module 1");
+        UndoManager level1Um = canvas.undo().getUndoManager();
 
-        canvas.drillInto("Module 1");
-        UndoManager level2Um = canvas.getUndoManager();
+        canvas.navigation().drillInto("Module 1");
+        UndoManager level2Um = canvas.undo().getUndoManager();
 
         assertThat(level1Um).isNotSameAs(rootUndoManager);
         assertThat(level2Um).isNotSameAs(level1Um);
 
-        canvas.clearNavigation();
+        canvas.navigation().clearNavigation();
 
         assertThat(level2Um.isClosed()).isTrue();
         assertThat(level1Um.isClosed()).isTrue();
-        assertThat(canvas.getUndoManager()).isSameAs(rootUndoManager);
+        assertThat(canvas.undo().getUndoManager()).isSameAs(rootUndoManager);
         assertThat(rootUndoManager.isClosed()).isFalse();
     }
 
@@ -109,9 +109,9 @@ class ClearNavigationUndoFxTest {
     void shouldNotCloseRootUndoManagerWhenAtRoot() {
         loadNestedModules();
 
-        canvas.clearNavigation();
+        canvas.navigation().clearNavigation();
 
-        assertThat(canvas.getUndoManager()).isSameAs(rootUndoManager);
+        assertThat(canvas.undo().getUndoManager()).isSameAs(rootUndoManager);
         assertThat(rootUndoManager.isClosed()).isFalse();
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/InputDispatcherMouseExitFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/InputDispatcherMouseExitFxTest.java
@@ -34,7 +34,7 @@ class InputDispatcherMouseExitFxTest {
     @Start
     void start(Stage stage) {
         canvas = new ModelCanvas(new Clipboard());
-        canvas.setUndoManager(new UndoManager());
+        canvas.undo().setUndoManager(new UndoManager());
 
         ModelEditor editor = new ModelEditor();
         editor.addStock(); // Stock 1

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/MaturityIndicatorFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/MaturityIndicatorFxTest.java
@@ -46,7 +46,7 @@ class MaturityIndicatorFxTest {
         ViewDef view = AutoLayout.layout(def);
 
         canvas = new ModelCanvas(new Clipboard());
-        canvas.setUndoManager(new UndoManager());
+        canvas.undo().setUndoManager(new UndoManager());
         editor = new ModelEditor();
         editor.loadFrom(def);
         canvas.setModel(editor, view);

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelCanvasInvalidateAnalysisFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelCanvasInvalidateAnalysisFxTest.java
@@ -52,7 +52,7 @@ class ModelCanvasInvalidateAnalysisFxTest {
     @Start
     void start(Stage stage) {
         canvas = new ModelCanvas(new Clipboard());
-        canvas.setUndoManager(new UndoManager());
+        canvas.undo().setUndoManager(new UndoManager());
         stage.setScene(new Scene(new StackPane(canvas), 800, 600));
         stage.show();
     }
@@ -113,8 +113,8 @@ class ModelCanvasInvalidateAnalysisFxTest {
         canvas.setModel(editor, state.toViewDef());
 
         // Validation should be computed (stock with no flow should have issues)
-        assertThat(canvas.getLastValidationResult()).isNotNull();
-        assertThat(canvas.getLastValidationResult().issues()).isNotNull();
+        assertThat(canvas.analysis().getLastValidationResult()).isNotNull();
+        assertThat(canvas.analysis().getLastValidationResult().issues()).isNotNull();
     }
 
     @Test
@@ -122,7 +122,7 @@ class ModelCanvasInvalidateAnalysisFxTest {
     void shouldHandleNullEditorGracefully() {
         // Canvas has no editor set -- calling methods that would trigger
         // invalidateAnalysis should not throw
-        assertThat(canvas.getLastValidationResult()).isNotNull();
-        assertThat(canvas.getLastValidationResult().issues()).isEmpty();
+        assertThat(canvas.analysis().getLastValidationResult()).isNotNull();
+        assertThat(canvas.analysis().getLastValidationResult().issues()).isEmpty();
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelCanvasNullEditorFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelCanvasNullEditorFxTest.java
@@ -29,7 +29,7 @@ class ModelCanvasNullEditorFxTest {
     @Start
     void start(Stage stage) {
         canvas = new ModelCanvas(new Clipboard());
-        canvas.setUndoManager(new UndoManager());
+        canvas.undo().setUndoManager(new UndoManager());
         stage.setScene(new Scene(new StackPane(canvas), 400, 300));
         stage.show();
     }
@@ -37,50 +37,50 @@ class ModelCanvasNullEditorFxTest {
     @Test
     @DisplayName("deleteSelectedElements should not throw when editor is null")
     void deleteSelectedElementsSafe() {
-        assertThatCode(() -> canvas.deleteSelectedElements()).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.elements().deleteSelectedElements()).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("renameElement should not throw when editor is null")
     void renameElementSafe() {
-        assertThatCode(() -> canvas.renameElement("A", "B")).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.elements().renameElement("A", "B")).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("copySelection should not throw when editor is null")
     void copySelectionSafe() {
-        assertThatCode(() -> canvas.copySelection()).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.elements().copySelection()).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("cutSelection should not throw when editor is null")
     void cutSelectionSafe() {
-        assertThatCode(() -> canvas.cutSelection()).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.elements().cutSelection()).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("pasteClipboard should return empty set when editor is null")
     void pasteClipboardSafe() {
-        Set<String> result = canvas.pasteClipboard();
+        Set<String> result = canvas.elements().pasteClipboard();
         assertThat(result).isEmpty();
     }
 
     @Test
     @DisplayName("performUndo should not throw when editor is null")
     void performUndoSafe() {
-        assertThatCode(() -> canvas.performUndo()).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.undo().performUndo()).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("performRedo should not throw when editor is null")
     void performRedoSafe() {
-        assertThatCode(() -> canvas.performRedo()).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.undo().performRedo()).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("toModelDefinition should throw IllegalStateException when editor is null")
     void toModelDefinitionSafe() {
-        assertThatThrownBy(() -> canvas.toModelDefinition())
+        assertThatThrownBy(() -> canvas.navigation().toModelDefinition())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("No model loaded");
     }
@@ -94,31 +94,31 @@ class ModelCanvasNullEditorFxTest {
     @Test
     @DisplayName("handleFlowClick should not throw when editor is null")
     void handleFlowClickSafe() {
-        assertThatCode(() -> canvas.handleFlowClick(100, 100)).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.elements().handleFlowClick(100, 100)).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("handleCausalLinkClick should not throw when editor is null")
     void handleCausalLinkClickSafe() {
-        assertThatCode(() -> canvas.handleCausalLinkClick(100, 100)).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.elements().handleCausalLinkClick(100, 100)).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("handleInfoLinkClick should not throw when editor is null")
     void handleInfoLinkClickSafe() {
-        assertThatCode(() -> canvas.handleInfoLinkClick(100, 100)).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.elements().handleInfoLinkClick(100, 100)).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("createElementAt should not throw when editor is null")
     void createElementAtSafe() {
-        assertThatCode(() -> canvas.createElementAt(200, 200)).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.elements().createElementAt(200, 200)).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("startInlineEdit should not throw when editor is null")
     void startInlineEditSafe() {
-        assertThatCode(() -> canvas.startInlineEdit("Stock 1")).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.elements().startInlineEdit("Stock 1")).doesNotThrowAnyException();
     }
 
     @Test
@@ -130,54 +130,54 @@ class ModelCanvasNullEditorFxTest {
     @Test
     @DisplayName("navigateBack should not throw when editor is null")
     void navigateBackSafe() {
-        assertThatCode(() -> canvas.navigateBack()).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.navigation().navigateBack()).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("whereUsed should return empty set when editor is null")
     void whereUsedSafe() {
-        assertThat(canvas.whereUsed("X")).isEmpty();
+        assertThat(canvas.analysis().whereUsed("X")).isEmpty();
     }
 
     @Test
     @DisplayName("uses should return empty set when editor is null")
     void usesSafe() {
-        assertThat(canvas.uses("X")).isEmpty();
+        assertThat(canvas.analysis().uses("X")).isEmpty();
     }
 
     @Test
     @DisplayName("showWhereUsed should not throw when editor is null")
     void showWhereUsedSafe() {
-        assertThatCode(() -> canvas.showWhereUsed("X")).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.analysis().showWhereUsed("X")).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("showUses should not throw when editor is null")
     void showUsesSafe() {
-        assertThatCode(() -> canvas.showUses("X")).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.analysis().showUses("X")).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("deleteSelectedOrConnection should not throw when editor is null")
     void deleteSelectedOrConnectionSafe() {
-        assertThatCode(() -> canvas.deleteSelectedOrConnection()).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.elements().deleteSelectedOrConnection()).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("setLoopHighlightActive should not throw when editor is null")
     void setLoopHighlightActiveSafe() {
-        assertThatCode(() -> canvas.setLoopHighlightActive(true)).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.analysis().setLoopHighlightActive(true)).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("traceUpstream should not throw when editor is null")
     void traceUpstreamSafe() {
-        assertThatCode(() -> canvas.traceUpstream("X")).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.analysis().traceUpstream("X")).doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("traceDownstream should not throw when editor is null")
     void traceDownstreamSafe() {
-        assertThatCode(() -> canvas.traceDownstream("X")).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.analysis().traceDownstream("X")).doesNotThrowAnyException();
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelCanvasResizeFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelCanvasResizeFxTest.java
@@ -30,7 +30,7 @@ class ModelCanvasResizeFxTest {
     @Start
     void start(Stage stage) {
         canvas = new ModelCanvas(new Clipboard());
-        canvas.setUndoManager(new UndoManager());
+        canvas.undo().setUndoManager(new UndoManager());
         root = new StackPane(canvas);
         stage.setScene(new Scene(root, 800, 600));
         stage.show();

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelCanvasUndoFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelCanvasUndoFxTest.java
@@ -25,7 +25,7 @@ class ModelCanvasUndoFxTest {
     void start(Stage stage) {
         canvas = new ModelCanvas(new Clipboard());
         undoManager = new UndoManager();
-        canvas.setUndoManager(undoManager);
+        canvas.undo().setUndoManager(undoManager);
         stage.setScene(new Scene(new StackPane(canvas), 800, 600));
         stage.show();
     }
@@ -55,8 +55,8 @@ class ModelCanvasUndoFxTest {
     void shouldNotPushUndoOnRejectedFlowSelfLoop() {
         loadTwoStocks();
 
-        canvas.handleFlowClick(100, 200); // Stock 1 as source
-        canvas.handleFlowClick(100, 200); // Stock 1 again → rejected
+        canvas.elements().handleFlowClick(100, 200); // Stock 1 as source
+        canvas.elements().handleFlowClick(100, 200); // Stock 1 again → rejected
 
         assertThat(undoManager.canUndo()).isFalse();
         assertThat(undoManager.undoLabels()).isEmpty();
@@ -67,8 +67,8 @@ class ModelCanvasUndoFxTest {
     void shouldNotPushUndoOnRejectedFlowCloudToCloud() {
         loadTwoStocks();
 
-        canvas.handleFlowClick(250, 100); // empty space → cloud source
-        canvas.handleFlowClick(300, 300); // empty space → cloud sink → rejected
+        canvas.elements().handleFlowClick(250, 100); // empty space → cloud source
+        canvas.elements().handleFlowClick(300, 300); // empty space → cloud sink → rejected
 
         assertThat(undoManager.canUndo()).isFalse();
         assertThat(undoManager.undoLabels()).isEmpty();
@@ -79,8 +79,8 @@ class ModelCanvasUndoFxTest {
     void shouldPushUndoOnSuccessfulFlowCreation() {
         loadTwoStocks();
 
-        canvas.handleFlowClick(100, 200); // Stock 1 as source
-        canvas.handleFlowClick(400, 200); // Stock 2 as sink → success
+        canvas.elements().handleFlowClick(100, 200); // Stock 1 as source
+        canvas.elements().handleFlowClick(400, 200); // Stock 2 as sink → success
 
         assertThat(undoManager.canUndo()).isTrue();
         assertThat(undoManager.undoLabels()).containsExactly("Add flow");
@@ -91,8 +91,8 @@ class ModelCanvasUndoFxTest {
     void shouldNotPushUndoOnRejectedCausalLinkNoTarget() {
         loadTwoCldVariables();
 
-        canvas.handleCausalLinkClick(100, 200); // Variable 1 as source
-        canvas.handleCausalLinkClick(300, 300); // empty space → rejected
+        canvas.elements().handleCausalLinkClick(100, 200); // Variable 1 as source
+        canvas.elements().handleCausalLinkClick(300, 300); // empty space → rejected
 
         assertThat(undoManager.canUndo()).isFalse();
         assertThat(undoManager.undoLabels()).isEmpty();
@@ -104,13 +104,13 @@ class ModelCanvasUndoFxTest {
         loadTwoCldVariables();
 
         // Create first link successfully
-        canvas.handleCausalLinkClick(100, 200);
-        canvas.handleCausalLinkClick(400, 200);
+        canvas.elements().handleCausalLinkClick(100, 200);
+        canvas.elements().handleCausalLinkClick(400, 200);
         int undoCountAfterFirst = undoManager.undoLabels().size();
 
         // Try to create duplicate link
-        canvas.handleCausalLinkClick(100, 200);
-        canvas.handleCausalLinkClick(400, 200);
+        canvas.elements().handleCausalLinkClick(100, 200);
+        canvas.elements().handleCausalLinkClick(400, 200);
 
         assertThat(undoManager.undoLabels()).hasSize(undoCountAfterFirst);
     }
@@ -120,8 +120,8 @@ class ModelCanvasUndoFxTest {
     void shouldPushUndoOnSuccessfulCausalLinkCreation() {
         loadTwoCldVariables();
 
-        canvas.handleCausalLinkClick(100, 200); // Variable 1 as source
-        canvas.handleCausalLinkClick(400, 200); // Variable 2 as target → success
+        canvas.elements().handleCausalLinkClick(100, 200); // Variable 1 as source
+        canvas.elements().handleCausalLinkClick(400, 200); // Variable 2 as target → success
 
         assertThat(undoManager.canUndo()).isTrue();
         assertThat(undoManager.undoLabels()).containsExactly("Add causal link");
@@ -132,7 +132,7 @@ class ModelCanvasUndoFxTest {
     void shouldPushUndoOnRename() {
         loadTwoStocks();
 
-        canvas.renameElement("Stock 1", "Population");
+        canvas.elements().renameElement("Stock 1", "Population");
 
         assertThat(undoManager.canUndo()).isTrue();
         assertThat(undoManager.undoLabels()).containsExactly("Rename Stock 1 → Population");
@@ -143,7 +143,7 @@ class ModelCanvasUndoFxTest {
     void shouldNotPushUndoOnRejectedRenameDuplicate() {
         loadTwoStocks();
 
-        canvas.renameElement("Stock 1", "Stock 2"); // already exists → rejected
+        canvas.elements().renameElement("Stock 1", "Stock 2"); // already exists → rejected
 
         assertThat(undoManager.canUndo()).isFalse();
         assertThat(undoManager.undoLabels()).isEmpty();
@@ -154,7 +154,7 @@ class ModelCanvasUndoFxTest {
     void shouldNotPushUndoOnNoOpRename() {
         loadTwoStocks();
 
-        canvas.renameElement("Stock 1", "Stock 1"); // no-op
+        canvas.elements().renameElement("Stock 1", "Stock 1"); // no-op
 
         assertThat(undoManager.canUndo()).isFalse();
         assertThat(undoManager.undoLabels()).isEmpty();

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/NavigateToDepthUndoFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/NavigateToDepthUndoFxTest.java
@@ -32,7 +32,7 @@ class NavigateToDepthUndoFxTest {
     @Start
     void start(Stage stage) {
         canvas = new ModelCanvas(new Clipboard());
-        canvas.setUndoManager(new UndoManager());
+        canvas.undo().setUndoManager(new UndoManager());
         stage.setScene(new Scene(new StackPane(canvas), 800, 600));
         stage.show();
     }
@@ -86,7 +86,7 @@ class NavigateToDepthUndoFxTest {
      */
     private void drillToDepth(int depth) {
         for (int i = 0; i < depth; i++) {
-            canvas.drillInto("Module 1");
+            canvas.navigation().drillInto("Module 1");
         }
     }
 
@@ -96,14 +96,14 @@ class NavigateToDepthUndoFxTest {
         loadNestedModules();
         drillToDepth(3);
 
-        assertThat(canvas.getNavigationPath()).hasSize(4); // Root + 3 levels
+        assertThat(canvas.navigation().getNavigationPath()).hasSize(4); // Root + 3 levels
 
         // The root-level undo manager was saved in the nav frame when we drilled in.
         // navigateToDepth should restore it and push exactly one undo entry.
-        canvas.navigateToDepth(0);
+        canvas.navigation().navigateToDepth(0);
 
-        assertThat(canvas.isInsideModule()).isFalse();
-        UndoManager rootUndo = canvas.getUndoManager();
+        assertThat(canvas.navigation().isInsideModule()).isFalse();
+        UndoManager rootUndo = canvas.undo().getUndoManager();
         assertThat(rootUndo.undoDepth()).isEqualTo(1);
     }
 
@@ -113,12 +113,12 @@ class NavigateToDepthUndoFxTest {
         loadNestedModules();
         drillToDepth(2);
 
-        assertThat(canvas.getNavigationPath()).hasSize(3); // Root + 2 levels
+        assertThat(canvas.navigation().getNavigationPath()).hasSize(3); // Root + 2 levels
 
-        canvas.navigateToDepth(0);
+        canvas.navigation().navigateToDepth(0);
 
-        assertThat(canvas.isInsideModule()).isFalse();
-        UndoManager rootUndo = canvas.getUndoManager();
+        assertThat(canvas.navigation().isInsideModule()).isFalse();
+        UndoManager rootUndo = canvas.undo().getUndoManager();
         assertThat(rootUndo.undoDepth()).isEqualTo(1);
     }
 
@@ -128,12 +128,12 @@ class NavigateToDepthUndoFxTest {
         loadNestedModules();
         drillToDepth(1);
 
-        assertThat(canvas.getNavigationPath()).hasSize(2); // Root + 1 level
+        assertThat(canvas.navigation().getNavigationPath()).hasSize(2); // Root + 1 level
 
-        canvas.navigateToDepth(0);
+        canvas.navigation().navigateToDepth(0);
 
-        assertThat(canvas.isInsideModule()).isFalse();
-        UndoManager rootUndo = canvas.getUndoManager();
+        assertThat(canvas.navigation().isInsideModule()).isFalse();
+        UndoManager rootUndo = canvas.undo().getUndoManager();
         assertThat(rootUndo.undoDepth()).isEqualTo(1);
     }
 
@@ -143,9 +143,9 @@ class NavigateToDepthUndoFxTest {
         loadNestedModules();
         drillToDepth(2);
 
-        canvas.navigateToDepth(2); // already at depth 2
+        canvas.navigation().navigateToDepth(2); // already at depth 2
 
-        UndoManager currentUndo = canvas.getUndoManager();
+        UndoManager currentUndo = canvas.undo().getUndoManager();
         assertThat(currentUndo.undoDepth()).isZero();
     }
 
@@ -155,10 +155,10 @@ class NavigateToDepthUndoFxTest {
         loadNestedModules();
         drillToDepth(1);
 
-        canvas.navigateBack();
+        canvas.navigation().navigateBack();
 
-        assertThat(canvas.isInsideModule()).isFalse();
-        UndoManager rootUndo = canvas.getUndoManager();
+        assertThat(canvas.navigation().isInsideModule()).isFalse();
+        UndoManager rootUndo = canvas.undo().getUndoManager();
         assertThat(rootUndo.undoDepth()).isEqualTo(1);
     }
 
@@ -166,7 +166,7 @@ class NavigateToDepthUndoFxTest {
     @DisplayName("navigateToDepth with no editor should not throw")
     void shouldNotThrowWhenEditorIsNull() {
         // canvas has no model set yet
-        assertThatCode(() -> canvas.navigateToDepth(0)).doesNotThrowAnyException();
+        assertThatCode(() -> canvas.navigation().navigateToDepth(0)).doesNotThrowAnyException();
     }
 
     @Test
@@ -176,11 +176,11 @@ class NavigateToDepthUndoFxTest {
         drillToDepth(3);
 
         // Navigate from depth 3 to depth 1 (back 2 levels, but stay inside module)
-        canvas.navigateToDepth(1);
+        canvas.navigation().navigateToDepth(1);
 
-        assertThat(canvas.isInsideModule()).isTrue();
-        assertThat(canvas.getNavigationPath()).hasSize(2); // Root + 1 level
-        UndoManager midUndo = canvas.getUndoManager();
+        assertThat(canvas.navigation().isInsideModule()).isTrue();
+        assertThat(canvas.navigation().getNavigationPath()).hasSize(2); // Root + 1 level
+        UndoManager midUndo = canvas.undo().getUndoManager();
         assertThat(midUndo.undoDepth()).isEqualTo(1);
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/PropertiesPanelUndoFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/PropertiesPanelUndoFxTest.java
@@ -32,7 +32,7 @@ class PropertiesPanelUndoFxTest {
     void start(Stage stage) {
         canvas = new ModelCanvas(new Clipboard());
         undoManager = new UndoManager();
-        canvas.setUndoManager(undoManager);
+        canvas.undo().setUndoManager(undoManager);
         panel = new PropertiesPanel();
 
         editor = new ModelEditor();
@@ -132,8 +132,8 @@ class PropertiesPanelUndoFxTest {
             state.addElement("Variable 2", ElementType.CLD_VARIABLE, 400, 200);
             canvas.setModel(editor, state.toViewDef());
 
-            canvas.handleCausalLinkClick(100, 200);
-            canvas.handleCausalLinkClick(400, 200);
+            canvas.elements().handleCausalLinkClick(100, 200);
+            canvas.elements().handleCausalLinkClick(400, 200);
 
             canvas.setSelectedConnection(
                     new ConnectionId("Variable 1", "Variable 2"), true);

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/WhereUsedFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/WhereUsedFxTest.java
@@ -63,35 +63,35 @@ class WhereUsedFxTest {
     @Test
     @DisplayName("whereUsed returns elements that reference the given element")
     void shouldReturnDependentsForWhereUsed() {
-        Set<String> whereUsed = canvas.whereUsed("Contact Rate");
+        Set<String> whereUsed = canvas.analysis().whereUsed("Contact Rate");
         assertThat(whereUsed).contains("Infection");
     }
 
     @Test
     @DisplayName("whereUsed returns multiple dependents for a shared variable")
     void shouldReturnMultipleDependentsForSharedVariable() {
-        Set<String> whereUsed = canvas.whereUsed("Infectious");
+        Set<String> whereUsed = canvas.analysis().whereUsed("Infectious");
         assertThat(whereUsed).contains("Infection", "Recovery");
     }
 
     @Test
     @DisplayName("uses returns elements referenced by the given element's equation")
     void shouldReturnDependenciesForUses() {
-        Set<String> uses = canvas.uses("Recovery");
+        Set<String> uses = canvas.analysis().uses("Recovery");
         assertThat(uses).contains("Infectious", "Duration");
     }
 
     @Test
     @DisplayName("uses returns empty set for a constant")
     void shouldReturnEmptyUsesForConstant() {
-        Set<String> uses = canvas.uses("Contact Rate");
+        Set<String> uses = canvas.analysis().uses("Contact Rate");
         assertThat(uses).isEmpty();
     }
 
     @Test
     @DisplayName("showWhereUsed selects all dependent elements")
     void shouldSelectDependentsOnShowWhereUsed() {
-        canvas.showWhereUsed("Duration");
+        canvas.analysis().showWhereUsed("Duration");
 
         Set<String> selected = canvas.getSelectedElementNames();
         assertThat(selected).contains("Recovery");
@@ -100,7 +100,7 @@ class WhereUsedFxTest {
     @Test
     @DisplayName("showUses selects all dependency elements")
     void shouldSelectDependenciesOnShowUses() {
-        canvas.showUses("Recovery");
+        canvas.analysis().showUses("Recovery");
 
         Set<String> selected = canvas.getSelectedElementNames();
         assertThat(selected).contains("Infectious", "Duration");


### PR DESCRIPTION
## Summary
- Extract 4 facade classes from ModelCanvas, reducing it from **1318 → 560 lines** (57% reduction)
  - `CanvasAnalysisFacade` (260 lines): loop highlighting, causal tracing, validation, dependency queries
  - `CanvasNavigationFacade` (206 lines): module drill-into/back, breadcrumb path, model definition composition
  - `CanvasUndoFacade` (93 lines): undo/redo state management, snapshot capture/restore
  - `CanvasElementController` (275 lines): element CRUD, connection creation, context menus, clipboard, inline editing
- Update 20 caller files (9 production, 11 test) to route through facade accessors: `canvas.analysis()`, `canvas.navigation()`, `canvas.undo()`, `canvas.elements()`

## Test plan
- [x] `mvn clean compile` — full reactor builds
- [x] `mvn clean test` — all tests pass (0 failures)
- [x] `mvn spotbugs:check` — no findings