### PR TITLE
Extract ExportUtils for shared exporter lookup helpers (#984)

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/ExportUtils.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/ExportUtils.java
@@ -1,0 +1,96 @@
+package systems.courant.sd.io;
+
+import systems.courant.sd.model.def.LookupTableDef;
+import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.VariableDef;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Shared helpers for model exporters (Vensim, XMILE).
+ * Centralises lookup-related parsing that was previously duplicated
+ * in {@code VensimExporter} and {@code XmileExporter}.
+ */
+public final class ExportUtils {
+
+    private static final Pattern LOOKUP_REF_PATTERN = Pattern.compile(
+            "(?i)^LOOKUP\\s*\\(");
+
+    private ExportUtils() {
+    }
+
+    /**
+     * Extracts the lookup table name from a {@code LOOKUP(name, input)} equation.
+     * Returns empty if the equation is not a simple LOOKUP call.
+     */
+    public static Optional<String> extractLookupReference(String equation) {
+        if (equation == null) {
+            return Optional.empty();
+        }
+        String trimmed = equation.strip();
+        if (!LOOKUP_REF_PATTERN.matcher(trimmed).find()) {
+            return Optional.empty();
+        }
+        int openParen = trimmed.indexOf('(');
+        int closeParen = FormatUtils.findMatchingCloseParen(trimmed, openParen);
+        if (closeParen < 0 || closeParen != trimmed.length() - 1) {
+            return Optional.empty();
+        }
+        int comma = FormatUtils.findTopLevelComma(trimmed, openParen + 1);
+        if (comma < 0) {
+            return Optional.empty();
+        }
+        return Optional.of(trimmed.substring(openParen + 1, comma).strip());
+    }
+
+    /**
+     * Extracts the input expression from a {@code LOOKUP(name, input)} equation.
+     * Returns empty if the equation is not a simple LOOKUP call.
+     */
+    public static Optional<String> extractLookupInput(String equation) {
+        if (equation == null) {
+            return Optional.empty();
+        }
+        String trimmed = equation.strip();
+        if (!LOOKUP_REF_PATTERN.matcher(trimmed).find()) {
+            return Optional.empty();
+        }
+        int openParen = trimmed.indexOf('(');
+        int closeParen = FormatUtils.findMatchingCloseParen(trimmed, openParen);
+        if (closeParen < 0 || closeParen != trimmed.length() - 1) {
+            return Optional.empty();
+        }
+        int comma = FormatUtils.findTopLevelComma(trimmed, openParen + 1);
+        if (comma < 0) {
+            return Optional.empty();
+        }
+        return Optional.of(trimmed.substring(comma + 1, closeParen).strip());
+    }
+
+    /**
+     * Collects the names of all lookup tables that are embedded (referenced via
+     * {@code LOOKUP(name, ...)}) in variable equations.
+     */
+    public static Set<String> collectEmbeddedLookupNames(ModelDefinition def) {
+        Set<String> names = new HashSet<>();
+        for (VariableDef v : def.variables()) {
+            extractLookupReference(v.equation()).ifPresent(names::add);
+        }
+        return names;
+    }
+
+    /**
+     * Finds a lookup table definition by name.
+     */
+    public static Optional<LookupTableDef> findLookup(ModelDefinition def, String name) {
+        for (LookupTableDef lt : def.lookupTables()) {
+            if (lt.name().equals(name)) {
+                return Optional.of(lt);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -1,5 +1,6 @@
 package systems.courant.sd.io.vensim;
 
+import systems.courant.sd.io.ExportUtils;
 import systems.courant.sd.io.FormatUtils;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.CldVariableDef;
@@ -62,8 +63,6 @@ public final class VensimExporter {
     private static final Pattern DOUBLE_EQ_PATTERN = Pattern.compile("==");
     private static final Pattern NOT_EQ_PATTERN = Pattern.compile("!=");
     private static final Pattern TIME_PATTERN = Pattern.compile("\\bTIME\\b");
-    private static final Pattern LOOKUP_REF_PATTERN = Pattern.compile(
-            "(?i)^LOOKUP\\s*\\(");
     private static final Pattern EMBEDDED_LOOKUP_PATTERN = Pattern.compile(
             "(?i)\\bLOOKUP\\s*\\(");
     private static final Pattern DELAY_FIXED_EXPORT_PATTERN = Pattern.compile(
@@ -96,7 +95,7 @@ public final class VensimExporter {
         Map<String, String> nameMap = buildNameMap(def);
 
         // Collect lookup names referenced by variables (embedded as WITH LOOKUP)
-        Set<String> embeddedLookupNames = collectEmbeddedLookupNames(def);
+        Set<String> embeddedLookupNames = ExportUtils.collectEmbeddedLookupNames(def);
 
         // Collect synthetic _net_flow names whose equations will be inlined into INTEG
         Set<String> inlinedFlowNames = collectInlinedFlowNames(def);
@@ -240,11 +239,11 @@ public final class VensimExporter {
                 + formatSubscriptSuffix(v.subscripts());
 
         // Check if this variable is a simple LOOKUP(name, input) — convert to WITH LOOKUP
-        Optional<String> lookupNameOpt = extractLookupReference(v.equation());
+        Optional<String> lookupNameOpt = ExportUtils.extractLookupReference(v.equation());
         if (lookupNameOpt.isPresent()) {
-            Optional<LookupTableDef> lookupOpt = findLookup(def, lookupNameOpt.get());
+            Optional<LookupTableDef> lookupOpt = ExportUtils.findLookup(def, lookupNameOpt.get());
             if (lookupOpt.isPresent()) {
-                Optional<String> inputExprOpt = extractLookupInput(v.equation());
+                Optional<String> inputExprOpt = ExportUtils.extractLookupInput(v.equation());
                 if (inputExprOpt.isPresent()) {
                     String vensimInput = toVensimExpr(inputExprOpt.get(), nameMap);
                     String lookupData = formatLookupData(lookupOpt.get());
@@ -536,7 +535,7 @@ public final class VensimExporter {
             }
             int funcStart = m.start();
             int openParen = m.end() - 1;
-            int closeParen = findClosingParen(expr, openParen);
+            int closeParen = FormatUtils.findMatchingCloseParen(expr, openParen);
             if (closeParen < 0) {
                 break;
             }
@@ -590,7 +589,7 @@ public final class VensimExporter {
         String trimmed = condition.strip();
         // Check for "(expr) == 0" pattern with balanced parens
         if (trimmed.startsWith("(")) {
-            int closeParen = findClosingParen(trimmed, 0);
+            int closeParen = FormatUtils.findMatchingCloseParen(trimmed, 0);
             if (closeParen > 0) {
                 String remainder = trimmed.substring(closeParen + 1).strip();
                 if (remainder.matches("==\\s*0")) {
@@ -889,65 +888,6 @@ public final class VensimExporter {
         return inlined;
     }
 
-    private static Set<String> collectEmbeddedLookupNames(ModelDefinition def) {
-        Set<String> names = new HashSet<>();
-        for (VariableDef v : def.variables()) {
-            extractLookupReference(v.equation()).ifPresent(names::add);
-        }
-        return names;
-    }
-
-    /**
-     * Extracts the lookup table name from a simple {@code LOOKUP(name, input)} expression.
-     * Only matches when the entire expression is a single LOOKUP call (no surrounding operators).
-     */
-    static Optional<String> extractLookupReference(String equation) {
-        if (equation == null) {
-            return Optional.empty();
-        }
-        String trimmed = equation.strip();
-        Matcher m = LOOKUP_REF_PATTERN.matcher(trimmed);
-        if (!m.find()) {
-            return Optional.empty();
-        }
-        int openParen = trimmed.indexOf('(');
-        int closeParen = findClosingParen(trimmed, openParen);
-        if (closeParen < 0 || closeParen != trimmed.length() - 1) {
-            // Not a simple LOOKUP(...) — there's content after the closing paren
-            return Optional.empty();
-        }
-        int comma = findTopLevelComma(trimmed, openParen + 1);
-        if (comma < 0) {
-            return Optional.empty();
-        }
-        return Optional.of(trimmed.substring(openParen + 1, comma).strip());
-    }
-
-    /**
-     * Extracts the input expression from a simple {@code LOOKUP(name, input)} expression.
-     * Only matches when the entire expression is a single LOOKUP call.
-     */
-    static Optional<String> extractLookupInput(String equation) {
-        if (equation == null) {
-            return Optional.empty();
-        }
-        String trimmed = equation.strip();
-        Matcher m = LOOKUP_REF_PATTERN.matcher(trimmed);
-        if (!m.find()) {
-            return Optional.empty();
-        }
-        int openParen = trimmed.indexOf('(');
-        int closeParen = findClosingParen(trimmed, openParen);
-        if (closeParen < 0 || closeParen != trimmed.length() - 1) {
-            return Optional.empty();
-        }
-        int comma = findTopLevelComma(trimmed, openParen + 1);
-        if (comma < 0) {
-            return Optional.empty();
-        }
-        return Optional.of(trimmed.substring(comma + 1, closeParen).strip());
-    }
-
     private static String formatLookupData(LookupTableDef lookup) {
         double[] xVals = lookup.xValues();
         double[] yVals = lookup.yValues();
@@ -980,21 +920,6 @@ public final class VensimExporter {
         return range + "," + pairs;
     }
 
-    private static Optional<LookupTableDef> findLookup(ModelDefinition def, String name) {
-        for (LookupTableDef lt : def.lookupTables()) {
-            if (lt.name().equals(name)) {
-                return Optional.of(lt);
-            }
-        }
-        return Optional.empty();
-    }
-
-    /**
-     * Replaces LOOKUP(name, input) calls in a complex expression with the lookup's
-     * table-call syntax: {@code name(input)}. This allows the downstream Vensim name
-     * denormalization to produce valid .mdl output where the lookup is referenced by
-     * its standalone table name rather than through the LOOKUP() wrapper.
-     */
     /**
      * Replaces LOOKUP(name, input) calls in a complex expression with table-call
      * syntax: {@code name(input)}. The standalone lookup table must still be emitted
@@ -1010,19 +935,19 @@ public final class VensimExporter {
         while (m.find()) {
             int funcStart = m.start();
             int openParen = m.end() - 1;
-            int closeParen = findClosingParen(expr, openParen);
+            int closeParen = FormatUtils.findMatchingCloseParen(expr, openParen);
             if (closeParen < 0) {
                 break;
             }
             String argsContent = expr.substring(openParen + 1, closeParen);
-            int comma = findTopLevelComma(argsContent, 0);
+            int comma = FormatUtils.findTopLevelComma(argsContent, 0);
             if (comma < 0) {
                 break;
             }
             String lookupName = argsContent.substring(0, comma).strip();
             String input = argsContent.substring(comma + 1).strip();
             // Only inline if the lookup table exists in the model
-            Optional<LookupTableDef> lookupOpt = findLookup(def, lookupName);
+            Optional<LookupTableDef> lookupOpt = ExportUtils.findLookup(def, lookupName);
             if (lookupOpt.isPresent()) {
                 // Do NOT add to embeddedLookupNames — standalone table must still be emitted
                 String replacement = lookupName + "(" + input + ")";
@@ -1035,23 +960,4 @@ public final class VensimExporter {
         return expr;
     }
 
-    private static int findClosingParen(String content, int openParenPos) {
-        int depth = 1;
-        for (int i = openParenPos + 1; i < content.length(); i++) {
-            char c = content.charAt(i);
-            if (c == '(') {
-                depth++;
-            } else if (c == ')') {
-                depth--;
-                if (depth == 0) {
-                    return i;
-                }
-            }
-        }
-        return -1;
-    }
-
-    private static int findTopLevelComma(String content, int startPos) {
-        return FormatUtils.findTopLevelComma(content, startPos);
-    }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
@@ -1,5 +1,6 @@
 package systems.courant.sd.io.xmile;
 
+import systems.courant.sd.io.ExportUtils;
 import systems.courant.sd.io.FormatUtils;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.FlowDef;
@@ -175,7 +176,7 @@ public final class XmileExporter {
                 XmileConstants.NAMESPACE_URI, XmileConstants.VARIABLES);
         modelElem.appendChild(variablesElem);
 
-        Set<String> embeddedLookupNames = collectEmbeddedLookupNames(def);
+        Set<String> embeddedLookupNames = ExportUtils.collectEmbeddedLookupNames(def);
 
         for (StockDef stock : def.stocks()) {
             writeStock(doc, variablesElem, stock, def);
@@ -352,12 +353,12 @@ public final class XmileExporter {
         elem.setAttribute(XmileConstants.ATTR_NAME, v.name());
 
         // Check if this variable references a lookup — if so, embed the gf
-        Optional<String> lookupNameOpt = extractLookupReference(v.equation());
+        Optional<String> lookupNameOpt = ExportUtils.extractLookupReference(v.equation());
         if (lookupNameOpt.isPresent()) {
-            Optional<LookupTableDef> lookupOpt = findLookup(def, lookupNameOpt.get());
+            Optional<LookupTableDef> lookupOpt = ExportUtils.findLookup(def, lookupNameOpt.get());
             if (lookupOpt.isPresent()) {
                 // Extract the input expression from LOOKUP(name, input)
-                String inputExpr = extractLookupInput(v.equation())
+                String inputExpr = ExportUtils.extractLookupInput(v.equation())
                         .orElse(v.equation());
                 Element eqn = doc.createElementNS(
                         XmileConstants.NAMESPACE_URI, XmileConstants.EQN);
@@ -456,69 +457,6 @@ public final class XmileExporter {
         gf.appendChild(ypts);
 
         parent.appendChild(gf);
-    }
-
-    private static Set<String> collectEmbeddedLookupNames(ModelDefinition def) {
-        Set<String> names = new HashSet<>();
-        for (VariableDef v : def.variables()) {
-            extractLookupReference(v.equation()).ifPresent(names::add);
-        }
-        return names;
-    }
-
-    /**
-     * Extracts the lookup table name from a LOOKUP(name, input) expression.
-     */
-    static Optional<String> extractLookupReference(String equation) {
-        if (equation == null) {
-            return Optional.empty();
-        }
-        String trimmed = equation.strip();
-        if (!trimmed.toUpperCase().startsWith("LOOKUP(")) {
-            return Optional.empty();
-        }
-        int openParen = trimmed.indexOf('(');
-        int comma = findTopLevelComma(trimmed, openParen + 1);
-        if (comma < 0) {
-            return Optional.empty();
-        }
-        return Optional.of(trimmed.substring(openParen + 1, comma).strip());
-    }
-
-    /**
-     * Extracts the input expression from a LOOKUP(name, input) expression.
-     */
-    static Optional<String> extractLookupInput(String equation) {
-        if (equation == null) {
-            return Optional.empty();
-        }
-        String trimmed = equation.strip();
-        if (!trimmed.toUpperCase().startsWith("LOOKUP(")) {
-            return Optional.empty();
-        }
-        int openParen = trimmed.indexOf('(');
-        int comma = findTopLevelComma(trimmed, openParen + 1);
-        if (comma < 0) {
-            return Optional.empty();
-        }
-        int closeParen = FormatUtils.findMatchingCloseParen(trimmed, openParen);
-        if (closeParen < 0 || closeParen <= comma) {
-            return Optional.empty();
-        }
-        return Optional.of(trimmed.substring(comma + 1, closeParen).strip());
-    }
-
-    private static int findTopLevelComma(String content, int startPos) {
-        return FormatUtils.findTopLevelComma(content, startPos);
-    }
-
-    private static Optional<LookupTableDef> findLookup(ModelDefinition def, String name) {
-        for (LookupTableDef lt : def.lookupTables()) {
-            if (lt.name().equals(name)) {
-                return Optional.of(lt);
-            }
-        }
-        return Optional.empty();
     }
 
     private static String joinDoubles(double[] values) {

--- a/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileExporterTest.java
@@ -1,5 +1,6 @@
 package systems.courant.sd.io.xmile;
 
+import systems.courant.sd.io.ExportUtils;
 import systems.courant.sd.io.ImportResult;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.FlowDef;
@@ -376,38 +377,38 @@ class XmileExporterTest {
 
         @Test
         void shouldExtractLookupReference() {
-            assertThat(XmileExporter.extractLookupReference("LOOKUP(my_table, x + 1)"))
+            assertThat(ExportUtils.extractLookupReference("LOOKUP(my_table, x + 1)"))
                     .hasValue("my_table");
         }
 
         @Test
         void shouldExtractLookupInput() {
-            assertThat(XmileExporter.extractLookupInput("LOOKUP(my_table, x + 1)"))
+            assertThat(ExportUtils.extractLookupInput("LOOKUP(my_table, x + 1)"))
                     .hasValue("x + 1");
         }
 
         @Test
         void shouldReturnEmptyForNonLookup() {
-            assertThat(XmileExporter.extractLookupReference("a + b")).isEmpty();
-            assertThat(XmileExporter.extractLookupInput("a + b")).isEmpty();
+            assertThat(ExportUtils.extractLookupReference("a + b")).isEmpty();
+            assertThat(ExportUtils.extractLookupInput("a + b")).isEmpty();
         }
 
         @Test
-        void shouldExtractInputWithTrailingExpression() {
-            // Issue #631: lastIndexOf(')') would grab ') + foo(y' instead of just 'x'
-            assertThat(XmileExporter.extractLookupInput("LOOKUP(name, x) + foo(y)"))
-                    .hasValue("x");
+        void shouldRejectNonSimpleLookupWithTrailingExpression() {
+            // Not a simple LOOKUP(...) call — there's "+ foo(y)" after the closing paren
+            assertThat(ExportUtils.extractLookupInput("LOOKUP(name, x) + foo(y)"))
+                    .isEmpty();
         }
 
         @Test
         void shouldExtractInputWithNestedParens() {
-            assertThat(XmileExporter.extractLookupInput("LOOKUP(my_table, max(a, b))"))
+            assertThat(ExportUtils.extractLookupInput("LOOKUP(my_table, max(a, b))"))
                     .hasValue("max(a, b)");
         }
 
         @Test
         void shouldReturnEmptyForUnmatchedParen() {
-            assertThat(XmileExporter.extractLookupInput("LOOKUP(name, x")).isEmpty();
+            assertThat(ExportUtils.extractLookupInput("LOOKUP(name, x")).isEmpty();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extract `ExportUtils` utility class in `systems.courant.sd.io` with shared methods: `extractLookupReference`, `extractLookupInput`, `collectEmbeddedLookupNames`, `findLookup`
- Remove duplicated methods from `VensimExporter` and `XmileExporter`
- Replace VensimExporter's private `findClosingParen` with existing `FormatUtils.findMatchingCloseParen`
- Unify the stricter validation (reject non-simple LOOKUP calls with trailing expressions)

Closes #984

## Test plan
- [x] `mvn clean compile` — full reactor
- [x] `mvn clean test` — all tests pass (one test updated for stricter validation)
- [x] `mvn spotbugs:check` — no findings