### PR TITLE
Extract TwoClickState helper for two-click controllers (#986)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CausalLinkCreationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CausalLinkCreationController.java
@@ -51,12 +51,7 @@ public class CausalLinkCreationController {
         }
     }
 
-    private boolean pending;
-    private String pendingSource;
-    private double sourceX;
-    private double sourceY;
-    private double rubberBandEndX;
-    private double rubberBandEndY;
+    private final TwoClickState state = new TwoClickState();
 
     /**
      * Handles a click during causal link creation.
@@ -65,17 +60,12 @@ public class CausalLinkCreationController {
      */
     public LinkResult handleClick(double worldX, double worldY,
                                   CanvasState canvasState, ModelEditor editor) {
-        if (!pending) {
+        if (!state.isPending()) {
             String hit = HitTester.hitTest(canvasState, worldX, worldY);
             if (hit == null) {
                 return LinkResult.rejected("Click on a variable to start drawing a causal link");
             }
-            pending = true;
-            pendingSource = hit;
-            sourceX = canvasState.getX(hit);
-            sourceY = canvasState.getY(hit);
-            rubberBandEndX = worldX;
-            rubberBandEndY = worldY;
+            state.begin(hit, canvasState.getX(hit), canvasState.getY(hit), worldX, worldY);
             return LinkResult.pending();
         } else {
             String targetHit = HitTester.hitTest(canvasState, worldX, worldY);
@@ -87,13 +77,13 @@ public class CausalLinkCreationController {
 
             // Check for duplicate link
             for (CausalLinkDef existing : editor.getCausalLinks()) {
-                if (existing.from().equals(pendingSource) && existing.to().equals(targetHit)) {
+                if (existing.from().equals(state.source()) && existing.to().equals(targetHit)) {
                     cancel();
                     return LinkResult.rejected("A causal link already exists between these variables");
                 }
             }
 
-            editor.addCausalLink(pendingSource, targetHit, CausalLinkDef.Polarity.UNKNOWN);
+            editor.addCausalLink(state.source(), targetHit, CausalLinkDef.Polarity.UNKNOWN);
             cancel();
             return LinkResult.created();
         }
@@ -103,38 +93,31 @@ public class CausalLinkCreationController {
      * Updates the rubber-band endpoint during mouse movement.
      */
     public void updateRubberBand(double worldX, double worldY) {
-        if (pending) {
-            rubberBandEndX = worldX;
-            rubberBandEndY = worldY;
-        }
+        state.updateRubberBand(worldX, worldY);
     }
 
     /**
      * Cancels any pending causal link creation, resetting all state.
      */
     public void cancel() {
-        pending = false;
-        pendingSource = null;
-        sourceX = 0;
-        sourceY = 0;
-        rubberBandEndX = 0;
-        rubberBandEndY = 0;
+        state.reset();
     }
 
     /**
      * Returns true if a causal link creation is pending (first click done, awaiting second).
      */
     public boolean isPending() {
-        return pending;
+        return state.isPending();
     }
 
     /**
      * Returns an immutable snapshot of the current causal link creation state.
      */
     public State getState() {
-        if (!pending) {
+        if (!state.isPending()) {
             return State.IDLE;
         }
-        return new State(true, pendingSource, sourceX, sourceY, rubberBandEndX, rubberBandEndY);
+        return new State(true, state.source(), state.sourceX(), state.sourceY(),
+                state.rubberBandEndX(), state.rubberBandEndY());
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/FlowCreationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/FlowCreationController.java
@@ -51,12 +51,7 @@ public class FlowCreationController {
         }
     }
 
-    private boolean pending;
-    private String pendingSource;
-    private double sourceX;
-    private double sourceY;
-    private double rubberBandEndX;
-    private double rubberBandEndY;
+    private final TwoClickState state = new TwoClickState();
 
     /**
      * Handles a click during flow creation.
@@ -65,40 +60,38 @@ public class FlowCreationController {
      */
     public FlowResult handleClick(double worldX, double worldY,
                                    CanvasState canvasState, ModelEditor editor) {
-        if (!pending) {
+        if (!state.isPending()) {
             // First click: set source
             String hit = hitTestStockOnly(worldX, worldY, canvasState);
-            pending = true;
-            pendingSource = hit;
-
+            double srcX;
+            double srcY;
             if (hit != null) {
-                sourceX = canvasState.getX(hit);
-                sourceY = canvasState.getY(hit);
+                srcX = canvasState.getX(hit);
+                srcY = canvasState.getY(hit);
             } else {
-                sourceX = worldX;
-                sourceY = worldY;
+                srcX = worldX;
+                srcY = worldY;
             }
-            rubberBandEndX = worldX;
-            rubberBandEndY = worldY;
+            state.begin(hit, srcX, srcY, worldX, worldY);
             return FlowResult.pending();
         } else {
             // Second click: set sink and create flow
             String sinkHit = hitTestStockOnly(worldX, worldY, canvasState);
 
             // Prevent self-loop: source and sink must not be the same stock
-            if (sinkHit != null && sinkHit.equals(pendingSource)) {
+            if (sinkHit != null && sinkHit.equals(state.source())) {
                 cancel();
                 return FlowResult.rejected("Cannot create a self-loop: source and sink are the same stock");
             }
 
             // Prevent cloud-to-cloud: at least one end must be a stock
-            if (pendingSource == null && sinkHit == null) {
+            if (state.source() == null && sinkHit == null) {
                 cancel();
                 return FlowResult.rejected("At least one end of a flow must connect to a stock");
             }
 
-            double srcX = sourceX;
-            double srcY = sourceY;
+            double srcX = state.sourceX();
+            double srcY = state.sourceY();
             double dstX;
             double dstY;
 
@@ -113,7 +106,7 @@ public class FlowCreationController {
             double midX = (srcX + dstX) / 2;
             double midY = (srcY + dstY) / 2;
 
-            String name = editor.addFlow(pendingSource, sinkHit);
+            String name = editor.addFlow(state.source(), sinkHit);
             canvasState.addElement(name, ElementType.FLOW, midX, midY);
 
             cancel();
@@ -125,39 +118,32 @@ public class FlowCreationController {
      * Updates the rubber-band endpoint during mouse movement.
      */
     public void updateRubberBand(double worldX, double worldY) {
-        if (pending) {
-            rubberBandEndX = worldX;
-            rubberBandEndY = worldY;
-        }
+        state.updateRubberBand(worldX, worldY);
     }
 
     /**
      * Cancels any pending flow creation, resetting all state.
      */
     public void cancel() {
-        pending = false;
-        pendingSource = null;
-        sourceX = 0;
-        sourceY = 0;
-        rubberBandEndX = 0;
-        rubberBandEndY = 0;
+        state.reset();
     }
 
     /**
      * Returns true if a flow creation is pending (first click done, awaiting second).
      */
     public boolean isPending() {
-        return pending;
+        return state.isPending();
     }
 
     /**
      * Returns an immutable snapshot of the current flow creation state.
      */
     public State getState() {
-        if (!pending) {
+        if (!state.isPending()) {
             return State.IDLE;
         }
-        return new State(true, pendingSource, sourceX, sourceY, rubberBandEndX, rubberBandEndY);
+        return new State(true, state.source(), state.sourceX(), state.sourceY(),
+                state.rubberBandEndX(), state.rubberBandEndY());
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/InfoLinkCreationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/InfoLinkCreationController.java
@@ -62,13 +62,8 @@ public class InfoLinkCreationController {
         }
     }
 
-    private boolean pending;
-    private String pendingSourceName;
+    private final TwoClickState state = new TwoClickState();
     private HitTester.PortHit pendingSourcePort;
-    private double sourceX;
-    private double sourceY;
-    private double rubberBandEndX;
-    private double rubberBandEndY;
     private HitTester.PortHit currentHoveredPort;
 
     /**
@@ -77,7 +72,7 @@ public class InfoLinkCreationController {
      */
     public LinkResult handleClick(double worldX, double worldY,
                                   CanvasState canvasState, ModelEditor editor) {
-        if (!pending) {
+        if (!state.isPending()) {
             return handleFirstClick(worldX, worldY, canvasState, editor);
         } else {
             return handleSecondClick(worldX, worldY, canvasState, editor);
@@ -90,13 +85,8 @@ public class InfoLinkCreationController {
         HitTester.PortHit portHit = HitTester.hitTestPort(canvasState, editor, worldX, worldY);
         if (portHit != null) {
             if (!portHit.isInput()) {
-                pending = true;
-                pendingSourceName = null;
                 pendingSourcePort = portHit;
-                sourceX = portHit.portX();
-                sourceY = portHit.portY();
-                rubberBandEndX = worldX;
-                rubberBandEndY = worldY;
+                state.begin(null, portHit.portX(), portHit.portY(), worldX, worldY);
                 return LinkResult.pending();
             }
             // Input port clicked as source — fall through to element hit
@@ -105,13 +95,8 @@ public class InfoLinkCreationController {
         // Try element hit
         String hit = HitTester.hitTest(canvasState, worldX, worldY);
         if (hit != null) {
-            pending = true;
-            pendingSourceName = hit;
             pendingSourcePort = null;
-            sourceX = canvasState.getX(hit);
-            sourceY = canvasState.getY(hit);
-            rubberBandEndX = worldX;
-            rubberBandEndY = worldY;
+            state.begin(hit, canvasState.getX(hit), canvasState.getY(hit), worldX, worldY);
             return LinkResult.pending();
         }
 
@@ -123,10 +108,10 @@ public class InfoLinkCreationController {
         // Try port hit first
         HitTester.PortHit portHit = HitTester.hitTestPort(canvasState, editor, worldX, worldY);
 
-        if (pendingSourceName != null) {
+        if (state.source() != null) {
             // Source is an element — target must be an input port
             if (portHit != null && portHit.isInput()) {
-                return createInputBinding(pendingSourceName, portHit, editor);
+                return createInputBinding(state.source(), portHit, editor);
             }
             // Element to element or element to output port — reject
             cancel();
@@ -200,10 +185,7 @@ public class InfoLinkCreationController {
      * Updates the rubber-band endpoint and hovered port during mouse movement.
      */
     public void updateRubberBand(double worldX, double worldY) {
-        if (pending) {
-            rubberBandEndX = worldX;
-            rubberBandEndY = worldY;
-        }
+        state.updateRubberBand(worldX, worldY);
     }
 
     /**
@@ -218,28 +200,24 @@ public class InfoLinkCreationController {
      * Cancels any pending info link creation.
      */
     public void cancel() {
-        pending = false;
-        pendingSourceName = null;
+        state.reset();
         pendingSourcePort = null;
-        sourceX = 0;
-        sourceY = 0;
-        rubberBandEndX = 0;
-        rubberBandEndY = 0;
         currentHoveredPort = null;
     }
 
     public boolean isPending() {
-        return pending;
+        return state.isPending();
     }
 
     /**
      * Returns an immutable snapshot of the current state.
      */
     public State getState() {
-        if (!pending) {
+        if (!state.isPending()) {
             return new State(false, null, null, 0, 0, 0, 0, currentHoveredPort);
         }
-        return new State(true, pendingSourceName, pendingSourcePort,
-                sourceX, sourceY, rubberBandEndX, rubberBandEndY, currentHoveredPort);
+        return new State(true, state.source(), pendingSourcePort,
+                state.sourceX(), state.sourceY(),
+                state.rubberBandEndX(), state.rubberBandEndY(), currentHoveredPort);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/TwoClickState.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/TwoClickState.java
@@ -1,0 +1,81 @@
+package systems.courant.sd.app.canvas.controllers;
+
+/**
+ * Common two-click state machine for controllers that create links between elements.
+ * Manages the pending/source/rubber-band state shared by {@link FlowCreationController},
+ * {@link CausalLinkCreationController}, and {@link InfoLinkCreationController}.
+ */
+public class TwoClickState {
+
+    private boolean pending;
+    private String source;
+    private double sourceX;
+    private double sourceY;
+    private double rubberBandEndX;
+    private double rubberBandEndY;
+
+    /**
+     * Transitions to the pending state with the given source and coordinates.
+     *
+     * @param source the source element name, or {@code null} for cloud/port sources
+     * @param srcX   the source X coordinate
+     * @param srcY   the source Y coordinate
+     * @param mouseX the initial rubber-band end X
+     * @param mouseY the initial rubber-band end Y
+     */
+    public void begin(String source, double srcX, double srcY, double mouseX, double mouseY) {
+        this.pending = true;
+        this.source = source;
+        this.sourceX = srcX;
+        this.sourceY = srcY;
+        this.rubberBandEndX = mouseX;
+        this.rubberBandEndY = mouseY;
+    }
+
+    /**
+     * Updates the rubber-band endpoint during mouse movement.
+     * Ignored when not in the pending state.
+     */
+    public void updateRubberBand(double worldX, double worldY) {
+        if (pending) {
+            rubberBandEndX = worldX;
+            rubberBandEndY = worldY;
+        }
+    }
+
+    /**
+     * Resets all state back to idle.
+     */
+    public void reset() {
+        pending = false;
+        source = null;
+        sourceX = 0;
+        sourceY = 0;
+        rubberBandEndX = 0;
+        rubberBandEndY = 0;
+    }
+
+    public boolean isPending() {
+        return pending;
+    }
+
+    public String source() {
+        return source;
+    }
+
+    public double sourceX() {
+        return sourceX;
+    }
+
+    public double sourceY() {
+        return sourceY;
+    }
+
+    public double rubberBandEndX() {
+        return rubberBandEndX;
+    }
+
+    public double rubberBandEndY() {
+        return rubberBandEndY;
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/TwoClickStateTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/TwoClickStateTest.java
@@ -1,0 +1,69 @@
+package systems.courant.sd.app.canvas.controllers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TwoClickStateTest {
+
+    @Test
+    void shouldStartIdle() {
+        TwoClickState state = new TwoClickState();
+        assertThat(state.isPending()).isFalse();
+        assertThat(state.source()).isNull();
+    }
+
+    @Test
+    void shouldTransitionToPendingOnBegin() {
+        TwoClickState state = new TwoClickState();
+        state.begin("stock1", 10, 20, 15, 25);
+
+        assertThat(state.isPending()).isTrue();
+        assertThat(state.source()).isEqualTo("stock1");
+        assertThat(state.sourceX()).isEqualTo(10);
+        assertThat(state.sourceY()).isEqualTo(20);
+        assertThat(state.rubberBandEndX()).isEqualTo(15);
+        assertThat(state.rubberBandEndY()).isEqualTo(25);
+    }
+
+    @Test
+    void shouldUpdateRubberBandWhenPending() {
+        TwoClickState state = new TwoClickState();
+        state.begin("src", 0, 0, 0, 0);
+        state.updateRubberBand(50, 60);
+
+        assertThat(state.rubberBandEndX()).isEqualTo(50);
+        assertThat(state.rubberBandEndY()).isEqualTo(60);
+    }
+
+    @Test
+    void shouldIgnoreRubberBandWhenIdle() {
+        TwoClickState state = new TwoClickState();
+        state.updateRubberBand(50, 60);
+
+        assertThat(state.rubberBandEndX()).isEqualTo(0);
+        assertThat(state.rubberBandEndY()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldResetToIdle() {
+        TwoClickState state = new TwoClickState();
+        state.begin("src", 10, 20, 30, 40);
+        state.reset();
+
+        assertThat(state.isPending()).isFalse();
+        assertThat(state.source()).isNull();
+        assertThat(state.sourceX()).isEqualTo(0);
+        assertThat(state.sourceY()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldAllowNullSource() {
+        TwoClickState state = new TwoClickState();
+        state.begin(null, 5, 10, 15, 20);
+
+        assertThat(state.isPending()).isTrue();
+        assertThat(state.source()).isNull();
+        assertThat(state.sourceX()).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `TwoClickState` helper class encapsulating the common pending/source/rubber-band state shared by `FlowCreationController`, `CausalLinkCreationController`, and `InfoLinkCreationController`
- Refactor all 3 controllers to delegate `updateRubberBand`, `cancel`, `isPending`, and state field management to `TwoClickState`
- Add unit tests for `TwoClickState`

Closes #986

## Test plan
- [x] `mvn clean compile` — full reactor
- [x] `mvn clean test` — all tests pass
- [x] `mvn spotbugs:check` — no findings