### PR TITLE
Extract shared geometry records to deduplicate SvgExporter (#976)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ArrowheadGeometry.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ArrowheadGeometry.java
@@ -1,0 +1,122 @@
+package systems.courant.sd.app.canvas;
+
+/**
+ * Computed arrowhead triangle geometry. Both the Canvas renderer and SVG exporter
+ * consume these pre-computed coordinates instead of duplicating the direction-vector
+ * and perpendicular-offset math.
+ *
+ * <p>An arrowhead is a triangle with its tip at ({@code tipX}, {@code tipY}) pointing
+ * in the direction from a source toward the tip. The base is perpendicular to the
+ * direction vector at a distance of {@code length} behind the tip.
+ *
+ * @param tipX    x-coordinate of the arrowhead tip (the point)
+ * @param tipY    y-coordinate of the arrowhead tip
+ * @param baseLeftX   x-coordinate of the left base vertex
+ * @param baseLeftY   y-coordinate of the left base vertex
+ * @param baseRightX  x-coordinate of the right base vertex
+ * @param baseRightY  y-coordinate of the right base vertex
+ */
+public record ArrowheadGeometry(
+        double tipX, double tipY,
+        double baseLeftX, double baseLeftY,
+        double baseRightX, double baseRightY
+) {
+
+    /**
+     * Computes arrowhead geometry for a straight line from ({@code fromX}, {@code fromY})
+     * toward ({@code toX}, {@code toY}), with the tip at the "to" point.
+     *
+     * @param fromX  line origin x
+     * @param fromY  line origin y
+     * @param toX    line endpoint x (arrowhead tip)
+     * @param toY    line endpoint y (arrowhead tip)
+     * @param length arrowhead length (tip to base)
+     * @param width  arrowhead width (base spread)
+     * @return the arrowhead geometry, or {@code null} if the line is too short (distance &lt; 1)
+     */
+    public static ArrowheadGeometry fromLine(double fromX, double fromY,
+                                             double toX, double toY,
+                                             double length, double width) {
+        double dx = toX - fromX;
+        double dy = toY - fromY;
+        double dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < 1) {
+            return null;
+        }
+
+        double ux = dx / dist;
+        double uy = dy / dist;
+        return fromUnitVector(toX, toY, ux, uy, length, width);
+    }
+
+    /**
+     * Computes arrowhead geometry from a tangent vector at the tip point.
+     * Used for arrowheads on curved paths (Bezier curves) where the direction
+     * is given by the curve tangent rather than a straight line.
+     *
+     * @param tipX   arrowhead tip x
+     * @param tipY   arrowhead tip y
+     * @param tanX   tangent vector x component (unnormalized)
+     * @param tanY   tangent vector y component (unnormalized)
+     * @param length arrowhead length (tip to base)
+     * @param width  arrowhead width (base spread)
+     * @return the arrowhead geometry, or {@code null} if the tangent is near-zero
+     */
+    public static ArrowheadGeometry fromTangent(double tipX, double tipY,
+                                                double tanX, double tanY,
+                                                double length, double width) {
+        double dist = Math.sqrt(tanX * tanX + tanY * tanY);
+        if (dist < 1e-9) {
+            return null;
+        }
+
+        double ux = tanX / dist;
+        double uy = tanY / dist;
+        return fromUnitVector(tipX, tipY, ux, uy, length, width);
+    }
+
+    /**
+     * Computes the point where a line should stop before reaching an arrowhead,
+     * so the line ends at the arrowhead's base rather than extending behind it.
+     *
+     * <p>Given a line from ({@code fromX}, {@code fromY}) to ({@code toX}, {@code toY}),
+     * this returns the point that is {@code arrowLength} before the "to" endpoint,
+     * measured along the line direction. If the line is shorter than {@code arrowLength},
+     * the "to" point is returned unchanged.
+     *
+     * @param fromX       line start x
+     * @param fromY       line start y
+     * @param toX         line end x (where the arrowhead tip sits)
+     * @param toY         line end y
+     * @param arrowLength arrowhead length to subtract
+     * @return a 2-element array {stopX, stopY}
+     */
+    public static double[] lineStopPoint(double fromX, double fromY,
+                                         double toX, double toY,
+                                         double arrowLength) {
+        double dx = toX - fromX;
+        double dy = toY - fromY;
+        double dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist > arrowLength) {
+            double ux = dx / dist;
+            double uy = dy / dist;
+            return new double[]{toX - ux * arrowLength, toY - uy * arrowLength};
+        }
+        return new double[]{toX, toY};
+    }
+
+    private static ArrowheadGeometry fromUnitVector(double tipX, double tipY,
+                                                    double ux, double uy,
+                                                    double length, double width) {
+        double baseX = tipX - ux * length;
+        double baseY = tipY - uy * length;
+
+        double perpX = -uy * width / 2;
+        double perpY = ux * width / 2;
+
+        return new ArrowheadGeometry(
+                tipX, tipY,
+                baseX + perpX, baseY + perpY,
+                baseX - perpX, baseY - perpY);
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/MaterialFlowEndpoints.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/MaterialFlowEndpoints.java
@@ -1,0 +1,83 @@
+package systems.courant.sd.app.canvas;
+
+import systems.courant.sd.model.def.FlowDef;
+
+/**
+ * Resolved source and sink endpoints for a material flow pipe. Encapsulates
+ * the endpoint-resolution logic that was previously duplicated between
+ * {@link systems.courant.sd.app.canvas.renderers.MaterialFlowPass} and
+ * {@link SvgExporter}.
+ *
+ * <p>For each endpoint (source and sink), the position is either clipped to
+ * the connected stock's border or placed at the cloud position computed by
+ * {@link FlowEndpointCalculator}.
+ *
+ * @param sourceX       resolved source endpoint x
+ * @param sourceY       resolved source endpoint y
+ * @param midX          flow indicator (diamond) center x
+ * @param midY          flow indicator (diamond) center y
+ * @param sinkX         resolved sink endpoint x
+ * @param sinkY         resolved sink endpoint y
+ * @param sourceIsCloud true if the source endpoint is a cloud (disconnected)
+ * @param sinkIsCloud   true if the sink endpoint is a cloud (disconnected)
+ */
+public record MaterialFlowEndpoints(
+        double sourceX, double sourceY,
+        double midX, double midY,
+        double sinkX, double sinkY,
+        boolean sourceIsCloud, boolean sinkIsCloud
+) {
+
+    /**
+     * Resolves the endpoints for a material flow.
+     *
+     * @param flow  the flow definition
+     * @param state canvas state for position lookups
+     * @return the resolved endpoints, or {@code null} if the flow element is not on the canvas
+     */
+    public static MaterialFlowEndpoints resolve(FlowDef flow, CanvasState state) {
+        if (!state.hasElement(flow.name())) {
+            return null;
+        }
+
+        double midX = state.getX(flow.name());
+        double midY = state.getY(flow.name());
+
+        double sourceX;
+        double sourceY;
+        boolean sourceIsCloud;
+
+        if (flow.source() != null && state.hasElement(flow.source())) {
+            FlowGeometry.Point2D edge = FlowGeometry.clipToElement(state, flow.source(), midX, midY);
+            sourceX = edge.x();
+            sourceY = edge.y();
+            sourceIsCloud = false;
+        } else {
+            FlowGeometry.Point2D cloud = FlowEndpointCalculator.cloudPosition(
+                    FlowEndpointCalculator.FlowEnd.SOURCE, flow, state);
+            sourceX = cloud != null ? cloud.x() : midX - LayoutMetrics.CLOUD_OFFSET;
+            sourceY = cloud != null ? cloud.y() : midY;
+            sourceIsCloud = true;
+        }
+
+        double sinkX;
+        double sinkY;
+        boolean sinkIsCloud;
+
+        if (flow.sink() != null && state.hasElement(flow.sink())) {
+            FlowGeometry.Point2D edge = FlowGeometry.clipToElement(state, flow.sink(), midX, midY);
+            sinkX = edge.x();
+            sinkY = edge.y();
+            sinkIsCloud = false;
+        } else {
+            FlowGeometry.Point2D cloud = FlowEndpointCalculator.cloudPosition(
+                    FlowEndpointCalculator.FlowEnd.SINK, flow, state);
+            sinkX = cloud != null ? cloud.x() : midX + LayoutMetrics.CLOUD_OFFSET;
+            sinkY = cloud != null ? cloud.y() : midY;
+            sinkIsCloud = true;
+        }
+
+        return new MaterialFlowEndpoints(sourceX, sourceY, midX, midY, sinkX, sinkY,
+                sourceIsCloud, sinkIsCloud);
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/PolarityLabelLayout.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/PolarityLabelLayout.java
@@ -1,0 +1,85 @@
+package systems.courant.sd.app.canvas;
+
+import systems.courant.sd.model.def.CausalLinkDef;
+
+/**
+ * Computes the position for a causal link polarity label along a Bezier curve.
+ * Extracts the perpendicular-offset computation that was duplicated between
+ * {@link systems.courant.sd.app.canvas.renderers.ConnectionRenderer} and
+ * {@link SvgExporter}.
+ *
+ * @param x      label center x
+ * @param y      label center y
+ * @param valid  true if a valid position was computed (false when endpoints are coincident)
+ */
+public record PolarityLabelLayout(double x, double y, boolean valid) {
+
+    /** Perpendicular offset distance from the curve to the label center. */
+    private static final double PERP_OFFSET = 12;
+
+    /** Parameter position along the curve where the label is placed. */
+    private static final double LABEL_T = 0.8;
+
+    /**
+     * Computes the polarity label position for a quadratic Bezier causal link.
+     * The label is placed at t=0.8 along the curve, offset perpendicular to the tangent.
+     *
+     * @param fromX  curve start x (clipped to element border)
+     * @param fromY  curve start y
+     * @param cpX    control point x
+     * @param cpY    control point y
+     * @param toX    curve end x (clipped to element border)
+     * @param toY    curve end y
+     * @return the label layout; {@code valid} is false if endpoints are too close
+     */
+    public static PolarityLabelLayout forQuadratic(double fromX, double fromY,
+                                                   double cpX, double cpY,
+                                                   double toX, double toY) {
+        double dx = toX - fromX;
+        double dy = toY - fromY;
+        double dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist <= 1) {
+            return new PolarityLabelLayout(0, 0, false);
+        }
+
+        double[] labelPt = CausalLinkGeometry.evaluate(fromX, fromY, cpX, cpY, toX, toY, LABEL_T);
+        double[] labelTan = CausalLinkGeometry.tangent(fromX, fromY, cpX, cpY, toX, toY, LABEL_T);
+        double tanDist = Math.sqrt(labelTan[0] * labelTan[0] + labelTan[1] * labelTan[1]);
+        if (tanDist <= 0) {
+            return new PolarityLabelLayout(0, 0, false);
+        }
+
+        double perpX = -labelTan[1] / tanDist;
+        double perpY = labelTan[0] / tanDist;
+        return new PolarityLabelLayout(
+                labelPt[0] + perpX * PERP_OFFSET,
+                labelPt[1] + perpY * PERP_OFFSET,
+                true);
+    }
+
+    /**
+     * Computes the polarity label position for a cubic Bezier self-loop.
+     * The label is placed at the midpoint of the loop curve, offset above.
+     *
+     * @param loopPts 8-element array from {@link CausalLinkGeometry#selfLoopPoints}:
+     *                {startX, startY, cp1X, cp1Y, cp2X, cp2Y, endX, endY}
+     * @return the label layout (always valid for self-loops)
+     */
+    public static PolarityLabelLayout forSelfLoop(double[] loopPts) {
+        double[] midPt = CausalLinkGeometry.evaluateCubic(
+                loopPts[0], loopPts[1], loopPts[2], loopPts[3],
+                loopPts[4], loopPts[5], loopPts[6], loopPts[7], 0.5);
+        return new PolarityLabelLayout(midPt[0], midPt[1] - 10, true);
+    }
+
+    /**
+     * Returns the label color for a given polarity.
+     */
+    public static javafx.scene.paint.Color colorFor(CausalLinkDef.Polarity polarity) {
+        return switch (polarity) {
+            case POSITIVE -> ColorPalette.CAUSAL_POSITIVE;
+            case NEGATIVE -> ColorPalette.CAUSAL_NEGATIVE;
+            case UNKNOWN -> ColorPalette.CAUSAL_UNKNOWN;
+        };
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
@@ -24,6 +24,11 @@ import systems.courant.sd.app.canvas.renderers.OutlineGeometry;
 /**
  * Exports the diagram to an SVG file by translating canvas drawing operations
  * into SVG XML elements. Follows the same layer order as {@link CanvasRenderer}.
+ *
+ * <p>Geometry computations are shared with the Canvas renderer via
+ * {@link ArrowheadGeometry}, {@link MaterialFlowEndpoints}, and
+ * {@link PolarityLabelLayout}, ensuring that any fix to the geometry
+ * is applied consistently in both renderers.
  */
 public final class SvgExporter {
 
@@ -151,81 +156,37 @@ public final class SvgExporter {
 
     private static void writeMaterialFlows(PrintWriter w, CanvasState state, ModelEditor editor) {
         for (FlowDef flow : editor.getFlows()) {
-            if (!state.hasElement(flow.name())) {
+            MaterialFlowEndpoints ep = MaterialFlowEndpoints.resolve(flow, state);
+            if (ep == null) {
                 continue;
-            }
-            double midX = state.getX(flow.name());
-            double midY = state.getY(flow.name());
-
-            double sourceX;
-            double sourceY;
-            boolean sourceIsCloud;
-
-            if (flow.source() != null && state.hasElement(flow.source())) {
-                FlowGeometry.Point2D edge = FlowGeometry.clipToElement(state, flow.source(), midX, midY);
-                sourceX = edge.x();
-                sourceY = edge.y();
-                sourceIsCloud = false;
-            } else {
-                FlowGeometry.Point2D cloud = FlowEndpointCalculator.cloudPosition(
-                        FlowEndpointCalculator.FlowEnd.SOURCE, flow, state);
-                sourceX = cloud != null ? cloud.x() : midX - LayoutMetrics.CLOUD_OFFSET;
-                sourceY = cloud != null ? cloud.y() : midY;
-                sourceIsCloud = true;
-            }
-
-            double sinkX;
-            double sinkY;
-            boolean sinkIsCloud;
-
-            if (flow.sink() != null && state.hasElement(flow.sink())) {
-                FlowGeometry.Point2D edge = FlowGeometry.clipToElement(state, flow.sink(), midX, midY);
-                sinkX = edge.x();
-                sinkY = edge.y();
-                sinkIsCloud = false;
-            } else {
-                FlowGeometry.Point2D cloud = FlowEndpointCalculator.cloudPosition(
-                        FlowEndpointCalculator.FlowEnd.SINK, flow, state);
-                sinkX = cloud != null ? cloud.x() : midX + LayoutMetrics.CLOUD_OFFSET;
-                sinkY = cloud != null ? cloud.y() : midY;
-                sinkIsCloud = true;
             }
 
             // Clouds
-            if (sourceIsCloud) {
-                writeCloud(w, sourceX, sourceY);
+            if (ep.sourceIsCloud()) {
+                writeCloud(w, ep.sourceX(), ep.sourceY());
             }
-            if (sinkIsCloud) {
-                writeCloud(w, sinkX, sinkY);
+            if (ep.sinkIsCloud()) {
+                writeCloud(w, ep.sinkX(), ep.sinkY());
             }
 
-            // Source → diamond (no arrowhead — full length)
+            // Source -> diamond (no arrowhead -- full length)
             w.printf(Locale.US,
                     "  <line x1=\"%.2f\" y1=\"%.2f\" x2=\"%.2f\" y2=\"%.2f\" " +
                     "stroke=\"%s\" stroke-width=\"%.1f\"/>%n",
-                    sourceX, sourceY, midX, midY,
+                    ep.sourceX(), ep.sourceY(), ep.midX(), ep.midY(),
                     svgColor(ColorPalette.MATERIAL_FLOW), LayoutMetrics.MATERIAL_FLOW_WIDTH);
 
-            // Diamond → sink: stop line at arrowhead base
-            double sinkDx = sinkX - midX;
-            double sinkDy = sinkY - midY;
-            double sinkDist = Math.sqrt(sinkDx * sinkDx + sinkDy * sinkDy);
-            double lineEndX = sinkX;
-            double lineEndY = sinkY;
-            if (sinkDist > LayoutMetrics.ARROWHEAD_LENGTH) {
-                double ux = sinkDx / sinkDist;
-                double uy = sinkDy / sinkDist;
-                lineEndX = sinkX - ux * LayoutMetrics.ARROWHEAD_LENGTH;
-                lineEndY = sinkY - uy * LayoutMetrics.ARROWHEAD_LENGTH;
-            }
+            // Diamond -> sink: stop line at arrowhead base
+            double[] stop = ArrowheadGeometry.lineStopPoint(
+                    ep.midX(), ep.midY(), ep.sinkX(), ep.sinkY(), LayoutMetrics.ARROWHEAD_LENGTH);
             w.printf(Locale.US,
                     "  <line x1=\"%.2f\" y1=\"%.2f\" x2=\"%.2f\" y2=\"%.2f\" " +
                     "stroke=\"%s\" stroke-width=\"%.1f\"/>%n",
-                    midX, midY, lineEndX, lineEndY,
+                    ep.midX(), ep.midY(), stop[0], stop[1],
                     svgColor(ColorPalette.MATERIAL_FLOW), LayoutMetrics.MATERIAL_FLOW_WIDTH);
 
             // Arrowhead fills gap from lineEnd to sink
-            writeArrowhead(w, midX, midY, sinkX, sinkY,
+            writeSvgArrowhead(w, ep.midX(), ep.midY(), ep.sinkX(), ep.sinkY(),
                     LayoutMetrics.ARROWHEAD_LENGTH, LayoutMetrics.ARROWHEAD_WIDTH,
                     ColorPalette.MATERIAL_FLOW);
         }
@@ -249,28 +210,19 @@ public final class SvgExporter {
             FlowGeometry.Point2D ct = FlowGeometry.clipToElement(state, route.to(), fromX, fromY);
 
             // Stop line at arrowhead base
-            double ldx = ct.x() - cf.x();
-            double ldy = ct.y() - cf.y();
-            double ldist = Math.sqrt(ldx * ldx + ldy * ldy);
-            double ltx = ct.x();
-            double lty = ct.y();
-            if (ldist > LayoutMetrics.INFO_ARROWHEAD_LENGTH) {
-                double lux = ldx / ldist;
-                double luy = ldy / ldist;
-                ltx = ct.x() - lux * LayoutMetrics.INFO_ARROWHEAD_LENGTH;
-                lty = ct.y() - luy * LayoutMetrics.INFO_ARROWHEAD_LENGTH;
-            }
+            double[] stop = ArrowheadGeometry.lineStopPoint(
+                    cf.x(), cf.y(), ct.x(), ct.y(), LayoutMetrics.INFO_ARROWHEAD_LENGTH);
 
             w.printf(Locale.US,
                     "  <line x1=\"%.2f\" y1=\"%.2f\" x2=\"%.2f\" y2=\"%.2f\" " +
                     "stroke=\"%s\" stroke-opacity=\"%.2f\" stroke-width=\"%.1f\" " +
                     "stroke-dasharray=\"%.0f %.0f\"/>%n",
-                    cf.x(), cf.y(), ltx, lty,
+                    cf.x(), cf.y(), stop[0], stop[1],
                     svgColor(ColorPalette.INFO_LINK), svgOpacity(ColorPalette.INFO_LINK),
                     LayoutMetrics.INFO_LINK_WIDTH,
                     LayoutMetrics.INFO_LINK_DASH_LENGTH, LayoutMetrics.INFO_LINK_DASH_GAP);
 
-            writeArrowhead(w, cf.x(), cf.y(), ct.x(), ct.y(),
+            writeSvgArrowhead(w, cf.x(), cf.y(), ct.x(), ct.y(),
                     LayoutMetrics.INFO_ARROWHEAD_LENGTH, LayoutMetrics.INFO_ARROWHEAD_WIDTH,
                     ColorPalette.INFO_LINK);
         }
@@ -466,7 +418,7 @@ public final class SvgExporter {
         double y = cy - height / 2;
         double r = LayoutMetrics.AUX_CORNER_RADIUS;
 
-        // Fill — subtle gray, no border
+        // Fill -- subtle gray, no border
         w.printf(Locale.US,
                 "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.2f\" height=\"%.2f\" rx=\"%.1f\" " +
                 "fill=\"%s\"/>%n",
@@ -489,7 +441,7 @@ public final class SvgExporter {
                 "font-family=\"sans-serif\" font-size=\"%.0f\" font-weight=\"bold\" fill=\"%s\">%s</text>%n",
                 x + 5, y + 3, LayoutMetrics.BADGE_FONT_SIZE, svgColor(ColorPalette.BADGE_TEXT), escapeXml(badge));
 
-        // Name centered — wrap to two lines if needed
+        // Name centered -- wrap to two lines if needed
         writeSvgWrappedName(w, name, LayoutMetrics.AUX_NAME_FONT, LayoutMetrics.AUX_NAME_FONT_SIZE,
                 cx, cy, width, 20);
     }
@@ -534,7 +486,7 @@ public final class SvgExporter {
         double y = cy - height / 2;
         double r = LayoutMetrics.LOOKUP_CORNER_RADIUS;
 
-        // Fill — subtle gray, no border
+        // Fill -- subtle gray, no border
         w.printf(Locale.US,
                 "  <rect x=\"%.2f\" y=\"%.2f\" width=\"%.2f\" height=\"%.2f\" rx=\"%.1f\" " +
                 "fill=\"%s\"/>%n",
@@ -547,14 +499,14 @@ public final class SvgExporter {
                 x + 4, y + 3, LayoutMetrics.BADGE_FONT_SIZE,
                 svgColor(ColorPalette.BADGE_TEXT), ElementRenderer.BADGE_LOOKUP);
 
-        // Name centered vertically — wrap to two lines if needed
+        // Name centered vertically -- wrap to two lines if needed
         writeSvgWrappedName(w, name, LayoutMetrics.LOOKUP_NAME_FONT, LayoutMetrics.LOOKUP_NAME_FONT_SIZE,
                 cx, cy, width, 16);
     }
 
     private static void writeCldVariable(PrintWriter w, String name,
                                           double cx, double cy, double width, double height) {
-        // Plain text only — no rectangle, matching standard CLD notation
+        // Plain text only -- no rectangle, matching standard CLD notation
         String label = ElementRenderer.truncate(name, LayoutMetrics.AUX_NAME_FONT, width - 12);
         w.printf(Locale.US,
                 "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"middle\" dominant-baseline=\"central\" " +
@@ -609,7 +561,7 @@ public final class SvgExporter {
                 Color selfLinkColor = isUnknown ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
                 String dashAttr = isUnknown ? " stroke-dasharray=\"4 3\"" : "";
 
-                // Cubic Bézier path
+                // Cubic Bezier path
                 w.printf(Locale.US,
                         "  <path d=\"M %.2f %.2f C %.2f %.2f, %.2f %.2f, %.2f %.2f\" " +
                         "fill=\"none\" stroke=\"%s\" stroke-width=\"%.1f\"%s/>%n",
@@ -619,14 +571,13 @@ public final class SvgExporter {
                 // Arrowhead at end
                 double[] tan = CausalLinkGeometry.tangentCubic(
                         lp[0], lp[1], lp[2], lp[3], lp[4], lp[5], lp[6], lp[7], 1.0);
-                writeArrowheadFromTangent(w, lp[6], lp[7], tan[0], tan[1],
+                writeSvgArrowheadFromTangent(w, lp[6], lp[7], tan[0], tan[1],
                         LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH, LayoutMetrics.CAUSAL_ARROWHEAD_WIDTH,
                         selfLinkColor);
 
                 // Polarity label at top of loop
-                double[] midPt = CausalLinkGeometry.evaluateCubic(
-                        lp[0], lp[1], lp[2], lp[3], lp[4], lp[5], lp[6], lp[7], 0.5);
-                writePolarityLabel(w, link.polarity(), midPt[0], midPt[1] - 10);
+                PolarityLabelLayout labelLayout = PolarityLabelLayout.forSelfLoop(lp);
+                writePolarityLabel(w, link.polarity(), labelLayout.x(), labelLayout.y());
                 continue;
             }
 
@@ -643,7 +594,7 @@ public final class SvgExporter {
             Color curLinkColor = isUnknown ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
             String dashAttr = isUnknown ? " stroke-dasharray=\"4 3\"" : "";
 
-            // Quadratic Bézier path
+            // Quadratic Bezier path
             w.printf(Locale.US,
                     "  <path d=\"M %.2f %.2f Q %.2f %.2f, %.2f %.2f\" " +
                     "fill=\"none\" stroke=\"%s\" stroke-width=\"%.1f\"%s/>%n",
@@ -653,39 +604,22 @@ public final class SvgExporter {
             // Arrowhead oriented along curve tangent at endpoint
             double[] tan = CausalLinkGeometry.tangent(
                     cf.x(), cf.y(), cp.x(), cp.y(), ct.x(), ct.y(), 1.0);
-            writeArrowheadFromTangent(w, ct.x(), ct.y(), tan[0], tan[1],
+            writeSvgArrowheadFromTangent(w, ct.x(), ct.y(), tan[0], tan[1],
                     LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH, LayoutMetrics.CAUSAL_ARROWHEAD_WIDTH,
                     curLinkColor);
 
             // Polarity label at t=0.8 on the curve, offset perpendicular
-            double dx = ct.x() - cf.x();
-            double dy = ct.y() - cf.y();
-            double dist = Math.sqrt(dx * dx + dy * dy);
-            if (dist > 1) {
-                double[] labelPt = CausalLinkGeometry.evaluate(
-                        cf.x(), cf.y(), cp.x(), cp.y(), ct.x(), ct.y(), 0.8);
-                double[] labelTan = CausalLinkGeometry.tangent(
-                        cf.x(), cf.y(), cp.x(), cp.y(), ct.x(), ct.y(), 0.8);
-                double tanDist = Math.sqrt(labelTan[0] * labelTan[0] + labelTan[1] * labelTan[1]);
-                if (tanDist > 0) {
-                    double perpX = -labelTan[1] / tanDist;
-                    double perpY = labelTan[0] / tanDist;
-                    double perpOffset = 12;
-                    writePolarityLabel(w, link.polarity(),
-                            labelPt[0] + perpX * perpOffset,
-                            labelPt[1] + perpY * perpOffset);
-                }
+            PolarityLabelLayout labelLayout = PolarityLabelLayout.forQuadratic(
+                    cf.x(), cf.y(), cp.x(), cp.y(), ct.x(), ct.y());
+            if (labelLayout.valid()) {
+                writePolarityLabel(w, link.polarity(), labelLayout.x(), labelLayout.y());
             }
         }
     }
 
     private static void writePolarityLabel(PrintWriter w, CausalLinkDef.Polarity polarity,
                                             double x, double y) {
-        Color labelColor = switch (polarity) {
-            case POSITIVE -> ColorPalette.CAUSAL_POSITIVE;
-            case NEGATIVE -> ColorPalette.CAUSAL_NEGATIVE;
-            case UNKNOWN -> ColorPalette.CAUSAL_UNKNOWN;
-        };
+        Color labelColor = PolarityLabelLayout.colorFor(polarity);
         double fontSize = polarity == CausalLinkDef.Polarity.UNKNOWN
                 ? LayoutMetrics.CAUSAL_UNKNOWN_FONT_SIZE : LayoutMetrics.CAUSAL_POLARITY_FONT_SIZE;
         w.printf(Locale.US,
@@ -693,30 +627,6 @@ public final class SvgExporter {
                 "dominant-baseline=\"central\" font-weight=\"bold\" font-size=\"%.0f\" " +
                 "fill=\"%s\">%s</text>%n",
                 x, y, fontSize, svgColor(labelColor), escapeXml(polarity.symbol()));
-    }
-
-    private static void writeArrowheadFromTangent(PrintWriter w,
-                                                   double tipX, double tipY,
-                                                   double tanX, double tanY,
-                                                   double length, double width,
-                                                   Color color) {
-        double dist = Math.sqrt(tanX * tanX + tanY * tanY);
-        if (dist < 1e-9) {
-            return;
-        }
-        double ux = tanX / dist;
-        double uy = tanY / dist;
-        double baseX = tipX - ux * length;
-        double baseY = tipY - uy * length;
-        double perpX = -uy * width / 2;
-        double perpY = ux * width / 2;
-
-        w.printf(Locale.US,
-                "  <polygon points=\"%.2f,%.2f %.2f,%.2f %.2f,%.2f\" fill=\"%s\"/>%n",
-                tipX, tipY,
-                baseX + perpX, baseY + perpY,
-                baseX - perpX, baseY - perpY,
-                svgColor(color));
     }
 
     // --- Loop highlights ---
@@ -804,27 +714,42 @@ public final class SvgExporter {
                 cx, cy, svgColor(ColorPalette.CLOUD));
     }
 
-    private static void writeArrowhead(PrintWriter w, double fromX, double fromY,
-                                       double toX, double toY,
-                                       double length, double arrowWidth, Color color) {
-        double dx = toX - fromX;
-        double dy = toY - fromY;
-        double dist = Math.sqrt(dx * dx + dy * dy);
-        if (dist < 1) {
+    /**
+     * Writes an SVG arrowhead polygon for a straight line, using shared geometry.
+     */
+    private static void writeSvgArrowhead(PrintWriter w, double fromX, double fromY,
+                                          double toX, double toY,
+                                          double length, double arrowWidth, Color color) {
+        ArrowheadGeometry ah = ArrowheadGeometry.fromLine(fromX, fromY, toX, toY, length, arrowWidth);
+        if (ah == null) {
             return;
         }
+        writeSvgArrowheadPolygon(w, ah, color);
+    }
 
-        double ux = dx / dist;
-        double uy = dy / dist;
+    /**
+     * Writes an SVG arrowhead polygon oriented along a tangent vector, using shared geometry.
+     */
+    private static void writeSvgArrowheadFromTangent(PrintWriter w,
+                                                      double tipX, double tipY,
+                                                      double tanX, double tanY,
+                                                      double length, double width,
+                                                      Color color) {
+        ArrowheadGeometry ah = ArrowheadGeometry.fromTangent(tipX, tipY, tanX, tanY, length, width);
+        if (ah == null) {
+            return;
+        }
+        writeSvgArrowheadPolygon(w, ah, color);
+    }
 
-        double baseX = toX - ux * length;
-        double baseY = toY - uy * length;
-
-        double perpX = -uy * arrowWidth / 2;
-        double perpY = ux * arrowWidth / 2;
-
+    /**
+     * Writes the SVG polygon element for an arrowhead.
+     */
+    private static void writeSvgArrowheadPolygon(PrintWriter w, ArrowheadGeometry ah, Color color) {
         String points = String.format(Locale.US, "%.2f,%.2f %.2f,%.2f %.2f,%.2f",
-                toX, toY, baseX + perpX, baseY + perpY, baseX - perpX, baseY - perpY);
+                ah.tipX(), ah.tipY(),
+                ah.baseLeftX(), ah.baseLeftY(),
+                ah.baseRightX(), ah.baseRightY());
 
         double opacity = svgOpacity(color);
         if (opacity < 1.0) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ConnectionRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ConnectionRenderer.java
@@ -7,13 +7,17 @@ import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
+import systems.courant.sd.app.canvas.ArrowheadGeometry;
 import systems.courant.sd.app.canvas.CausalLinkGeometry;
 import systems.courant.sd.app.canvas.ColorPalette;
 import systems.courant.sd.app.canvas.FlowEndpointCalculator;
 import systems.courant.sd.app.canvas.LayoutMetrics;
+import systems.courant.sd.app.canvas.PolarityLabelLayout;
 
 /**
  * Static methods for drawing material flows and info links between elements.
+ * Geometry computations are delegated to {@link ArrowheadGeometry} and
+ * {@link PolarityLabelLayout} so they can be shared with the SVG exporter.
  */
 public final class ConnectionRenderer {
 
@@ -35,8 +39,8 @@ public final class ConnectionRenderer {
 
     /**
      * Draws a material flow routed through the flow indicator (diamond) position.
-     * The path is: source → diamond → sink, with clouds drawn at endpoints marked as clouds.
-     * All coordinates must be concrete (no NaN) — the caller is responsible for computing
+     * The path is: source -> diamond -> sink, with clouds drawn at endpoints marked as clouds.
+     * All coordinates must be concrete (no NaN) -- the caller is responsible for computing
      * cloud positions via {@link FlowEndpointCalculator#cloudPosition}.
      *
      * @param sourceX       source endpoint X
@@ -89,25 +93,16 @@ public final class ConnectionRenderer {
             }
         }
 
-        // Source → diamond segment (no arrowhead — draw full length)
+        // Source -> diamond segment (no arrowhead -- draw full length)
         gc.setStroke(color);
         gc.setLineWidth(LayoutMetrics.MATERIAL_FLOW_WIDTH);
         gc.setLineDashes();
         gc.strokeLine(pipeSourceX, pipeSourceY, midX, midY);
 
-        // Diamond → sink segment: stop line at arrowhead base
-        double sinkDx = pipeSinkX - midX;
-        double sinkDy = pipeSinkY - midY;
-        double sinkDist = Math.sqrt(sinkDx * sinkDx + sinkDy * sinkDy);
-        double lineEndX = pipeSinkX;
-        double lineEndY = pipeSinkY;
-        if (sinkDist > LayoutMetrics.ARROWHEAD_LENGTH) {
-            double ux = sinkDx / sinkDist;
-            double uy = sinkDy / sinkDist;
-            lineEndX = pipeSinkX - ux * LayoutMetrics.ARROWHEAD_LENGTH;
-            lineEndY = pipeSinkY - uy * LayoutMetrics.ARROWHEAD_LENGTH;
-        }
-        gc.strokeLine(midX, midY, lineEndX, lineEndY);
+        // Diamond -> sink segment: stop line at arrowhead base
+        double[] stop = ArrowheadGeometry.lineStopPoint(
+                midX, midY, pipeSinkX, pipeSinkY, LayoutMetrics.ARROWHEAD_LENGTH);
+        gc.strokeLine(midX, midY, stop[0], stop[1]);
 
         // Arrowhead fills the gap from lineEnd to pipeSink
         drawArrowhead(gc, midX, midY, pipeSinkX, pipeSinkY,
@@ -122,22 +117,13 @@ public final class ConnectionRenderer {
                                     double fromX, double fromY,
                                     double toX, double toY) {
         // Stop line at arrowhead base so it doesn't extend behind the arrowhead
-        double dx = toX - fromX;
-        double dy = toY - fromY;
-        double dist = Math.sqrt(dx * dx + dy * dy);
-        double lineToX = toX;
-        double lineToY = toY;
-        if (dist > LayoutMetrics.INFO_ARROWHEAD_LENGTH) {
-            double ux = dx / dist;
-            double uy = dy / dist;
-            lineToX = toX - ux * LayoutMetrics.INFO_ARROWHEAD_LENGTH;
-            lineToY = toY - uy * LayoutMetrics.INFO_ARROWHEAD_LENGTH;
-        }
+        double[] stop = ArrowheadGeometry.lineStopPoint(
+                fromX, fromY, toX, toY, LayoutMetrics.INFO_ARROWHEAD_LENGTH);
 
         gc.setStroke(ColorPalette.INFO_LINK);
         gc.setLineWidth(LayoutMetrics.INFO_LINK_WIDTH);
         gc.setLineDashes(LayoutMetrics.INFO_LINK_DASH_LENGTH, LayoutMetrics.INFO_LINK_DASH_GAP);
-        gc.strokeLine(fromX, fromY, lineToX, lineToY);
+        gc.strokeLine(fromX, fromY, stop[0], stop[1]);
         gc.setLineDashes();
 
         drawArrowhead(gc, fromX, fromY, toX, toY,
@@ -146,7 +132,7 @@ public final class ConnectionRenderer {
     }
 
     /**
-     * Draws a causal link as a quadratic Bézier curve with arrowhead and polarity label.
+     * Draws a causal link as a quadratic Bezier curve with arrowhead and polarity label.
      */
     public static void drawCausalLink(GraphicsContext gc,
                                       double fromX, double fromY,
@@ -177,46 +163,29 @@ public final class ConnectionRenderer {
         gc.setLineDashes();
 
         // Arrowhead oriented along the curve tangent at the tip
-        drawArrowheadFromTangent(gc, tipX, tipY, tanX, tanY,
-                LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH, LayoutMetrics.CAUSAL_ARROWHEAD_WIDTH,
-                linkColor);
+        ArrowheadGeometry arrowhead = ArrowheadGeometry.fromTangent(tipX, tipY, tanX, tanY,
+                LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH, LayoutMetrics.CAUSAL_ARROWHEAD_WIDTH);
+        if (arrowhead != null) {
+            fillArrowhead(gc, arrowhead, linkColor);
+        }
 
         // Polarity label near the arrowhead, offset perpendicular to the curve tangent
-        double dx = toX - fromX;
-        double dy = toY - fromY;
-        double dist = Math.sqrt(dx * dx + dy * dy);
-        if (dist > 1) {
-            Color labelColor = switch (polarity) {
-                case POSITIVE -> ColorPalette.CAUSAL_POSITIVE;
-                case NEGATIVE -> ColorPalette.CAUSAL_NEGATIVE;
-                case UNKNOWN -> ColorPalette.CAUSAL_UNKNOWN;
-            };
-
-            // Place label at t ≈ 0.8 on the curve, offset perpendicular to the tangent
-            double labelT = 0.8;
-            double[] labelPt = CausalLinkGeometry.evaluate(fromX, fromY, cp.x(), cp.y(), toX, toY, labelT);
-            double[] labelTan = CausalLinkGeometry.tangent(fromX, fromY, cp.x(), cp.y(), toX, toY, labelT);
-            double tanDist = Math.sqrt(labelTan[0] * labelTan[0] + labelTan[1] * labelTan[1]);
-            if (tanDist > 0) {
-                double perpX = -labelTan[1] / tanDist;
-                double perpY = labelTan[0] / tanDist;
-                double perpOffset = 12;
-                double labelX = labelPt[0] + perpX * perpOffset;
-                double labelY = labelPt[1] + perpY * perpOffset;
-
-                Font labelFont = polarity == CausalLinkDef.Polarity.UNKNOWN
-                        ? LayoutMetrics.CAUSAL_UNKNOWN_FONT : LayoutMetrics.CAUSAL_POLARITY_FONT;
-                gc.setFill(labelColor);
-                gc.setFont(labelFont);
-                gc.setTextAlign(TextAlignment.CENTER);
-                gc.setTextBaseline(VPos.CENTER);
-                gc.fillText(polarity.symbol(), labelX, labelY);
-            }
+        PolarityLabelLayout labelLayout = PolarityLabelLayout.forQuadratic(
+                fromX, fromY, cp.x(), cp.y(), toX, toY);
+        if (labelLayout.valid()) {
+            Color labelColor = PolarityLabelLayout.colorFor(polarity);
+            Font labelFont = polarity == CausalLinkDef.Polarity.UNKNOWN
+                    ? LayoutMetrics.CAUSAL_UNKNOWN_FONT : LayoutMetrics.CAUSAL_POLARITY_FONT;
+            gc.setFill(labelColor);
+            gc.setFont(labelFont);
+            gc.setTextAlign(TextAlignment.CENTER);
+            gc.setTextBaseline(VPos.CENTER);
+            gc.fillText(polarity.symbol(), labelLayout.x(), labelLayout.y());
         }
     }
 
     /**
-     * Draws a self-loop causal link as a cubic Bézier curve.
+     * Draws a self-loop causal link as a cubic Bezier curve.
      */
     public static void drawCausalLinkSelfLoop(GraphicsContext gc,
                                                double[] loopPts,
@@ -250,52 +219,30 @@ public final class ConnectionRenderer {
         // Arrowhead at the end
         double[] tan = CausalLinkGeometry.tangentCubic(
                 startX, startY, cp1X, cp1Y, cp2X, cp2Y, endX, endY, 1.0);
-        drawArrowheadFromTangent(gc, endX, endY, tan[0], tan[1],
-                LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH, LayoutMetrics.CAUSAL_ARROWHEAD_WIDTH,
-                linkColor);
+        ArrowheadGeometry arrowhead = ArrowheadGeometry.fromTangent(endX, endY, tan[0], tan[1],
+                LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH, LayoutMetrics.CAUSAL_ARROWHEAD_WIDTH);
+        if (arrowhead != null) {
+            fillArrowhead(gc, arrowhead, linkColor);
+        }
 
         // Polarity label at the top of the loop
-        double[] midPt = CausalLinkGeometry.evaluateCubic(
-                startX, startY, cp1X, cp1Y, cp2X, cp2Y, endX, endY, 0.5);
-        Color labelColor = switch (polarity) {
-            case POSITIVE -> ColorPalette.CAUSAL_POSITIVE;
-            case NEGATIVE -> ColorPalette.CAUSAL_NEGATIVE;
-            case UNKNOWN -> ColorPalette.CAUSAL_UNKNOWN;
-        };
+        PolarityLabelLayout labelLayout = PolarityLabelLayout.forSelfLoop(loopPts);
+        Color labelColor = PolarityLabelLayout.colorFor(polarity);
         Font labelFont = polarity == CausalLinkDef.Polarity.UNKNOWN
                 ? LayoutMetrics.CAUSAL_UNKNOWN_FONT : LayoutMetrics.CAUSAL_POLARITY_FONT;
         gc.setFill(labelColor);
         gc.setFont(labelFont);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
-        gc.fillText(polarity.symbol(), midPt[0], midPt[1] - 10);
+        gc.fillText(polarity.symbol(), labelLayout.x(), labelLayout.y());
     }
 
     /**
-     * Draws a filled arrowhead at (tipX,tipY) oriented along the given tangent vector.
+     * Fills a pre-computed arrowhead triangle on the graphics context.
      */
-    private static void drawArrowheadFromTangent(GraphicsContext gc,
-                                                  double tipX, double tipY,
-                                                  double tanX, double tanY,
-                                                  double length, double width,
-                                                  javafx.scene.paint.Color color) {
-        double dist = Math.sqrt(tanX * tanX + tanY * tanY);
-        if (dist < 1e-9) {
-            return;
-        }
-
-        double ux = tanX / dist;
-        double uy = tanY / dist;
-
-        double baseX = tipX - ux * length;
-        double baseY = tipY - uy * length;
-
-        double perpX = -uy * width / 2;
-        double perpY = ux * width / 2;
-
-        double[] xPoints = {tipX, baseX + perpX, baseX - perpX};
-        double[] yPoints = {tipY, baseY + perpY, baseY - perpY};
-
+    private static void fillArrowhead(GraphicsContext gc, ArrowheadGeometry ah, Color color) {
+        double[] xPoints = {ah.tipX(), ah.baseLeftX(), ah.baseRightX()};
+        double[] yPoints = {ah.tipY(), ah.baseLeftY(), ah.baseRightY()};
         gc.setFill(color);
         gc.fillPolygon(xPoints, yPoints, 3);
     }
@@ -308,30 +255,11 @@ public final class ConnectionRenderer {
                                       double fromX, double fromY,
                                       double toX, double toY,
                                       double length, double width,
-                                      javafx.scene.paint.Color color) {
-        double dx = toX - fromX;
-        double dy = toY - fromY;
-        double dist = Math.sqrt(dx * dx + dy * dy);
-        if (dist < 1) {
-            return;
+                                      Color color) {
+        ArrowheadGeometry ah = ArrowheadGeometry.fromLine(fromX, fromY, toX, toY, length, width);
+        if (ah != null) {
+            fillArrowhead(gc, ah, color);
         }
-
-        double ux = dx / dist;
-        double uy = dy / dist;
-
-        // Base of the arrowhead
-        double baseX = toX - ux * length;
-        double baseY = toY - uy * length;
-
-        // Perpendicular offset
-        double perpX = -uy * width / 2;
-        double perpY = ux * width / 2;
-
-        double[] xPoints = {toX, baseX + perpX, baseX - perpX};
-        double[] yPoints = {toY, baseY + perpY, baseY - perpY};
-
-        gc.setFill(color);
-        gc.fillPolygon(xPoints, yPoints, 3);
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/MaterialFlowPass.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/MaterialFlowPass.java
@@ -4,17 +4,15 @@ import javafx.scene.canvas.GraphicsContext;
 
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.ColorPalette;
-import systems.courant.sd.app.canvas.FlowEndpointCalculator;
-import systems.courant.sd.app.canvas.FlowGeometry;
-import systems.courant.sd.app.canvas.LayoutMetrics;
+import systems.courant.sd.app.canvas.MaterialFlowEndpoints;
 import systems.courant.sd.app.canvas.MaturityAnalysis;
 import systems.courant.sd.app.canvas.ModelEditor;
 import systems.courant.sd.model.def.FlowDef;
 
 /**
  * Draws material flow arrows routed through the flow indicator (diamond).
- * Cloud positions are computed via {@link FlowEndpointCalculator#cloudPosition}
- * so that rendering and hit-testing use the same logic.
+ * Endpoint resolution is delegated to {@link MaterialFlowEndpoints} so that
+ * rendering and SVG export use the same logic.
  * Flows with unit mismatches are drawn in red.
  */
 final class MaterialFlowPass implements RenderPass {
@@ -31,57 +29,26 @@ final class MaterialFlowPass implements RenderPass {
         MaturityAnalysis maturity = ctx.maturityAnalysis();
 
         for (FlowDef flow : editor.getFlows()) {
-            if (!canvasState.hasElement(flow.name())) {
+            MaterialFlowEndpoints endpoints = MaterialFlowEndpoints.resolve(flow, canvasState);
+            if (endpoints == null) {
                 continue;
-            }
-            double midX = canvasState.getX(flow.name());
-            double midY = canvasState.getY(flow.name());
-
-            double sourceX;
-            double sourceY;
-            boolean sourceIsCloud;
-
-            if (flow.source() != null && canvasState.hasElement(flow.source())) {
-                FlowGeometry.Point2D edge = FlowGeometry.clipToElement(
-                        canvasState, flow.source(), midX, midY);
-                sourceX = edge.x();
-                sourceY = edge.y();
-                sourceIsCloud = false;
-            } else {
-                FlowGeometry.Point2D cloud = FlowEndpointCalculator.cloudPosition(
-                        FlowEndpointCalculator.FlowEnd.SOURCE, flow, canvasState);
-                sourceX = cloud != null ? cloud.x() : midX - LayoutMetrics.CLOUD_OFFSET;
-                sourceY = cloud != null ? cloud.y() : midY;
-                sourceIsCloud = true;
-            }
-
-            double sinkX;
-            double sinkY;
-            boolean sinkIsCloud;
-
-            if (flow.sink() != null && canvasState.hasElement(flow.sink())) {
-                FlowGeometry.Point2D edge = FlowGeometry.clipToElement(
-                        canvasState, flow.sink(), midX, midY);
-                sinkX = edge.x();
-                sinkY = edge.y();
-                sinkIsCloud = false;
-            } else {
-                FlowGeometry.Point2D cloud = FlowEndpointCalculator.cloudPosition(
-                        FlowEndpointCalculator.FlowEnd.SINK, flow, canvasState);
-                sinkX = cloud != null ? cloud.x() : midX + LayoutMetrics.CLOUD_OFFSET;
-                sinkY = cloud != null ? cloud.y() : midY;
-                sinkIsCloud = true;
             }
 
             boolean mismatch = maturity != null
                     && maturity.unitMismatchFlows().contains(flow.name());
             if (mismatch) {
-                ConnectionRenderer.drawMaterialFlow(gc, sourceX, sourceY, midX, midY,
-                        sinkX, sinkY, sourceIsCloud, sinkIsCloud,
+                ConnectionRenderer.drawMaterialFlow(gc,
+                        endpoints.sourceX(), endpoints.sourceY(),
+                        endpoints.midX(), endpoints.midY(),
+                        endpoints.sinkX(), endpoints.sinkY(),
+                        endpoints.sourceIsCloud(), endpoints.sinkIsCloud(),
                         ColorPalette.UNIT_MISMATCH);
             } else {
-                ConnectionRenderer.drawMaterialFlow(gc, sourceX, sourceY, midX, midY,
-                        sinkX, sinkY, sourceIsCloud, sinkIsCloud);
+                ConnectionRenderer.drawMaterialFlow(gc,
+                        endpoints.sourceX(), endpoints.sourceY(),
+                        endpoints.midX(), endpoints.midY(),
+                        endpoints.sinkX(), endpoints.sinkY(),
+                        endpoints.sourceIsCloud(), endpoints.sinkIsCloud());
             }
         }
     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ArrowheadGeometryTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ArrowheadGeometryTest.java
@@ -1,0 +1,172 @@
+package systems.courant.sd.app.canvas;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+
+@DisplayName("ArrowheadGeometry")
+class ArrowheadGeometryTest {
+
+    private static final double EPSILON = 1e-9;
+
+    @Nested
+    @DisplayName("fromLine")
+    class FromLine {
+
+        @Test
+        void shouldReturnNullWhenDistanceLessThanOne() {
+            ArrowheadGeometry result = ArrowheadGeometry.fromLine(0, 0, 0.5, 0, 10, 6);
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldReturnNullWhenCoincident() {
+            ArrowheadGeometry result = ArrowheadGeometry.fromLine(5, 5, 5, 5, 10, 6);
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldComputeArrowheadPointingRight() {
+            // Line from (0,0) to (100,0), arrowhead length=10, width=6
+            ArrowheadGeometry ah = ArrowheadGeometry.fromLine(0, 0, 100, 0, 10, 6);
+
+            assertThat(ah).isNotNull();
+            assertThat(ah.tipX()).isCloseTo(100, offset(EPSILON));
+            assertThat(ah.tipY()).isCloseTo(0, offset(EPSILON));
+            // Base is 10 units behind the tip
+            assertThat(ah.baseLeftX()).isCloseTo(90, offset(EPSILON));
+            assertThat(ah.baseLeftY()).isCloseTo(3, offset(EPSILON));
+            assertThat(ah.baseRightX()).isCloseTo(90, offset(EPSILON));
+            assertThat(ah.baseRightY()).isCloseTo(-3, offset(EPSILON));
+        }
+
+        @Test
+        void shouldComputeArrowheadPointingUp() {
+            // Line from (0,100) to (0,0), arrowhead length=10, width=6
+            ArrowheadGeometry ah = ArrowheadGeometry.fromLine(0, 100, 0, 0, 10, 6);
+
+            assertThat(ah).isNotNull();
+            assertThat(ah.tipX()).isCloseTo(0, offset(EPSILON));
+            assertThat(ah.tipY()).isCloseTo(0, offset(EPSILON));
+            // Base is 10 units below the tip (in the +y direction)
+            // perpX = -uy * w/2 = 3, perpY = ux * w/2 = 0
+            assertThat(ah.baseLeftX()).isCloseTo(3, offset(EPSILON));
+            assertThat(ah.baseLeftY()).isCloseTo(10, offset(EPSILON));
+            assertThat(ah.baseRightX()).isCloseTo(-3, offset(EPSILON));
+            assertThat(ah.baseRightY()).isCloseTo(10, offset(EPSILON));
+        }
+
+        @Test
+        void shouldComputeArrowheadDiagonal() {
+            // Line from (0,0) to (100,100), arrowhead length=10, width=6
+            ArrowheadGeometry ah = ArrowheadGeometry.fromLine(0, 0, 100, 100, 10, 6);
+
+            assertThat(ah).isNotNull();
+            assertThat(ah.tipX()).isCloseTo(100, offset(EPSILON));
+            assertThat(ah.tipY()).isCloseTo(100, offset(EPSILON));
+
+            // Verify base center is 10 units behind tip along the line
+            double baseCx = (ah.baseLeftX() + ah.baseRightX()) / 2;
+            double baseCy = (ah.baseLeftY() + ah.baseRightY()) / 2;
+            double distToTip = Math.sqrt(
+                    Math.pow(100 - baseCx, 2) + Math.pow(100 - baseCy, 2));
+            assertThat(distToTip).isCloseTo(10, offset(EPSILON));
+
+            // Verify base width is 6
+            double baseWidth = Math.sqrt(
+                    Math.pow(ah.baseLeftX() - ah.baseRightX(), 2)
+                    + Math.pow(ah.baseLeftY() - ah.baseRightY(), 2));
+            assertThat(baseWidth).isCloseTo(6, offset(EPSILON));
+        }
+    }
+
+    @Nested
+    @DisplayName("fromTangent")
+    class FromTangent {
+
+        @Test
+        void shouldReturnNullWhenTangentIsZero() {
+            ArrowheadGeometry result = ArrowheadGeometry.fromTangent(50, 50, 0, 0, 10, 6);
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldReturnNullWhenTangentIsNearZero() {
+            ArrowheadGeometry result = ArrowheadGeometry.fromTangent(50, 50, 1e-10, 0, 10, 6);
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldComputeArrowheadFromUnnormalizedTangent() {
+            // Tangent (200, 0) should be normalized to (1, 0)
+            ArrowheadGeometry ah = ArrowheadGeometry.fromTangent(100, 0, 200, 0, 10, 6);
+
+            assertThat(ah).isNotNull();
+            assertThat(ah.tipX()).isCloseTo(100, offset(EPSILON));
+            assertThat(ah.tipY()).isCloseTo(0, offset(EPSILON));
+            assertThat(ah.baseLeftX()).isCloseTo(90, offset(EPSILON));
+        }
+
+        @Test
+        void shouldMatchFromLineForStraightSegments() {
+            // For a straight horizontal line, fromTangent with tangent (1,0) should match fromLine
+            ArrowheadGeometry fromLine = ArrowheadGeometry.fromLine(0, 0, 100, 0, 10, 6);
+            ArrowheadGeometry fromTan = ArrowheadGeometry.fromTangent(100, 0, 1, 0, 10, 6);
+
+            assertThat(fromLine).isNotNull();
+            assertThat(fromTan).isNotNull();
+            assertThat(fromTan.tipX()).isCloseTo(fromLine.tipX(), offset(EPSILON));
+            assertThat(fromTan.tipY()).isCloseTo(fromLine.tipY(), offset(EPSILON));
+            assertThat(fromTan.baseLeftX()).isCloseTo(fromLine.baseLeftX(), offset(EPSILON));
+            assertThat(fromTan.baseLeftY()).isCloseTo(fromLine.baseLeftY(), offset(EPSILON));
+            assertThat(fromTan.baseRightX()).isCloseTo(fromLine.baseRightX(), offset(EPSILON));
+            assertThat(fromTan.baseRightY()).isCloseTo(fromLine.baseRightY(), offset(EPSILON));
+        }
+    }
+
+    @Nested
+    @DisplayName("lineStopPoint")
+    class LineStopPoint {
+
+        @Test
+        void shouldReturnToPointWhenLineShorterThanArrow() {
+            double[] stop = ArrowheadGeometry.lineStopPoint(0, 0, 5, 0, 10);
+            assertThat(stop[0]).isCloseTo(5, offset(EPSILON));
+            assertThat(stop[1]).isCloseTo(0, offset(EPSILON));
+        }
+
+        @Test
+        void shouldReturnToPointWhenLineEqualsArrow() {
+            double[] stop = ArrowheadGeometry.lineStopPoint(0, 0, 10, 0, 10);
+            assertThat(stop[0]).isCloseTo(10, offset(EPSILON));
+            assertThat(stop[1]).isCloseTo(0, offset(EPSILON));
+        }
+
+        @Test
+        void shouldStopBeforeArrowheadBase() {
+            double[] stop = ArrowheadGeometry.lineStopPoint(0, 0, 100, 0, 14);
+            assertThat(stop[0]).isCloseTo(86, offset(EPSILON));
+            assertThat(stop[1]).isCloseTo(0, offset(EPSILON));
+        }
+
+        @Test
+        void shouldHandleVerticalLine() {
+            double[] stop = ArrowheadGeometry.lineStopPoint(0, 0, 0, 100, 8);
+            assertThat(stop[0]).isCloseTo(0, offset(EPSILON));
+            assertThat(stop[1]).isCloseTo(92, offset(EPSILON));
+        }
+
+        @Test
+        void shouldHandleDiagonalLine() {
+            double[] stop = ArrowheadGeometry.lineStopPoint(0, 0, 100, 100, 10);
+            // Direction is (1/sqrt(2), 1/sqrt(2)), stop point should be at
+            // (100 - 10/sqrt(2), 100 - 10/sqrt(2))
+            double offset45 = 10.0 / Math.sqrt(2);
+            assertThat(stop[0]).isCloseTo(100 - offset45, offset(EPSILON));
+            assertThat(stop[1]).isCloseTo(100 - offset45, offset(EPSILON));
+        }
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/MaterialFlowEndpointsTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/MaterialFlowEndpointsTest.java
@@ -1,0 +1,39 @@
+package systems.courant.sd.app.canvas;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import systems.courant.sd.model.def.FlowDef;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("MaterialFlowEndpoints")
+class MaterialFlowEndpointsTest {
+
+    @Nested
+    @DisplayName("resolve")
+    class Resolve {
+
+        @Test
+        void shouldReturnNullWhenFlowNotOnCanvas() {
+            CanvasState state = new CanvasState();
+            // Flow "myflow" not added to canvas
+            FlowDef flow = new FlowDef("myflow", "10", "Day", "stock1", "stock2");
+            assertThat(MaterialFlowEndpoints.resolve(flow, state)).isNull();
+        }
+
+        @Test
+        void shouldResolveBothCloudsWhenDisconnected() {
+            CanvasState state = new CanvasState();
+            state.addElement("myflow", systems.courant.sd.model.def.ElementType.FLOW, 100, 200);
+            FlowDef flow = new FlowDef("myflow", "10", "Day", null, null);
+
+            MaterialFlowEndpoints ep = MaterialFlowEndpoints.resolve(flow, state);
+            assertThat(ep).isNotNull();
+            assertThat(ep.midX()).isEqualTo(100);
+            assertThat(ep.midY()).isEqualTo(200);
+            assertThat(ep.sourceIsCloud()).isTrue();
+            assertThat(ep.sinkIsCloud()).isTrue();
+        }
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/PolarityLabelLayoutTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/PolarityLabelLayoutTest.java
@@ -1,0 +1,88 @@
+package systems.courant.sd.app.canvas;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import systems.courant.sd.model.def.CausalLinkDef;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+
+@DisplayName("PolarityLabelLayout")
+class PolarityLabelLayoutTest {
+
+    private static final double EPSILON = 1e-6;
+
+    @Nested
+    @DisplayName("forQuadratic")
+    class ForQuadratic {
+
+        @Test
+        void shouldReturnInvalidWhenEndpointsCoincident() {
+            PolarityLabelLayout layout = PolarityLabelLayout.forQuadratic(
+                    50, 50, 60, 40, 50, 50);
+            assertThat(layout.valid()).isFalse();
+        }
+
+        @Test
+        void shouldReturnValidForSeparatedEndpoints() {
+            PolarityLabelLayout layout = PolarityLabelLayout.forQuadratic(
+                    0, 0, 50, -30, 100, 0);
+            assertThat(layout.valid()).isTrue();
+        }
+
+        @Test
+        void shouldPlaceLabelOffsetFromCurve() {
+            // Straight-ish curve from (0,0) to (100,0) with control point at (50, -30)
+            PolarityLabelLayout layout = PolarityLabelLayout.forQuadratic(
+                    0, 0, 50, -30, 100, 0);
+            assertThat(layout.valid()).isTrue();
+            // Label should be somewhere near t=0.8, offset perpendicularly
+            assertThat(layout.x()).isGreaterThan(50);
+            assertThat(layout.x()).isLessThan(120);
+        }
+    }
+
+    @Nested
+    @DisplayName("forSelfLoop")
+    class ForSelfLoop {
+
+        @Test
+        void shouldReturnValidLayout() {
+            double[] loopPts = CausalLinkGeometry.selfLoopPoints(100, 200, 30, 20);
+            PolarityLabelLayout layout = PolarityLabelLayout.forSelfLoop(loopPts);
+            assertThat(layout.valid()).isTrue();
+        }
+
+        @Test
+        void shouldPlaceLabelAboveElement() {
+            double[] loopPts = CausalLinkGeometry.selfLoopPoints(100, 200, 30, 20);
+            PolarityLabelLayout layout = PolarityLabelLayout.forSelfLoop(loopPts);
+            // Label should be above the element center (lower y value)
+            assertThat(layout.y()).isLessThan(200);
+        }
+    }
+
+    @Nested
+    @DisplayName("colorFor")
+    class ColorFor {
+
+        @Test
+        void shouldReturnPositiveColor() {
+            assertThat(PolarityLabelLayout.colorFor(CausalLinkDef.Polarity.POSITIVE))
+                    .isEqualTo(ColorPalette.CAUSAL_POSITIVE);
+        }
+
+        @Test
+        void shouldReturnNegativeColor() {
+            assertThat(PolarityLabelLayout.colorFor(CausalLinkDef.Polarity.NEGATIVE))
+                    .isEqualTo(ColorPalette.CAUSAL_NEGATIVE);
+        }
+
+        @Test
+        void shouldReturnUnknownColor() {
+            assertThat(PolarityLabelLayout.colorFor(CausalLinkDef.Polarity.UNKNOWN))
+                    .isEqualTo(ColorPalette.CAUSAL_UNKNOWN);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `ArrowheadGeometry` record: shared arrowhead triangle computation (tip, base-left, base-right vertices) and line-stop-before-arrowhead calculation, replacing duplicated math in both `ConnectionRenderer` and `SvgExporter`
- Extract `MaterialFlowEndpoints` record: shared source/sink endpoint resolution (clip-to-stock-border or cloud-position), replacing identical 30-line blocks in `MaterialFlowPass` and `SvgExporter.writeMaterialFlows`
- Extract `PolarityLabelLayout` record: shared polarity label positioning (perpendicular offset at t=0.8 on quadratic Bezier, and self-loop midpoint), replacing duplicated computation in `ConnectionRenderer.drawCausalLink`/`drawCausalLinkSelfLoop` and `SvgExporter.writeCausalLinks`
- Net reduction of ~180 lines of duplicated geometry code across the 3 consumer files

## Test plan
- [x] New `ArrowheadGeometryTest` with 11 tests covering `fromLine`, `fromTangent`, and `lineStopPoint`
- [x] New `MaterialFlowEndpointsTest` with 2 tests covering null-when-absent and cloud resolution
- [x] New `PolarityLabelLayoutTest` with 6 tests covering quadratic, self-loop, and color mapping
- [x] Full test suite passes (all modules, zero failures)
- [x] SpotBugs clean
- [x] Verified functional equivalence: extracted code computes identical values

Closes #976