### PR TITLE
Extract FormContext.addCommentArea() factory (#985)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/CldVariableForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/CldVariableForm.java
@@ -38,15 +38,7 @@ public class CldVariableForm implements ElementForm {
         ctx.addFieldRow(row++, "Name", nameField,
                 "The name of this causal variable");
 
-        commentArea = new TextArea(variable.comment() != null ? variable.comment() : "");
-        commentArea.setId("propComment");
-        commentArea.setPrefRowCount(2);
-        commentArea.setWrapText(true);
-        commentArea.setMaxWidth(Double.MAX_VALUE);
-        GridPane.setHgrow(commentArea, Priority.ALWAYS);
-        ctx.addTextAreaCommitHandlers(commentArea, this::commitComment);
-        ctx.addFieldRow(row++, "Description", commentArea,
-                "Documentation for this variable");
+        commentArea = ctx.addCommentArea(row++, variable.comment(), this::commitComment);
 
         return row;
     }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FlowForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FlowForm.java
@@ -48,15 +48,7 @@ public class FlowForm implements ElementForm {
         ctx.addFieldRow(row++, "Name", nameField,
                 "The name used to reference this flow in equations");
 
-        commentArea = new TextArea(flow.comment() != null ? flow.comment() : "");
-        commentArea.setId("propComment");
-        commentArea.setPrefRowCount(2);
-        commentArea.setWrapText(true);
-        commentArea.setMaxWidth(Double.MAX_VALUE);
-        GridPane.setHgrow(commentArea, Priority.ALWAYS);
-        ctx.addTextAreaCommitHandlers(commentArea, this::commitComment);
-        ctx.addFieldRow(row++, "Description", commentArea,
-                "Documentation for this element");
+        commentArea = ctx.addCommentArea(row++, flow.comment(), this::commitComment);
 
         equationField = ctx.createEquationField(flow.equation());
         ctx.addEquationCommitHandlers(equationField, this::commitEquation);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormContext.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormContext.java
@@ -308,6 +308,27 @@ public class FormContext {
         });
     }
 
+    /**
+     * Creates a standard comment/description TextArea, registers commit handlers,
+     * and adds it as a field row. Returns the TextArea for forms that need a reference.
+     *
+     * @param row            the grid row index
+     * @param currentComment the element's current comment (may be {@code null})
+     * @param commitHandler  handler invoked on focus-loss to persist changes
+     * @return the configured TextArea
+     */
+    public TextArea addCommentArea(int row, String currentComment, Consumer<TextArea> commitHandler) {
+        TextArea area = new TextArea(currentComment != null ? currentComment : "");
+        area.setId("propComment");
+        area.setPrefRowCount(2);
+        area.setWrapText(true);
+        area.setMaxWidth(Double.MAX_VALUE);
+        GridPane.setHgrow(area, Priority.ALWAYS);
+        addTextAreaCommitHandlers(area, commitHandler);
+        addFieldRow(row, "Description", area, "Documentation for this element");
+        return area;
+    }
+
     public void addComboCommitHandlers(ComboBox<String> box, Consumer<ComboBox<String>> handler) {
         box.setOnAction(e -> {
             if (!updatingFields) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/LookupForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/LookupForm.java
@@ -78,15 +78,7 @@ public class LookupForm implements ElementForm {
                 "The name used to reference this lookup table in equations.\n"
                 + "Use LOOKUP(table_name, input_value) in equations.");
 
-        TextArea commentArea = new TextArea(lookup.comment() != null ? lookup.comment() : "");
-        commentArea.setId("propComment");
-        commentArea.setPrefRowCount(2);
-        commentArea.setWrapText(true);
-        commentArea.setMaxWidth(Double.MAX_VALUE);
-        GridPane.setHgrow(commentArea, javafx.scene.layout.Priority.ALWAYS);
-        ctx.addTextAreaCommitHandlers(commentArea, this::commitComment);
-        ctx.addFieldRow(row++, "Description", commentArea,
-                "Documentation for this element");
+        ctx.addCommentArea(row++, lookup.comment(), this::commitComment);
 
         ComboBox<String> unitBox = ctx.createUnitComboBox(lookup.unit());
         ctx.addComboCommitHandlers(unitBox, this::commitUnit);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/StockForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/StockForm.java
@@ -44,15 +44,7 @@ public class StockForm implements ElementForm {
         ctx.addFieldRow(row++, "Name", nameField,
                 "The name used to reference this stock in equations");
 
-        commentArea = new TextArea(stock.comment() != null ? stock.comment() : "");
-        commentArea.setId("propComment");
-        commentArea.setPrefRowCount(2);
-        commentArea.setWrapText(true);
-        commentArea.setMaxWidth(Double.MAX_VALUE);
-        GridPane.setHgrow(commentArea, Priority.ALWAYS);
-        ctx.addTextAreaCommitHandlers(commentArea, this::commitComment);
-        ctx.addFieldRow(row++, "Description", commentArea,
-                "Documentation for this element");
+        commentArea = ctx.addCommentArea(row++, stock.comment(), this::commitComment);
 
         initialValueField = ctx.createTextField(
                 ElementRenderer.formatValue(stock.initialValue()));

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/VariableForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/VariableForm.java
@@ -44,15 +44,7 @@ public class VariableForm implements ElementForm {
         ctx.addFieldRow(row++, "Name", nameField,
                 "The name used to reference this variable in equations");
 
-        commentArea = new TextArea(v.comment() != null ? v.comment() : "");
-        commentArea.setId("propComment");
-        commentArea.setPrefRowCount(2);
-        commentArea.setWrapText(true);
-        commentArea.setMaxWidth(Double.MAX_VALUE);
-        GridPane.setHgrow(commentArea, Priority.ALWAYS);
-        ctx.addTextAreaCommitHandlers(commentArea, this::commitComment);
-        ctx.addFieldRow(row++, "Description", commentArea,
-                "Documentation for this element");
+        commentArea = ctx.addCommentArea(row++, v.comment(), this::commitComment);
 
         equationField = ctx.createEquationField(v.equation());
         ctx.addEquationCommitHandlers(equationField, this::commitEquation);


### PR DESCRIPTION
## Summary
- Add `FormContext.addCommentArea()` factory method that encapsulates the 8-line comment TextArea configuration pattern
- Replace duplicated blocks in StockForm, FlowForm, VariableForm, LookupForm, and CldVariableForm with one-liner calls

Closes #985

## Test plan
- [x] `mvn clean compile` — full reactor
- [x] `mvn clean test` — all tests pass
- [x] `mvn spotbugs:check` — no findings