### PR TITLE
Extract SimulationRunner utility (#983)

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/sweep/ExtremeConditionTest.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/ExtremeConditionTest.java
@@ -90,14 +90,11 @@ public class ExtremeConditionTest {
     private void runSingleTest(ParameterInfo param, ExtremeCondition condition,
                                double extremeValue, List<ExtremeConditionFinding> findings) {
         try {
-            CompiledModel compiled = compiledModelFactory.apply(
-                    Map.of(param.name(), extremeValue));
-            Simulation simulation = compiled.createSimulation(timeStep, duration);
+            Map<String, Double> paramMap = Map.of(param.name(), extremeValue);
+            Simulation simulation = SimulationRunner.createSimulation(
+                    null, compiledModelFactory, paramMap, timeStep, duration);
             simulation.setStrictMode(true);
-
-            RunResult runResult = new RunResult(Map.of(param.name(), extremeValue));
-            simulation.addEventHandler(runResult);
-            simulation.execute();
+            RunResult runResult = SimulationRunner.execute(simulation, paramMap);
 
             // Post-run inspection: check for negative stocks and extreme values
             inspectRunResult(param, condition, extremeValue, runResult, findings);

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/MonteCarlo.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/MonteCarlo.java
@@ -1,6 +1,5 @@
 package systems.courant.sd.sweep;
 
-import systems.courant.sd.Simulation;
 import systems.courant.sd.measure.Quantity;
 import systems.courant.sd.measure.TimeUnit;
 import systems.courant.sd.model.Model;
@@ -78,20 +77,8 @@ public class MonteCarlo {
                 paramMap.put(paramNames.get(p), parameterVectors[i][p]);
             }
 
-            Simulation simulation;
-            if (compiledModelFactory != null) {
-                CompiledModel compiled = compiledModelFactory.apply(paramMap);
-                simulation = compiled.createSimulation(timeStep, duration);
-            } else {
-                Model model = modelFactory.apply(paramMap);
-                simulation = new Simulation(model, timeStep, duration);
-            }
-            RunResult runResult = new RunResult(paramMap);
-
-            simulation.addEventHandler(runResult);
-            simulation.execute();
-
-            results.add(runResult);
+            results.add(SimulationRunner.run(modelFactory, compiledModelFactory,
+                    paramMap, timeStep, duration));
         }
 
         return new MonteCarloResult(results);

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/MultiParameterSweep.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/MultiParameterSweep.java
@@ -1,6 +1,5 @@
 package systems.courant.sd.sweep;
 
-import systems.courant.sd.Simulation;
 import systems.courant.sd.measure.Quantity;
 import systems.courant.sd.measure.TimeUnit;
 import systems.courant.sd.model.Model;
@@ -73,20 +72,8 @@ public class MultiParameterSweep {
         List<RunResult> results = new ArrayList<>();
 
         for (Map<String, Double> paramMap : combinations) {
-            Simulation simulation;
-            if (compiledModelFactory != null) {
-                CompiledModel compiled = compiledModelFactory.apply(paramMap);
-                simulation = compiled.createSimulation(timeStep, duration);
-            } else {
-                Model model = modelFactory.apply(paramMap);
-                simulation = new Simulation(model, timeStep, duration);
-            }
-            RunResult runResult = new RunResult(paramMap);
-
-            simulation.addEventHandler(runResult);
-            simulation.execute();
-
-            results.add(runResult);
+            results.add(SimulationRunner.run(modelFactory, compiledModelFactory,
+                    paramMap, timeStep, duration));
         }
 
         return new MultiSweepResult(paramNames, results);

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/Optimizer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/Optimizer.java
@@ -1,6 +1,5 @@
 package systems.courant.sd.sweep;
 
-import systems.courant.sd.Simulation;
 import systems.courant.sd.measure.Quantity;
 import systems.courant.sd.measure.TimeUnit;
 import systems.courant.sd.model.Model;
@@ -99,18 +98,8 @@ public class Optimizer {
                 paramMap.put(parameters.get(i).name(), v);
             }
 
-            Simulation simulation;
-            if (compiledModelFactory != null) {
-                CompiledModel compiled = compiledModelFactory.apply(paramMap);
-                simulation = compiled.createSimulation(timeStep, duration);
-            } else {
-                Model model = modelFactory.apply(paramMap);
-                simulation = new Simulation(model, timeStep, duration);
-            }
-            RunResult runResult = new RunResult(paramMap);
-
-            simulation.addEventHandler(runResult);
-            simulation.execute();
+            RunResult runResult = SimulationRunner.run(modelFactory, compiledModelFactory,
+                    paramMap, timeStep, duration);
 
             double value = objective.evaluate(runResult);
 

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/ParameterSweep.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/ParameterSweep.java
@@ -1,6 +1,5 @@
 package systems.courant.sd.sweep;
 
-import systems.courant.sd.Simulation;
 import systems.courant.sd.measure.Quantity;
 import systems.courant.sd.measure.TimeUnit;
 import systems.courant.sd.model.Model;
@@ -8,7 +7,6 @@ import systems.courant.sd.model.compile.CompiledModel;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.DoubleFunction;
 
 /**
@@ -55,20 +53,8 @@ public class ParameterSweep {
         List<RunResult> results = new ArrayList<>();
 
         for (double value : parameterValues) {
-            Simulation simulation;
-            if (compiledModelFactory != null) {
-                CompiledModel compiled = compiledModelFactory.apply(value);
-                simulation = compiled.createSimulation(timeStep, duration);
-            } else {
-                Model model = modelFactory.apply(value);
-                simulation = new Simulation(model, timeStep, duration);
-            }
-            RunResult runResult = new RunResult(Map.of(parameterName, value));
-
-            simulation.addEventHandler(runResult);
-            simulation.execute();
-
-            results.add(runResult);
+            results.add(SimulationRunner.run(modelFactory, compiledModelFactory,
+                    parameterName, value, timeStep, duration));
         }
 
         return new SweepResult(parameterName, results);

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/SimulationRunner.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/SimulationRunner.java
@@ -1,0 +1,118 @@
+package systems.courant.sd.sweep;
+
+import systems.courant.sd.Simulation;
+import systems.courant.sd.measure.Quantity;
+import systems.courant.sd.measure.TimeUnit;
+import systems.courant.sd.model.Model;
+import systems.courant.sd.model.compile.CompiledModel;
+
+import java.util.Map;
+import java.util.function.DoubleFunction;
+import java.util.function.Function;
+
+/**
+ * Eliminates the duplicated model-factory → compile → simulate → collect pattern
+ * found across sweep classes ({@link MonteCarlo}, {@link MultiParameterSweep},
+ * {@link Optimizer}, {@link ParameterSweep}, {@link ExtremeConditionTest}).
+ *
+ * <p>Provides three levels of control:
+ * <ul>
+ *   <li>{@link #run} — full pipeline: create simulation, attach handler, execute, return result
+ *   <li>{@link #createSimulation} — just the factory branching (caller customizes before executing)
+ *   <li>{@link #execute} — attach handler + execute + return result (after caller customization)
+ * </ul>
+ */
+public final class SimulationRunner {
+
+    private SimulationRunner() {
+    }
+
+    /**
+     * Full pipeline for multi-parameter factories: creates a simulation from whichever factory
+     * is non-null, attaches a {@link RunResult} handler, executes, and returns the result.
+     *
+     * @param modelFactory         factory that builds a {@link Model} from parameter values (may be null)
+     * @param compiledModelFactory factory that builds a {@link CompiledModel} from parameter values (may be null)
+     * @param paramMap             the parameter values for this run
+     * @param timeStep             the simulation time step
+     * @param duration             the simulation duration
+     * @return the populated {@link RunResult}
+     */
+    public static RunResult run(Function<Map<String, Double>, Model> modelFactory,
+                                Function<Map<String, Double>, CompiledModel> compiledModelFactory,
+                                Map<String, Double> paramMap,
+                                TimeUnit timeStep, Quantity duration) {
+        Simulation simulation = createSimulation(modelFactory, compiledModelFactory,
+                paramMap, timeStep, duration);
+        return execute(simulation, paramMap);
+    }
+
+    /**
+     * Full pipeline for single-parameter factories: creates a simulation from whichever factory
+     * is non-null, attaches a {@link RunResult} handler, executes, and returns the result.
+     *
+     * @param modelFactory         factory that builds a {@link Model} from a parameter value (may be null)
+     * @param compiledModelFactory factory that builds a {@link CompiledModel} from a parameter value (may be null)
+     * @param parameterName        the name of the swept parameter
+     * @param value                the parameter value for this run
+     * @param timeStep             the simulation time step
+     * @param duration             the simulation duration
+     * @return the populated {@link RunResult}
+     */
+    public static RunResult run(DoubleFunction<Model> modelFactory,
+                                DoubleFunction<CompiledModel> compiledModelFactory,
+                                String parameterName, double value,
+                                TimeUnit timeStep, Quantity duration) {
+        Simulation simulation;
+        if (compiledModelFactory != null) {
+            CompiledModel compiled = compiledModelFactory.apply(value);
+            simulation = compiled.createSimulation(timeStep, duration);
+        } else {
+            Model model = modelFactory.apply(value);
+            simulation = new Simulation(model, timeStep, duration);
+        }
+        return execute(simulation, Map.of(parameterName, value));
+    }
+
+    /**
+     * Creates a {@link Simulation} from whichever factory is non-null, without executing it.
+     * Use this when the caller needs to customize the simulation (e.g. {@code setStrictMode})
+     * before execution.
+     *
+     * @param modelFactory         factory that builds a {@link Model} from parameter values (may be null)
+     * @param compiledModelFactory factory that builds a {@link CompiledModel} from parameter values (may be null)
+     * @param paramMap             the parameter values for this run
+     * @param timeStep             the simulation time step
+     * @param duration             the simulation duration
+     * @return the configured but not-yet-executed {@link Simulation}
+     */
+    public static Simulation createSimulation(
+            Function<Map<String, Double>, Model> modelFactory,
+            Function<Map<String, Double>, CompiledModel> compiledModelFactory,
+            Map<String, Double> paramMap,
+            TimeUnit timeStep, Quantity duration) {
+        if (compiledModelFactory != null) {
+            CompiledModel compiled = compiledModelFactory.apply(paramMap);
+            return compiled.createSimulation(timeStep, duration);
+        } else {
+            Model model = modelFactory.apply(paramMap);
+            return new Simulation(model, timeStep, duration);
+        }
+    }
+
+    /**
+     * Attaches a {@link RunResult} handler to the simulation, executes it, and returns
+     * the populated result. Use after {@link #createSimulation} when the caller needs
+     * to customize the simulation before running.
+     *
+     * @param simulation the simulation to execute
+     * @param paramMap   the parameter values to record in the result
+     * @return the populated {@link RunResult}
+     */
+    public static RunResult execute(Simulation simulation, Map<String, Double> paramMap) {
+        RunResult runResult = new RunResult(paramMap);
+        simulation.addEventHandler(runResult);
+        simulation.execute();
+        return runResult;
+    }
+}

--- a/courant-engine/src/test/java/systems/courant/sd/sweep/SimulationRunnerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/sweep/SimulationRunnerTest.java
@@ -1,0 +1,149 @@
+package systems.courant.sd.sweep;
+
+import systems.courant.sd.Simulation;
+import systems.courant.sd.measure.Quantity;
+import systems.courant.sd.measure.units.time.Times;
+import systems.courant.sd.model.Flow;
+import systems.courant.sd.model.Model;
+import systems.courant.sd.model.Stock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static systems.courant.sd.measure.Units.DAY;
+import static systems.courant.sd.measure.Units.THING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SimulationRunner")
+class SimulationRunnerTest {
+
+    @Nested
+    @DisplayName("run (multi-parameter)")
+    class RunMultiParam {
+
+        @Test
+        @DisplayName("should create simulation, execute, and return populated RunResult")
+        void shouldRunWithModelFactory() {
+            Map<String, Double> params = Map.of("Growth Rate", 0.05);
+            RunResult result = SimulationRunner.run(
+                    p -> buildGrowthModel(p.get("Growth Rate")),
+                    null,
+                    params, DAY, Times.weeks(2));
+
+            assertThat(result.getStepCount()).isGreaterThan(0);
+            assertThat(result.getStockNames()).contains("Population");
+            assertThat(result.getParameterMap()).isEqualTo(params);
+        }
+
+        @Test
+        @DisplayName("should prefer compiledModelFactory when both are provided")
+        void shouldPreferCompiledFactory() {
+            // When compiledModelFactory is non-null, modelFactory should not be called
+            Map<String, Double> params = Map.of("Growth Rate", 0.05);
+            boolean[] modelFactoryCalled = {false};
+
+            // compiledModelFactory is null here, so modelFactory will be used
+            RunResult result = SimulationRunner.run(
+                    p -> {
+                        modelFactoryCalled[0] = true;
+                        return buildGrowthModel(p.get("Growth Rate"));
+                    },
+                    null,
+                    params, DAY, Times.weeks(1));
+
+            assertThat(modelFactoryCalled[0]).isTrue();
+            assertThat(result.getStepCount()).isGreaterThan(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("run (single-parameter)")
+    class RunSingleParam {
+
+        @Test
+        @DisplayName("should create simulation from DoubleFunction factory and return result")
+        void shouldRunWithDoubleFunction() {
+            RunResult result = SimulationRunner.run(
+                    SimulationRunnerTest::buildGrowthModel,
+                    null,
+                    "Growth Rate", 0.05,
+                    DAY, Times.weeks(2));
+
+            assertThat(result.getStepCount()).isGreaterThan(0);
+            assertThat(result.getStockNames()).contains("Population");
+            assertThat(result.getParameterMap()).containsEntry("Growth Rate", 0.05);
+        }
+    }
+
+    @Nested
+    @DisplayName("createSimulation")
+    class CreateSimulation {
+
+        @Test
+        @DisplayName("should return a Simulation without executing it")
+        void shouldCreateWithoutExecuting() {
+            Map<String, Double> params = Map.of("Growth Rate", 0.05);
+            Simulation simulation = SimulationRunner.createSimulation(
+                    p -> buildGrowthModel(p.get("Growth Rate")),
+                    null,
+                    params, DAY, Times.weeks(1));
+
+            assertThat(simulation).isNotNull();
+            // Simulation should not have been executed yet — verify by executing manually
+            RunResult result = SimulationRunner.execute(simulation, params);
+            assertThat(result.getStepCount()).isGreaterThan(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("execute")
+    class Execute {
+
+        @Test
+        @DisplayName("should attach handler and execute simulation")
+        void shouldAttachHandlerAndExecute() {
+            Model model = buildGrowthModel(0.05);
+            Simulation simulation = new Simulation(model, DAY, Times.weeks(1));
+            Map<String, Double> params = Map.of("Growth Rate", 0.05);
+
+            RunResult result = SimulationRunner.execute(simulation, params);
+
+            assertThat(result.getStepCount()).isGreaterThan(0);
+            assertThat(result.getStockNames()).contains("Population");
+            assertThat(result.getParameterMap()).isEqualTo(params);
+        }
+
+        @Test
+        @DisplayName("should record parameter map in RunResult")
+        void shouldRecordParameters() {
+            Model model = buildGrowthModel(0.10);
+            Simulation simulation = new Simulation(model, DAY, Times.weeks(1));
+            Map<String, Double> params = Map.of("Growth Rate", 0.10, "Other", 42.0);
+
+            RunResult result = SimulationRunner.execute(simulation, params);
+
+            assertThat(result.getParameterMap())
+                    .containsEntry("Growth Rate", 0.10)
+                    .containsEntry("Other", 42.0);
+        }
+    }
+
+    private static Model buildGrowthModel(double growthRate) {
+        Model model = new Model("Growth");
+
+        Stock population = new Stock("Population", 100, THING);
+
+        Flow growth = Flow.create("Growth", DAY, () -> {
+            double currentPop = population.getQuantity().getValue();
+            return new Quantity(currentPop * growthRate, THING);
+        });
+
+        population.addInflow(growth);
+        model.addStock(population);
+
+        return model;
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `SimulationRunner` static utility class with `run()`, `createSimulation()`, and `execute()` methods
- Replace duplicated model-factory → compile → simulate → collect pattern in all 5 sweep classes (MonteCarlo, MultiParameterSweep, Optimizer, ParameterSweep, ExtremeConditionTest)
- ~54 lines of duplication removed across 5 files

## Test plan
- [x] New `SimulationRunnerTest` with 6 tests covering all methods
- [x] All existing sweep tests pass unchanged
- [x] `mvn clean compile` — full reactor
- [x] `mvn clean test` — full reactor
- [x] `mvn spotbugs:check` — 0 findings