### PR TITLE
Throw CsvOutputException on write errors instead of logging warnings

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/CsvSubscriber.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/CsvSubscriber.java
@@ -91,8 +91,9 @@ public class CsvSubscriber implements EventHandler, Closeable {
         }
         csvWriter.writeNext(values.toArray(new String[0]));
         if (csvWriter.checkError()) {
-            logger.warn("Failed to write CSV data row at step {}: {}",
-                    event.getStep(), csvWriter.getException());
+            throw new CsvOutputException(
+                    "Failed to write CSV data row at step " + event.getStep(),
+                    csvWriter.getException());
         }
     }
 
@@ -118,7 +119,8 @@ public class CsvSubscriber implements EventHandler, Closeable {
         values.addAll(variableNames);
         csvWriter.writeNext(values.toArray(new String[0]));
         if (csvWriter.checkError()) {
-            logger.warn("Failed to write CSV header: {}", csvWriter.getException());
+            throw new CsvOutputException(
+                    "Failed to write CSV header", csvWriter.getException());
         }
     }
 


### PR DESCRIPTION
## Summary
- CSV write errors in `CsvSubscriber` now throw `CsvOutputException` instead of silently logging warnings, preventing undetected data loss during simulation output

Closes #944