### PR TITLE
Extract Bézier curve stroking into CausalLinkGeometry (#982)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CausalLinkGeometry.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CausalLinkGeometry.java
@@ -2,6 +2,8 @@ package systems.courant.sd.app.canvas;
 
 import systems.courant.sd.model.def.CausalLinkDef;
 
+import javafx.scene.canvas.GraphicsContext;
+
 import java.util.List;
 
 /**
@@ -254,5 +256,46 @@ public final class CausalLinkGeometry {
             }
         }
         return minDist;
+    }
+
+    private static final int CURVE_SEGMENTS = 30;
+
+    /**
+     * Strokes a quadratic Bézier curve on the graphics context using line segments.
+     *
+     * @param stopT parameter value to stop at (1.0 for full curve, &lt;1.0 to leave room for arrowhead)
+     */
+    public static void strokeQuadCurve(GraphicsContext gc,
+                                        double fromX, double fromY,
+                                        double cpX, double cpY,
+                                        double toX, double toY, double stopT) {
+        gc.beginPath();
+        gc.moveTo(fromX, fromY);
+        for (int i = 1; i <= CURVE_SEGMENTS; i++) {
+            double t = stopT * i / CURVE_SEGMENTS;
+            double[] pt = evaluate(fromX, fromY, cpX, cpY, toX, toY, t);
+            gc.lineTo(pt[0], pt[1]);
+        }
+        gc.stroke();
+    }
+
+    /**
+     * Strokes a cubic Bézier curve on the graphics context using line segments.
+     *
+     * @param stopT parameter value to stop at (1.0 for full curve, &lt;1.0 to leave room for arrowhead)
+     */
+    public static void strokeCubicCurve(GraphicsContext gc,
+                                         double p0x, double p0y,
+                                         double cp1x, double cp1y,
+                                         double cp2x, double cp2y,
+                                         double p1x, double p1y, double stopT) {
+        gc.beginPath();
+        gc.moveTo(p0x, p0y);
+        for (int i = 1; i <= CURVE_SEGMENTS; i++) {
+            double t = stopT * i / CURVE_SEGMENTS;
+            double[] pt = evaluateCubic(p0x, p0y, cp1x, cp1y, cp2x, cp2y, p1x, p1y, t);
+            gc.lineTo(pt[0], pt[1]);
+        }
+        gc.stroke();
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CausalTraceRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CausalTraceRenderer.java
@@ -107,14 +107,6 @@ public final class CausalTraceRenderer {
         gc.setLineWidth(EDGE_LINE_WIDTH);
         gc.setLineDashes();
 
-        gc.beginPath();
-        gc.moveTo(fromX, fromY);
-        int segments = 30;
-        for (int i = 1; i <= segments; i++) {
-            double t = (double) i / segments;
-            double[] pt = CausalLinkGeometry.evaluate(fromX, fromY, cpX, cpY, toX, toY, t);
-            gc.lineTo(pt[0], pt[1]);
-        }
-        gc.stroke();
+        CausalLinkGeometry.strokeQuadCurve(gc, fromX, fromY, cpX, cpY, toX, toY, 1.0);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ConnectionRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ConnectionRenderer.java
@@ -173,16 +173,7 @@ public final class ConnectionRenderer {
             gc.setLineDashes();
         }
 
-        gc.beginPath();
-        gc.moveTo(fromX, fromY);
-        // Draw the curve using sampled line segments for precision
-        int segments = 30;
-        for (int i = 1; i <= segments; i++) {
-            double t = stopT * i / segments;
-            double[] pt = CausalLinkGeometry.evaluate(fromX, fromY, cp.x(), cp.y(), toX, toY, t);
-            gc.lineTo(pt[0], pt[1]);
-        }
-        gc.stroke();
+        CausalLinkGeometry.strokeQuadCurve(gc, fromX, fromY, cp.x(), cp.y(), toX, toY, stopT);
         gc.setLineDashes();
 
         // Arrowhead oriented along the curve tangent at the tip
@@ -250,18 +241,10 @@ public final class ConnectionRenderer {
             gc.setLineDashes();
         }
 
-        int segments = 30;
-        gc.beginPath();
-        gc.moveTo(startX, startY);
         // Stop a bit before the end for the arrowhead
         double stopT = 0.9;
-        for (int i = 1; i <= segments; i++) {
-            double t = stopT * i / segments;
-            double[] pt = CausalLinkGeometry.evaluateCubic(
-                    startX, startY, cp1X, cp1Y, cp2X, cp2Y, endX, endY, t);
-            gc.lineTo(pt[0], pt[1]);
-        }
-        gc.stroke();
+        CausalLinkGeometry.strokeCubicCurve(gc,
+                startX, startY, cp1X, cp1Y, cp2X, cp2Y, endX, endY, stopT);
         gc.setLineDashes();
 
         // Arrowhead at the end

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/FeedbackLoopRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/FeedbackLoopRenderer.java
@@ -129,15 +129,7 @@ public final class FeedbackLoopRenderer {
         gc.setLineWidth(EDGE_LINE_WIDTH);
         gc.setLineDashes();
 
-        gc.beginPath();
-        gc.moveTo(fromX, fromY);
-        int segments = 30;
-        for (int i = 1; i <= segments; i++) {
-            double t = (double) i / segments;
-            double[] pt = CausalLinkGeometry.evaluate(fromX, fromY, cpX, cpY, toX, toY, t);
-            gc.lineTo(pt[0], pt[1]);
-        }
-        gc.stroke();
+        CausalLinkGeometry.strokeQuadCurve(gc, fromX, fromY, cpX, cpY, toX, toY, 1.0);
     }
 
     /**
@@ -148,16 +140,8 @@ public final class FeedbackLoopRenderer {
         gc.setLineWidth(EDGE_LINE_WIDTH);
         gc.setLineDashes();
 
-        gc.beginPath();
-        gc.moveTo(loopPts[0], loopPts[1]);
-        int segments = 30;
-        for (int i = 1; i <= segments; i++) {
-            double t = (double) i / segments;
-            double[] pt = CausalLinkGeometry.evaluateCubic(
-                    loopPts[0], loopPts[1], loopPts[2], loopPts[3],
-                    loopPts[4], loopPts[5], loopPts[6], loopPts[7], t);
-            gc.lineTo(pt[0], pt[1]);
-        }
-        gc.stroke();
+        CausalLinkGeometry.strokeCubicCurve(gc,
+                loopPts[0], loopPts[1], loopPts[2], loopPts[3],
+                loopPts[4], loopPts[5], loopPts[6], loopPts[7], 1.0);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/SelectionRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/SelectionRenderer.java
@@ -89,7 +89,7 @@ public final class SelectionRenderer {
         gc.setStroke(ColorPalette.HOVER);
         gc.setLineWidth(3.0);
         gc.setLineDashes();
-        strokeQuadCurve(gc, fromX, fromY, cpX, cpY, toX, toY);
+        CausalLinkGeometry.strokeQuadCurve(gc, fromX, fromY, cpX, cpY, toX, toY, 1.0);
     }
 
     /**
@@ -102,23 +102,8 @@ public final class SelectionRenderer {
         gc.setStroke(SELECTION_COLOR);
         gc.setLineWidth(3.0);
         gc.setLineDashes(SELECTION_DASH_LENGTH, SELECTION_DASH_GAP);
-        strokeQuadCurve(gc, fromX, fromY, cpX, cpY, toX, toY);
+        CausalLinkGeometry.strokeQuadCurve(gc, fromX, fromY, cpX, cpY, toX, toY, 1.0);
         gc.setLineDashes();
-    }
-
-    private static void strokeQuadCurve(GraphicsContext gc,
-                                         double fromX, double fromY,
-                                         double cpX, double cpY,
-                                         double toX, double toY) {
-        gc.beginPath();
-        gc.moveTo(fromX, fromY);
-        int segments = 30;
-        for (int i = 1; i <= segments; i++) {
-            double t = (double) i / segments;
-            double[] pt = CausalLinkGeometry.evaluate(fromX, fromY, cpX, cpY, toX, toY, t);
-            gc.lineTo(pt[0], pt[1]);
-        }
-        gc.stroke();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add `strokeQuadCurve()` and `strokeCubicCurve()` static methods to `CausalLinkGeometry`
- Replace 6 duplicated Bézier stroking loops across ConnectionRenderer, FeedbackLoopRenderer, CausalTraceRenderer, and SelectionRenderer

Closes #982

## Test plan
- [x] `mvn clean compile` — full reactor
- [x] `mvn clean test` — all tests pass
- [x] `mvn spotbugs:check` — no findings