### PR TITLE
Fix 11 low-priority code quality issues

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/CourantApp.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/CourantApp.java
@@ -9,7 +9,6 @@ import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -20,7 +19,7 @@ public class CourantApp extends Application {
 
     static final double DECORATION_ALLOWANCE = 40;
 
-    private final List<ModelWindow> openWindows = new ArrayList<>();
+    private int openWindowCount;
     private final Clipboard clipboard = new Clipboard();
 
     @Override
@@ -33,11 +32,11 @@ public class CourantApp extends Application {
     }
 
     private void openWindow(Stage stage) {
-        ModelWindow window = new ModelWindow(stage, this, clipboard);
-        openWindows.add(window);
+        new ModelWindow(stage, this, clipboard);
+        openWindowCount++;
         stage.setOnHidden(e -> {
-            openWindows.remove(window);
-            if (openWindows.isEmpty()) {
+            openWindowCount--;
+            if (openWindowCount == 0) {
                 // Close any remaining windows (help dialogs, etc.)
                 List.copyOf(Window.getWindows()).forEach(w -> {
                     if (w instanceof Stage s) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationAutoComplete.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationAutoComplete.java
@@ -163,7 +163,21 @@ public final class EquationAutoComplete {
         if (tf == null) {
             return;
         }
-        detach(new TextFieldEquationField(tf));
+        Object obj = tf.getProperties().remove(PROP_STATE);
+        if (obj instanceof State state) {
+            state.hidePopup();
+            state.hideHint();
+            tf.removeEventFilter(KeyEvent.KEY_PRESSED, state.keyFilter);
+            tf.textProperty().removeListener(state.textListener);
+            tf.caretPositionProperty().removeListener(state.caretListener);
+            tf.focusedProperty().removeListener(state.focusListener);
+        }
+        Object original = tf.getProperties().remove(PROP_ORIGINAL_ACTION);
+        if (original instanceof EventHandler<?> handler) {
+            @SuppressWarnings("unchecked")
+            EventHandler<ActionEvent> actionHandler = (EventHandler<ActionEvent>) handler;
+            tf.setOnAction(actionHandler);
+        }
     }
 
     /** Returns true if the autocomplete popup is showing for the given {@link TextField}. */
@@ -171,7 +185,8 @@ public final class EquationAutoComplete {
         if (tf == null) {
             return false;
         }
-        return isPopupShowing(new TextFieldEquationField(tf));
+        Object obj = tf.getProperties().get(PROP_STATE);
+        return obj instanceof State state && state.popup != null && state.popup.isShowing();
     }
 
     // ── Token extraction (package-private for testing) ──────────────────

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ExportBounds.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ExportBounds.java
@@ -31,7 +31,8 @@ final class ExportBounds {
      * Includes flow label areas below diamond indicators.
      */
     static Bounds compute(CanvasState canvasState, ModelEditor editor) {
-        if (canvasState.getDrawOrder().isEmpty() && editor.getFlows().isEmpty()) {
+        if (canvasState.getDrawOrder().isEmpty() && editor.getFlows().isEmpty()
+                && editor.getCausalLinks().isEmpty()) {
             return new Bounds(0, 0, 2 * PADDING, 2 * PADDING);
         }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CanvasRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CanvasRenderer.java
@@ -948,20 +948,8 @@ public class CanvasRenderer {
         gc.setLineDashes();
     }
 
-    /**
-     * Draws a dashed highlight rectangle around a stock element.
-     */
     private void drawStockHoverHighlight(GraphicsContext gc, String stockName) {
-        double sx = canvasState.getX(stockName);
-        double sy = canvasState.getY(stockName);
-        double halfW = LayoutMetrics.effectiveWidth(canvasState, stockName) / 2 + 4;
-        double halfH = LayoutMetrics.effectiveHeight(canvasState, stockName) / 2 + 4;
-
-        gc.setStroke(STOCK_HOVER_COLOR);
-        gc.setLineWidth(2.5);
-        gc.setLineDashes(6, 3);
-        gc.strokeRect(sx - halfW, sy - halfH, halfW * 2, halfH * 2);
-        gc.setLineDashes();
+        drawElementHoverHighlight(gc, stockName);
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
@@ -347,7 +347,7 @@ public final class ElementRenderer {
             return "NaN";
         }
         if (value == Math.floor(value) && !Double.isInfinite(value)
-                && Math.abs(value) <= Long.MAX_VALUE) {
+                && value >= Long.MIN_VALUE && value < (double) Long.MAX_VALUE) {
             return String.valueOf((long) value);
         }
         return String.valueOf(value);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/FeedbackLoopRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/FeedbackLoopRenderer.java
@@ -8,6 +8,7 @@ import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
+import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.CausalLinkGeometry;
@@ -81,7 +82,9 @@ public final class FeedbackLoopRenderer {
             case INDETERMINATE -> ColorPalette.LOOP_INDETERMINATE;
         };
 
-        double textWidth = label.length() * 9;
+        Text textNode = new Text(label);
+        textNode.setFont(LOOP_LABEL_FONT);
+        double textWidth = textNode.getLayoutBounds().getWidth();
         double badgeW = textWidth + LABEL_PADDING * 2;
         double badgeH = 20;
         double x = cx - badgeW / 2;

--- a/courant-engine/src/main/java/systems/courant/sd/io/ReferenceDataCsvReader.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/ReferenceDataCsvReader.java
@@ -96,6 +96,10 @@ public final class ReferenceDataCsvReader {
                         row[i] = Double.NaN;
                     }
                 }
+                if (Double.isNaN(row[0])) {
+                    throw new IOException(
+                            "Missing or blank time value at line " + lineNumber);
+                }
                 rawRows.add(row);
             }
 

--- a/courant-engine/src/main/java/systems/courant/sd/model/FindZero.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/FindZero.java
@@ -2,6 +2,9 @@ package systems.courant.sd.model;
 
 import com.google.common.base.Preconditions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.function.DoubleSupplier;
 
 /**
@@ -16,6 +19,7 @@ import java.util.function.DoubleSupplier;
  */
 public class FindZero implements Formula {
 
+    private static final Logger log = LoggerFactory.getLogger(FindZero.class);
     private static final int MAX_ITERATIONS = 50;
     private static final double TOLERANCE = 1e-10;
 
@@ -55,6 +59,12 @@ public class FindZero implements Formula {
     public double getCurrentValue() {
         double lo = loBound.getAsDouble();
         double hi = hiBound.getAsDouble();
+
+        if (Double.isNaN(lo) || Double.isNaN(hi)) {
+            log.warn("FIND ZERO: NaN bound (lo={}, hi={}), returning NaN", lo, hi);
+            variableHolder[0] = Double.NaN;
+            return Double.NaN;
+        }
 
         // Evaluate expression at lo
         variableHolder[0] = lo;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Model.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Model.java
@@ -21,8 +21,10 @@ public class Model extends Element {
     private static final Logger log = LoggerFactory.getLogger(Model.class);
 
     private final List<Stock> stocks = new ArrayList<>();
+    private final Set<Stock> stockIdentity = new HashSet<>();
     private final Set<String> stockNames = new HashSet<>();
     private final List<Flow> flows = new ArrayList<>();
+    private final Set<Flow> flowIdentity = new HashSet<>();
     private final Set<String> flowNames = new HashSet<>();
     private final Map<String, Variable> variables = new LinkedHashMap<>();
     private final List<Module> modules = new ArrayList<>();
@@ -64,6 +66,7 @@ public class Model extends Element {
                     "Duplicate stock name '" + stock.getName() + "' in model '" + getName() + "'");
         }
         stocks.add(stock);
+        stockIdentity.add(stock);
     }
 
     /**
@@ -72,6 +75,7 @@ public class Model extends Element {
      */
     public void removeStock(Stock stock) {
         if (stocks.remove(stock)) {
+            stockIdentity.remove(stock);
             stockNames.remove(stock.getName());
             for (Flow flow : stock.getInflows()) {
                 flow.setSink(null);
@@ -110,6 +114,7 @@ public class Model extends Element {
         for (Stock stock : arrayedStock.getStocks()) {
             if (stockNames.add(stock.getName())) {
                 stocks.add(stock);
+                stockIdentity.add(stock);
             }
         }
     }
@@ -130,6 +135,7 @@ public class Model extends Element {
         for (Stock stock : multiArrayedStock.getStocks()) {
             if (stockNames.add(stock.getName())) {
                 stocks.add(stock);
+                stockIdentity.add(stock);
             }
         }
     }
@@ -164,7 +170,7 @@ public class Model extends Element {
 
         modules.add(module);
         for (Stock stock : module.getStocks()) {
-            if (!stocks.contains(stock)) {
+            if (stockIdentity.add(stock)) {
                 if (stockNames.contains(stock.getName())) {
                     log.warn("Module '{}' stock '{}' has same name as existing stock in model '{}'",
                             module.getName(), stock.getName(), getName());
@@ -174,7 +180,7 @@ public class Model extends Element {
             }
         }
         for (Flow flow : module.getFlows()) {
-            if (!flows.contains(flow)) {
+            if (flowIdentity.add(flow)) {
                 if (flowNames.contains(flow.getName())) {
                     log.warn("Module '{}' flow '{}' has same name as existing flow in model '{}'",
                             module.getName(), flow.getName(), getName());
@@ -223,6 +229,7 @@ public class Model extends Element {
                     "Duplicate flow name '" + flow.getName() + "' in model '" + getName() + "'");
         }
         flows.add(flow);
+        flowIdentity.add(flow);
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/model/Subscript.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Subscript.java
@@ -2,8 +2,10 @@ package systems.courant.sd.model;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -18,6 +20,7 @@ public class Subscript {
 
     private final String name;
     private final List<String> labels;
+    private final Map<String, Integer> labelIndex;
 
     /**
      * Creates a new subscript with the given name and labels.
@@ -46,6 +49,11 @@ public class Subscript {
         }
         this.name = name;
         this.labels = Collections.unmodifiableList(copy);
+        Map<String, Integer> index = new HashMap<>(copy.size());
+        for (int i = 0; i < copy.size(); i++) {
+            index.put(copy.get(i), i);
+        }
+        this.labelIndex = Collections.unmodifiableMap(index);
     }
 
     /**
@@ -80,8 +88,8 @@ public class Subscript {
      * @throws IllegalArgumentException if the label is not found
      */
     public int indexOf(String label) {
-        int index = labels.indexOf(label);
-        if (index < 0) {
+        Integer index = labelIndex.get(label);
+        if (index == null) {
             throw new IllegalArgumentException(
                     "Label '" + label + "' not found in subscript '" + name + "'");
         }

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
@@ -151,14 +151,18 @@ public class BatchImportCli {
                 failures.add(msg);
                 log.error("  FAILED: {}", msg);
             } finally {
-                if (isTemp && sourceFile != null) {
-                    try {
-                        Files.deleteIfExists(sourceFile);
-                        if (tempDir != null) {
-                            Files.deleteIfExists(tempDir);
-                        }
+                if (isTemp && tempDir != null) {
+                    try (var paths = Files.walk(tempDir)) {
+                        paths.sorted(java.util.Comparator.reverseOrder())
+                                .forEach(p -> {
+                                    try {
+                                        Files.deleteIfExists(p);
+                                    } catch (IOException e2) {
+                                        log.warn("  Could not delete temp path: {}", p);
+                                    }
+                                });
                     } catch (IOException e) {
-                        log.warn("  Could not delete temp file: {}", sourceFile);
+                        log.warn("  Could not clean up temp directory: {}", tempDir);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Batch fix of 11 low-priority, easy-difficulty code quality issues:

- **#969** Replace `openWindows` list with int counter in CourantApp
- **#968** Use recursive delete for temp directories in BatchImportCli
- **#967** Include flows and causal links in ExportBounds empty-diagram guard
- **#966** Fix unsafe long cast for extreme doubles in `ElementRenderer.formatValue`
- **#965** Measure actual text width in FeedbackLoopRenderer loop labels
- **#964** Consolidate duplicate `drawStockHoverHighlight` into `drawElementHoverHighlight`
- **#963** Reject NaN time values in ReferenceDataCsvReader
- **#962** Add identity sets for O(1) stock/flow duplicate checks in `Model.addModule`
- **#961** Add HashMap index for O(1) `Subscript.indexOf` lookups
- **#960** Guard FindZero bisection against NaN bounds
- **#958** Eliminate throwaway TextFieldEquationField in `EquationAutoComplete.detach`

Closes #969, closes #968, closes #967, closes #966, closes #965, closes #964, closes #963, closes #962, closes #961, closes #960, closes #958

## Test plan

- [x] Full reactor `mvn clean compile` passes
- [x] Full reactor `mvn clean test` passes (all 131 tests)
- [x] `mvn spotbugs:check` clean