### PR TITLE
Extract NameResolver utility (#988)

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/NameResolver.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/NameResolver.java
@@ -1,0 +1,77 @@
+package systems.courant.sd.model;
+
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Resolves element names across the underscore/space boundary.
+ *
+ * <p>Element names in a model use spaces (e.g. "birth rate") but equation
+ * references use underscores (e.g. "birth_rate"). This utility centralises
+ * the fallback-lookup pattern that was previously duplicated across
+ * {@code CompilationContext}, {@code FeedbackAnalysis}, and
+ * {@code ModelValidator}.
+ */
+public final class NameResolver {
+
+    private NameResolver() {
+    }
+
+    /**
+     * Tries {@code lookup.apply(name)}; if the result is {@code null} and
+     * the name contains an underscore, retries with underscores replaced by
+     * spaces.
+     *
+     * @param name   the reference name (may contain underscores)
+     * @param lookup a function that returns a value for a known name, or {@code null}
+     * @param <V>    the value type
+     * @return the first non-null result, or {@code null} if neither form matches
+     */
+    public static <V> V resolve(String name, Function<String, V> lookup) {
+        V value = lookup.apply(name);
+        if (value != null) {
+            return value;
+        }
+        if (name.contains("_")) {
+            return lookup.apply(name.replace('_', ' '));
+        }
+        return null;
+    }
+
+    /**
+     * Returns the matching form of {@code name} present in {@code names},
+     * trying the exact name first, then the underscore-to-space variant.
+     *
+     * @param name  the reference name
+     * @param names the set of known element names
+     * @return the form found in the set, or {@code null}
+     */
+    public static String resolveInSet(String name, Set<String> names) {
+        if (names.contains(name)) {
+            return name;
+        }
+        String spaced = name.replace('_', ' ');
+        if (names.contains(spaced)) {
+            return spaced;
+        }
+        return null;
+    }
+
+    /**
+     * Checks whether {@code name} is present in {@code names} under any
+     * variant: exact, underscore→space, or space→underscore.
+     *
+     * @param name  the element name to check
+     * @param names the set of reference names (typically extracted from equations)
+     * @return {@code true} if any variant of the name is in the set
+     */
+    public static boolean containsName(String name, Set<String> names) {
+        if (names.contains(name)) {
+            return true;
+        }
+        if (names.contains(name.replace(' ', '_'))) {
+            return true;
+        }
+        return names.contains(name.replace('_', ' '));
+    }
+}

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/CompilationContext.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/CompilationContext.java
@@ -4,6 +4,7 @@ import systems.courant.sd.measure.TimeUnit;
 import systems.courant.sd.measure.UnitRegistry;
 import systems.courant.sd.model.Flow;
 import systems.courant.sd.model.LookupTable;
+import systems.courant.sd.model.NameResolver;
 import systems.courant.sd.model.Stock;
 import systems.courant.sd.model.Variable;
 import systems.courant.sd.model.def.LookupTableDef;
@@ -168,16 +169,9 @@ public class CompilationContext {
      * with isolated input holders.
      */
     public Optional<LookupTableDef> resolveLookupTableDef(String name) {
-        LookupTableDef def = lookupTableDefs.get(name);
+        LookupTableDef def = NameResolver.resolve(name, lookupTableDefs::get);
         if (def != null) {
             return Optional.of(def);
-        }
-        if (name.contains("_")) {
-            String spaceName = name.replace('_', ' ');
-            def = lookupTableDefs.get(spaceName);
-            if (def != null) {
-                return Optional.of(def);
-            }
         }
         if (parent != null) {
             return parent.resolveLookupTableDef(name);
@@ -256,16 +250,9 @@ public class CompilationContext {
      * Returns null if not found as a constant.
      */
     public OptionalDouble resolveConstant(String name) {
-        Double val = literalConstants.get(name);
+        Double val = NameResolver.resolve(name, literalConstants::get);
         if (val != null) {
             return OptionalDouble.of(val);
-        }
-        if (name.contains("_")) {
-            String spaceName = name.replace('_', ' ');
-            val = literalConstants.get(spaceName);
-            if (val != null) {
-                return OptionalDouble.of(val);
-            }
         }
         if (parent != null) {
             return parent.resolveConstant(name);
@@ -281,16 +268,9 @@ public class CompilationContext {
      * @return the lookup table, or empty if not found
      */
     public Optional<LookupTable> resolveLookupTable(String name) {
-        LookupTable table = lookupTables.get(name);
+        LookupTable table = NameResolver.resolve(name, lookupTables::get);
         if (table != null) {
             return Optional.of(table);
-        }
-        if (name.contains("_")) {
-            String spaceName = name.replace('_', ' ');
-            table = lookupTables.get(spaceName);
-            if (table != null) {
-                return Optional.of(table);
-            }
         }
         if (parent != null) {
             return parent.resolveLookupTable(name);
@@ -334,16 +314,9 @@ public class CompilationContext {
      * @return the single-element input holder array, or empty if not found
      */
     public Optional<double[]> resolveLookupInputHolder(String name) {
-        double[] holder = lookupInputHolders.get(name);
+        double[] holder = NameResolver.resolve(name, lookupInputHolders::get);
         if (holder != null) {
             return Optional.of(holder);
-        }
-        if (name.contains("_")) {
-            String spaceName = name.replace('_', ' ');
-            holder = lookupInputHolders.get(spaceName);
-            if (holder != null) {
-                return Optional.of(holder);
-            }
         }
         if (parent != null) {
             return parent.resolveLookupInputHolder(name);

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/ModelValidator.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/ModelValidator.java
@@ -1,5 +1,6 @@
 package systems.courant.sd.model.def;
 
+import systems.courant.sd.model.NameResolver;
 import systems.courant.sd.model.def.ValidationIssue.Severity;
 import systems.courant.sd.model.expr.Expr;
 import systems.courant.sd.model.expr.ExprDependencies;
@@ -396,16 +397,6 @@ public final class ModelValidator {
      * Checks if a name is referenced, accounting for the underscore/space name resolution.
      */
     private static boolean isReferenced(String name, Set<String> referencedNames) {
-        if (referencedNames.contains(name)) {
-            return true;
-        }
-        // Check underscore variant (equations use underscores for names with spaces)
-        String underscored = name.replace(' ', '_');
-        if (referencedNames.contains(underscored)) {
-            return true;
-        }
-        // Check space variant (element named with underscores, equation uses spaces)
-        String spaced = name.replace('_', ' ');
-        return referencedNames.contains(spaced);
+        return NameResolver.containsName(name, referencedNames);
     }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/model/graph/FeedbackAnalysis.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/graph/FeedbackAnalysis.java
@@ -1,5 +1,6 @@
 package systems.courant.sd.model.graph;
 
+import systems.courant.sd.model.NameResolver;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.CausalLinkDef;
 import systems.courant.sd.model.def.FlowDef;
@@ -786,14 +787,7 @@ public record FeedbackAnalysis(
      * underscore-to-space mapping used in equations.
      */
     private static String resolveName(String ref, Set<String> allNames) {
-        if (allNames.contains(ref)) {
-            return ref;
-        }
-        String spaced = ref.replace('_', ' ');
-        if (allNames.contains(spaced)) {
-            return spaced;
-        }
-        return null;
+        return NameResolver.resolveInSet(ref, allNames);
     }
 
 }

--- a/courant-engine/src/test/java/systems/courant/sd/model/NameResolverTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/NameResolverTest.java
@@ -1,0 +1,103 @@
+package systems.courant.sd.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NameResolverTest {
+
+    @Nested
+    @DisplayName("resolve(name, lookup)")
+    class ResolveTests {
+
+        @Test
+        void shouldReturnExactMatch() {
+            Map<String, String> map = Map.of("birth rate", "value");
+            assertThat(NameResolver.resolve("birth rate", map::get)).isEqualTo("value");
+        }
+
+        @Test
+        void shouldFallbackUnderscoreToSpace() {
+            Map<String, String> map = Map.of("birth rate", "value");
+            assertThat(NameResolver.resolve("birth_rate", map::get)).isEqualTo("value");
+        }
+
+        @Test
+        void shouldReturnNullWhenNotFound() {
+            Map<String, String> map = Map.of("other", "value");
+            assertThat(NameResolver.resolve("birth_rate", map::get)).isNull();
+        }
+
+        @Test
+        void shouldPreferExactMatchOverFallback() {
+            Map<String, String> map = new HashMap<>();
+            map.put("a_b", "exact");
+            map.put("a b", "fallback");
+            assertThat(NameResolver.resolve("a_b", map::get)).isEqualTo("exact");
+        }
+
+        @Test
+        void shouldSkipFallbackWhenNoUnderscore() {
+            Map<String, String> map = Map.of("other", "value");
+            assertThat(NameResolver.resolve("nounderscore", map::get)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveInSet(name, names)")
+    class ResolveInSetTests {
+
+        @Test
+        void shouldReturnExactMatch() {
+            Set<String> names = Set.of("birth rate", "death rate");
+            assertThat(NameResolver.resolveInSet("birth rate", names)).isEqualTo("birth rate");
+        }
+
+        @Test
+        void shouldFallbackUnderscoreToSpace() {
+            Set<String> names = Set.of("birth rate", "death rate");
+            assertThat(NameResolver.resolveInSet("birth_rate", names)).isEqualTo("birth rate");
+        }
+
+        @Test
+        void shouldReturnNullWhenNotFound() {
+            Set<String> names = Set.of("birth rate");
+            assertThat(NameResolver.resolveInSet("unknown", names)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("containsName(name, names)")
+    class ContainsNameTests {
+
+        @Test
+        void shouldMatchExact() {
+            Set<String> names = Set.of("birth_rate");
+            assertThat(NameResolver.containsName("birth_rate", names)).isTrue();
+        }
+
+        @Test
+        void shouldMatchSpaceToUnderscore() {
+            Set<String> names = Set.of("birth_rate");
+            assertThat(NameResolver.containsName("birth rate", names)).isTrue();
+        }
+
+        @Test
+        void shouldMatchUnderscoreToSpace() {
+            Set<String> names = Set.of("birth rate");
+            assertThat(NameResolver.containsName("birth_rate", names)).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalseWhenNotFound() {
+            Set<String> names = Set.of("birth rate");
+            assertThat(NameResolver.containsName("unknown", names)).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `NameResolver` utility class with three static methods (`resolve`, `resolveInSet`, `containsName`) that centralise the underscore/space name fallback pattern
- Refactor `CompilationContext` (4 methods), `FeedbackAnalysis`, and `ModelValidator` to delegate to `NameResolver`
- Add unit tests for all three methods

## Test plan
- [x] `mvn clean compile` — full reactor
- [x] `mvn clean test` — all tests pass
- [x] `mvn spotbugs:check` — no findings