### PR TITLE
Make Variable.evaluating and cachedValue volatile for thread-safety

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/Variable.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Variable.java
@@ -18,7 +18,7 @@ public class Variable extends Element {
      * Cached value from the most recent evaluation, used as the initial guess
      * when breaking algebraic loops via the re-entrancy guard.
      */
-    private double cachedValue;
+    private volatile double cachedValue;
 
     /**
      * True while this variable's formula is being evaluated. A re-entrant call


### PR DESCRIPTION
## Summary
- Made `Variable.evaluating` and `cachedValue` fields volatile to ensure visibility across threads, preventing potential race conditions if a compiled model is shared across parallel simulation runs

Closes #943