### PR TITLE
Extract AbstractTutorialDialog and StyledText for dialog deduplication (#980)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/AbstractTutorialDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/AbstractTutorialDialog.java
@@ -1,0 +1,58 @@
+package systems.courant.sd.app.canvas.dialogs;
+
+import javafx.geometry.Insets;
+import javafx.scene.Scene;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.text.TextFlow;
+import javafx.stage.Stage;
+
+import java.util.List;
+
+/**
+ * Base class for tabbed tutorial and reference dialogs. Provides the common
+ * TabPane scaffolding and a {@link #createTab(String, TextFlow)} helper so
+ * subclasses only need to supply tab content.
+ */
+public abstract class AbstractTutorialDialog extends Stage {
+
+    private final double contentMaxWidth;
+
+    /**
+     * @param title           the dialog window title
+     * @param width           scene width
+     * @param height          scene height
+     * @param contentMaxWidth max width for TextFlow content inside tabs
+     */
+    protected AbstractTutorialDialog(String title, double width, double height,
+                                      double contentMaxWidth) {
+        this.contentMaxWidth = contentMaxWidth;
+        setTitle(title);
+
+        TabPane tabPane = new TabPane();
+        tabPane.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
+        tabPane.getTabs().addAll(buildTabs());
+
+        setScene(new Scene(tabPane, width, height));
+    }
+
+    /**
+     * Subclasses return the ordered list of tabs to display.
+     */
+    protected abstract List<Tab> buildTabs();
+
+    /**
+     * Creates a scrollable tab wrapping a {@link TextFlow} content pane.
+     */
+    protected Tab createTab(String title, TextFlow content) {
+        content.setPadding(new Insets(16));
+        content.setLineSpacing(4);
+        content.setMaxWidth(contentMaxWidth);
+
+        ScrollPane scroll = new ScrollPane(content);
+        scroll.setFitToWidth(true);
+
+        return new Tab(title, scroll);
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ExpressionLanguageDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ExpressionLanguageDialog.java
@@ -1,5 +1,8 @@
 package systems.courant.sd.app.canvas.dialogs;
 
+import static systems.courant.sd.app.canvas.dialogs.StyledText.bold;
+import static systems.courant.sd.app.canvas.dialogs.StyledText.plain;
+
 import systems.courant.sd.model.compile.FunctionDoc;
 import systems.courant.sd.model.compile.FunctionDocRegistry;
 
@@ -294,16 +297,6 @@ public class ExpressionLanguageDialog extends Stage {
         }
 
         return new VBox(4, header, grid);
-    }
-
-    private Text bold(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-weight: bold;");
-        return text;
-    }
-
-    private Text plain(String content) {
-        return new Text(content);
     }
 
     private Text mono(String content) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/QuickstartDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/QuickstartDialog.java
@@ -1,28 +1,26 @@
 package systems.courant.sd.app.canvas.dialogs;
 
-import javafx.geometry.Insets;
-import javafx.scene.Scene;
-import javafx.scene.control.ScrollPane;
+import static systems.courant.sd.app.canvas.dialogs.StyledText.*;
+
 import javafx.scene.control.Tab;
-import javafx.scene.control.TabPane;
-import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
-import javafx.stage.Stage;
+
+import java.util.List;
 
 /**
  * A step-by-step quickstart tutorial dialog that walks a new user through
  * building a coffee cooling model. Mirrors the content of userdocs/Quickstart.md
  * in an in-app help window.
  */
-public class QuickstartDialog extends Stage {
+public class QuickstartDialog extends AbstractTutorialDialog {
 
     public QuickstartDialog() {
-        setTitle("Getting Started — Build Your First Model");
+        super("Getting Started — Build Your First Model", 660, 540, 610);
+    }
 
-        TabPane tabs = new TabPane();
-        tabs.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
-
-        tabs.getTabs().addAll(
+    @Override
+    protected List<Tab> buildTabs() {
+        return List.of(
                 createTab("1. The Idea", ideaTab()),
                 createTab("2. Place Elements", placeElementsTab()),
                 createTab("3. Connect & Equate", connectTab()),
@@ -30,20 +28,6 @@ public class QuickstartDialog extends Stage {
                 createTab("5. Experiment", experimentTab()),
                 createTab("6. Next Steps", nextStepsTab())
         );
-
-        Scene scene = new Scene(tabs, 660, 540);
-        setScene(scene);
-    }
-
-    private Tab createTab(String title, TextFlow content) {
-        content.setPadding(new Insets(16));
-        content.setLineSpacing(4);
-        content.setMaxWidth(610);
-
-        ScrollPane scroll = new ScrollPane(content);
-        scroll.setFitToWidth(true);
-
-        return new Tab(title, scroll);
     }
 
     private TextFlow ideaTab() {
@@ -288,25 +272,4 @@ public class QuickstartDialog extends Stage {
         );
     }
 
-    private Text bold(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-weight: bold;");
-        return text;
-    }
-
-    private Text plain(String content) {
-        return new Text(content);
-    }
-
-    private Text mono(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-family: monospace; -fx-font-weight: bold;");
-        return text;
-    }
-
-    private Text italic(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-style: italic;");
-        return text;
-    }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SdConceptsDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SdConceptsDialog.java
@@ -1,26 +1,24 @@
 package systems.courant.sd.app.canvas.dialogs;
 
-import javafx.geometry.Insets;
-import javafx.scene.Scene;
-import javafx.scene.control.ScrollPane;
+import static systems.courant.sd.app.canvas.dialogs.StyledText.*;
+
 import javafx.scene.control.Tab;
-import javafx.scene.control.TabPane;
-import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
-import javafx.stage.Stage;
+
+import java.util.List;
 
 /**
  * A help dialog that explains core System Dynamics concepts.
  */
-public class SdConceptsDialog extends Stage {
+public class SdConceptsDialog extends AbstractTutorialDialog {
 
     public SdConceptsDialog() {
-        setTitle("SD Concepts");
+        super("SD Concepts", 640, 520, 580);
+    }
 
-        TabPane tabs = new TabPane();
-        tabs.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
-
-        tabs.getTabs().addAll(
+    @Override
+    protected List<Tab> buildTabs() {
+        return List.of(
                 createTab("Overview", overviewText()),
                 createTab("Stocks", stocksText()),
                 createTab("Flows", flowsText()),
@@ -29,21 +27,6 @@ public class SdConceptsDialog extends Stage {
                 createTab("Causal Loops", causalLoopsText()),
                 createTab("Simulation", simulationText())
         );
-
-        Scene scene = new Scene(tabs, 640, 520);
-        setScene(scene);
-    }
-
-    private Tab createTab(String title, TextFlow content) {
-        content.setPadding(new Insets(16));
-        content.setLineSpacing(4);
-        content.setMaxWidth(580);
-
-        ScrollPane scroll = new ScrollPane(content);
-        scroll.setFitToWidth(true);
-
-        Tab tab = new Tab(title, scroll);
-        return tab;
     }
 
     private TextFlow overviewText() {
@@ -256,13 +239,4 @@ public class SdConceptsDialog extends Stage {
         );
     }
 
-    private Text bold(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-weight: bold;");
-        return text;
-    }
-
-    private Text plain(String content) {
-        return new Text(content);
-    }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SirTutorialDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SirTutorialDialog.java
@@ -1,28 +1,26 @@
 package systems.courant.sd.app.canvas.dialogs;
 
-import javafx.geometry.Insets;
-import javafx.scene.Scene;
-import javafx.scene.control.ScrollPane;
+import static systems.courant.sd.app.canvas.dialogs.StyledText.*;
+
 import javafx.scene.control.Tab;
-import javafx.scene.control.TabPane;
-import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
-import javafx.stage.Stage;
+
+import java.util.List;
 
 /**
  * A step-by-step tutorial dialog that walks the user through building an
  * SIR epidemic model. Introduces reinforcing feedback, balancing feedback,
  * multi-stock systems, and S-shaped growth.
  */
-public class SirTutorialDialog extends Stage {
+public class SirTutorialDialog extends AbstractTutorialDialog {
 
     public SirTutorialDialog() {
-        setTitle("Tutorial — SIR Epidemic Model");
+        super("Tutorial — SIR Epidemic Model", 660, 540, 610);
+    }
 
-        TabPane tabs = new TabPane();
-        tabs.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
-
-        tabs.getTabs().addAll(
+    @Override
+    protected List<Tab> buildTabs() {
+        return List.of(
                 createTab("1. The Idea", ideaTab()),
                 createTab("2. Stocks", stocksTab()),
                 createTab("3. Flows", flowsTab()),
@@ -31,20 +29,6 @@ public class SirTutorialDialog extends Stage {
                 createTab("6. Experiment", experimentTab()),
                 createTab("7. Key Takeaways", takeawaysTab())
         );
-
-        Scene scene = new Scene(tabs, 660, 540);
-        setScene(scene);
-    }
-
-    private Tab createTab(String title, TextFlow content) {
-        content.setPadding(new Insets(16));
-        content.setLineSpacing(4);
-        content.setMaxWidth(610);
-
-        ScrollPane scroll = new ScrollPane(content);
-        scroll.setFitToWidth(true);
-
-        return new Tab(title, scroll);
     }
 
     private TextFlow ideaTab() {
@@ -308,25 +292,4 @@ public class SirTutorialDialog extends Stage {
         );
     }
 
-    private Text bold(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-weight: bold;");
-        return text;
-    }
-
-    private Text plain(String content) {
-        return new Text(content);
-    }
-
-    private Text mono(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-family: monospace; -fx-font-weight: bold;");
-        return text;
-    }
-
-    private Text italic(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-style: italic;");
-        return text;
-    }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/StyledText.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/StyledText.java
@@ -1,0 +1,36 @@
+package systems.courant.sd.app.canvas.dialogs;
+
+import javafx.scene.text.Text;
+
+/**
+ * Static factory methods for styled {@link Text} nodes used in tutorial
+ * and reference dialogs. Eliminates the per-dialog duplication of
+ * {@code bold()}, {@code plain()}, {@code mono()}, and {@code italic()} helpers.
+ */
+public final class StyledText {
+
+    private StyledText() {
+    }
+
+    public static Text bold(String s) {
+        Text t = new Text(s);
+        t.setStyle("-fx-font-weight: bold;");
+        return t;
+    }
+
+    public static Text plain(String s) {
+        return new Text(s);
+    }
+
+    public static Text mono(String s) {
+        Text t = new Text(s);
+        t.setStyle("-fx-font-family: monospace; -fx-font-weight: bold;");
+        return t;
+    }
+
+    public static Text italic(String s) {
+        Text t = new Text(s);
+        t.setStyle("-fx-font-style: italic;");
+        return t;
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SupplyChainTutorialDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SupplyChainTutorialDialog.java
@@ -1,28 +1,26 @@
 package systems.courant.sd.app.canvas.dialogs;
 
-import javafx.geometry.Insets;
-import javafx.scene.Scene;
-import javafx.scene.control.ScrollPane;
+import static systems.courant.sd.app.canvas.dialogs.StyledText.*;
+
 import javafx.scene.control.Tab;
-import javafx.scene.control.TabPane;
-import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
-import javafx.stage.Stage;
+
+import java.util.List;
 
 /**
  * A step-by-step tutorial dialog that walks the user through building a
  * supply chain / inventory model. Introduces delays, oscillation from
  * delayed feedback, and the bullwhip effect.
  */
-public class SupplyChainTutorialDialog extends Stage {
+public class SupplyChainTutorialDialog extends AbstractTutorialDialog {
 
     public SupplyChainTutorialDialog() {
-        setTitle("Tutorial — Supply Chain Model");
+        super("Tutorial — Supply Chain Model", 660, 540, 610);
+    }
 
-        TabPane tabs = new TabPane();
-        tabs.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
-
-        tabs.getTabs().addAll(
+    @Override
+    protected List<Tab> buildTabs() {
+        return List.of(
                 createTab("1. The Idea", ideaTab()),
                 createTab("2. Stocks", stocksTab()),
                 createTab("3. Flows", flowsTab()),
@@ -31,20 +29,6 @@ public class SupplyChainTutorialDialog extends Stage {
                 createTab("6. Experiment", experimentTab()),
                 createTab("7. Key Takeaways", takeawaysTab())
         );
-
-        Scene scene = new Scene(tabs, 660, 540);
-        setScene(scene);
-    }
-
-    private Tab createTab(String title, TextFlow content) {
-        content.setPadding(new Insets(16));
-        content.setLineSpacing(4);
-        content.setMaxWidth(610);
-
-        ScrollPane scroll = new ScrollPane(content);
-        scroll.setFitToWidth(true);
-
-        return new Tab(title, scroll);
     }
 
     private TextFlow ideaTab() {
@@ -309,25 +293,4 @@ public class SupplyChainTutorialDialog extends Stage {
         );
     }
 
-    private Text bold(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-weight: bold;");
-        return text;
-    }
-
-    private Text plain(String content) {
-        return new Text(content);
-    }
-
-    private Text mono(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-family: monospace; -fx-font-weight: bold;");
-        return text;
-    }
-
-    private Text italic(String content) {
-        Text text = new Text(content);
-        text.setStyle("-fx-font-style: italic;");
-        return text;
-    }
 }


### PR DESCRIPTION
## Summary
- Extract `StyledText` utility with `bold()`, `plain()`, `mono()`, `italic()` static helpers
- Extract `AbstractTutorialDialog` base class with TabPane scaffolding and `createTab()`
- Refactor SirTutorialDialog, SupplyChainTutorialDialog, QuickstartDialog, SdConceptsDialog to extend base class
- Refactor ExpressionLanguageDialog to use StyledText for bold/plain helpers

Closes #980

## Test plan
- [x] `mvn clean compile` — full reactor
- [x] `mvn clean test` — all tests pass
- [x] `mvn spotbugs:check` — no findings