### PR TITLE
Extract CsvExportHelper and deduplicate CSV/PNG export patterns (#291)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CsvExportHelper.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CsvExportHelper.java
@@ -1,0 +1,59 @@
+package systems.courant.sd.app.canvas;
+
+import com.opencsv.CSVWriter;
+
+import systems.courant.sd.sweep.RunResult;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared CSV export utilities that eliminate duplication across result pane classes.
+ *
+ * <p>Each method writes a specific data shape to a {@link File} and throws {@link IOException}
+ * on failure, making them compatible with {@link ChartUtils#showCsvSaveDialog}.
+ */
+public final class CsvExportHelper {
+
+    private CsvExportHelper() {
+    }
+
+    /**
+     * Writes a {@link RunResult} to CSV with columns for Step, all stocks, and all variables.
+     * Used by both optimization and calibration result panes to export the best-run time series.
+     *
+     * @param file the target CSV file
+     * @param run  the run result to export
+     * @throws IOException if writing fails
+     */
+    public static void writeRunResult(File file, RunResult run) throws IOException {
+        List<String> stockNames = run.getStockNames();
+        List<String> varNames = run.getVariableNames();
+
+        try (CSVWriter writer = new CSVWriter(new OutputStreamWriter(
+                Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8))) {
+            List<String> header = new ArrayList<>();
+            header.add("Step");
+            header.addAll(stockNames);
+            header.addAll(varNames);
+            writer.writeNext(header.toArray(new String[0]));
+
+            for (int s = 0; s < run.getStepCount(); s++) {
+                List<String> row = new ArrayList<>();
+                row.add(String.valueOf(run.getStep(s)));
+                for (double v : run.getStockValuesAtStep(s)) {
+                    row.add(String.valueOf(v));
+                }
+                for (double v : run.getVariableValuesAtStep(s)) {
+                    row.add(String.valueOf(v));
+                }
+                writer.writeNext(row.toArray(new String[0]));
+            }
+        }
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/CalibrationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/CalibrationResultPane.java
@@ -4,8 +4,6 @@ import systems.courant.sd.app.canvas.dialogs.CalibrateDialog;
 import systems.courant.sd.sweep.OptimizationResult;
 import systems.courant.sd.sweep.RunResult;
 
-import com.opencsv.CSVWriter;
-
 import javafx.geometry.Insets;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
@@ -17,15 +15,12 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
 
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import systems.courant.sd.app.canvas.ChartUtils;
 import systems.courant.sd.app.canvas.ClipboardExporter;
+import systems.courant.sd.app.canvas.CsvExportHelper;
 import systems.courant.sd.app.canvas.Styles;
 
 /**
@@ -149,32 +144,8 @@ public class CalibrationResultPane extends BorderPane {
 
     private void exportBestRunCsv() {
         ChartUtils.showCsvSaveDialog("Export Best Run CSV", "calibration_best_run.csv",
-                getScene() != null ? getScene().getWindow() : null, file -> {
-                    RunResult bestRun = result.getBestRunResult();
-                    List<String> stockNames = bestRun.getStockNames();
-                    List<String> varNames = bestRun.getVariableNames();
-
-                    try (CSVWriter writer = new CSVWriter(new OutputStreamWriter(
-                            Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8))) {
-                        List<String> header = new ArrayList<>();
-                        header.add("Step");
-                        header.addAll(stockNames);
-                        header.addAll(varNames);
-                        writer.writeNext(header.toArray(new String[0]));
-
-                        for (int s = 0; s < bestRun.getStepCount(); s++) {
-                            List<String> csvRow = new ArrayList<>();
-                            csvRow.add(String.valueOf(bestRun.getStep(s)));
-                            for (double v : bestRun.getStockValuesAtStep(s)) {
-                                csvRow.add(String.valueOf(v));
-                            }
-                            for (double v : bestRun.getVariableValuesAtStep(s)) {
-                                csvRow.add(String.valueOf(v));
-                            }
-                            writer.writeNext(csvRow.toArray(new String[0]));
-                        }
-                    }
-                });
+                getScene() != null ? getScene().getWindow() : null,
+                file -> CsvExportHelper.writeRunResult(file, result.getBestRunResult()));
     }
 
     private static Label boldLabel(String text) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/LoopDominancePane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/LoopDominancePane.java
@@ -5,33 +5,25 @@ import com.opencsv.CSVWriter;
 import systems.courant.sd.model.graph.FeedbackAnalysis;
 import systems.courant.sd.model.graph.LoopDominanceAnalysis;
 
-import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Insets;
-import javafx.scene.SnapshotParameters;
 import javafx.scene.chart.AreaChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
-import javafx.scene.control.Alert;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TitledPane;
-import javafx.scene.image.WritableImage;
 import javafx.beans.property.DoubleProperty;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.layout.Priority;
-import javafx.stage.FileChooser;
-import systems.courant.sd.app.LastDirectoryStore;
 
-import javax.imageio.ImageIO;
-
-import java.io.File;
-import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
+
+import systems.courant.sd.app.canvas.ChartUtils;
 import systems.courant.sd.app.canvas.LoopNavigatorBar;
 
 /**
@@ -123,60 +115,30 @@ public final class LoopDominancePane extends VBox {
     }
 
     private void saveChartAsPng() {
-        if (chart == null) {
-            return;
-        }
-        FileChooser fileChooser = new FileChooser();
-        fileChooser.setTitle("Save Chart as PNG");
-        fileChooser.getExtensionFilters().add(
-                new FileChooser.ExtensionFilter("PNG Image", "*.png"));
-        fileChooser.setInitialFileName("loop_dominance_chart.png");
-        LastDirectoryStore.applyExportDirectory(fileChooser);
-
-        File file = fileChooser.showSaveDialog(getScene() != null ? getScene().getWindow() : null);
-        if (file != null) {
-            LastDirectoryStore.recordExportDirectory(file);
-            WritableImage image = chart.snapshot(new SnapshotParameters(), null);
-            try {
-                ImageIO.write(SwingFXUtils.fromFXImage(image, null), "png", file);
-            } catch (IOException e) {
-                new Alert(Alert.AlertType.ERROR,
-                        "Failed to save image: " + e.getMessage()).showAndWait();
-            }
-        }
+        ChartUtils.saveNodeAsPng(chart, "loop_dominance_chart.png",
+                getScene() != null ? getScene().getWindow() : null);
     }
 
     private void exportCsv() {
-        FileChooser fileChooser = new FileChooser();
-        fileChooser.setTitle("Export Loop Dominance CSV");
-        fileChooser.getExtensionFilters().add(
-                new FileChooser.ExtensionFilter("CSV Files", "*.csv"));
-        fileChooser.setInitialFileName("loop_dominance.csv");
-        LastDirectoryStore.applyExportDirectory(fileChooser);
+        ChartUtils.showCsvSaveDialog("Export Loop Dominance CSV", "loop_dominance.csv",
+                getScene() != null ? getScene().getWindow() : null, file -> {
+                    try (CSVWriter writer = new CSVWriter(new OutputStreamWriter(
+                            Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8))) {
+                        List<String> header = new java.util.ArrayList<>();
+                        header.add("Step");
+                        header.addAll(dominance.loopLabels());
+                        writer.writeNext(header.toArray(new String[0]));
 
-        File file = fileChooser.showSaveDialog(getScene() != null ? getScene().getWindow() : null);
-        if (file != null) {
-            LastDirectoryStore.recordExportDirectory(file);
-            try (CSVWriter writer = new CSVWriter(new OutputStreamWriter(
-                    Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8))) {
-                List<String> header = new java.util.ArrayList<>();
-                header.add("Step");
-                header.addAll(dominance.loopLabels());
-                writer.writeNext(header.toArray(new String[0]));
-
-                for (int step = 0; step < dominance.stepCount(); step++) {
-                    String[] row = new String[dominance.loopCount() + 1];
-                    row[0] = String.valueOf(step);
-                    for (int loop = 0; loop < dominance.loopCount(); loop++) {
-                        row[loop + 1] = String.valueOf(dominance.score(loop, step));
+                        for (int step = 0; step < dominance.stepCount(); step++) {
+                            String[] row = new String[dominance.loopCount() + 1];
+                            row[0] = String.valueOf(step);
+                            for (int loop = 0; loop < dominance.loopCount(); loop++) {
+                                row[loop + 1] = String.valueOf(dominance.score(loop, step));
+                            }
+                            writer.writeNext(row);
+                        }
                     }
-                    writer.writeNext(row);
-                }
-            } catch (IOException e) {
-                new Alert(Alert.AlertType.ERROR,
-                        "Failed to export CSV: " + e.getMessage()).showAndWait();
-            }
-        }
+                });
     }
 
     private void applyLoopColors(AreaChart<Number, Number> chart,

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/OptimizationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/OptimizationResultPane.java
@@ -3,8 +3,6 @@ package systems.courant.sd.app.canvas.charts;
 import systems.courant.sd.sweep.OptimizationResult;
 import systems.courant.sd.sweep.RunResult;
 
-import com.opencsv.CSVWriter;
-
 import javafx.geometry.Insets;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
@@ -16,14 +14,13 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
 
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import systems.courant.sd.app.canvas.ChartUtils;
 import systems.courant.sd.app.canvas.ClipboardExporter;
+import systems.courant.sd.app.canvas.CsvExportHelper;
 import systems.courant.sd.app.canvas.Styles;
 
 /**
@@ -126,32 +123,8 @@ public class OptimizationResultPane extends BorderPane {
 
     private void exportBestRunCsv() {
         ChartUtils.showCsvSaveDialog("Export Best Run CSV", "optimization_best_run.csv",
-                getScene() != null ? getScene().getWindow() : null, file -> {
-                    RunResult bestRun = result.getBestRunResult();
-                    List<String> stockNames = bestRun.getStockNames();
-                    List<String> varNames = bestRun.getVariableNames();
-
-                    try (CSVWriter writer = new CSVWriter(new OutputStreamWriter(
-                            Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8))) {
-                        List<String> header = new ArrayList<>();
-                        header.add("Step");
-                        header.addAll(stockNames);
-                        header.addAll(varNames);
-                        writer.writeNext(header.toArray(new String[0]));
-
-                        for (int s = 0; s < bestRun.getStepCount(); s++) {
-                            List<String> row = new ArrayList<>();
-                            row.add(String.valueOf(bestRun.getStep(s)));
-                            for (double v : bestRun.getStockValuesAtStep(s)) {
-                                row.add(String.valueOf(v));
-                            }
-                            for (double v : bestRun.getVariableValuesAtStep(s)) {
-                                row.add(String.valueOf(v));
-                            }
-                            writer.writeNext(row.toArray(new String[0]));
-                        }
-                    }
-                });
+                getScene() != null ? getScene().getWindow() : null,
+                file -> CsvExportHelper.writeRunResult(file, result.getBestRunResult()));
     }
 
     private static Label boldLabel(String text) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/PhasePlotPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/PhasePlotPane.java
@@ -1,36 +1,26 @@
 package systems.courant.sd.app.canvas.charts;
 
-import systems.courant.sd.app.LastDirectoryStore;
-
 import javafx.collections.FXCollections;
-import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.SnapshotParameters;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
-import javafx.scene.control.Alert;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tooltip;
-import javafx.scene.image.WritableImage;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Rectangle;
-import javafx.stage.FileChooser;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.imageio.ImageIO;
 import systems.courant.sd.app.canvas.ChartUtils;
 import systems.courant.sd.app.canvas.GhostRun;
 import systems.courant.sd.app.canvas.SimulationRunner;
@@ -276,26 +266,7 @@ public class PhasePlotPane extends BorderPane {
     }
 
     private void saveChartAsPng() {
-        if (chart == null) {
-            return;
-        }
-        FileChooser fileChooser = new FileChooser();
-        fileChooser.setTitle("Save Phase Plot as PNG");
-        fileChooser.getExtensionFilters().add(
-                new FileChooser.ExtensionFilter("PNG Image", "*.png"));
-        fileChooser.setInitialFileName("phase_plot.png");
-        LastDirectoryStore.applyExportDirectory(fileChooser);
-
-        File file = fileChooser.showSaveDialog(getScene() != null ? getScene().getWindow() : null);
-        if (file != null) {
-            LastDirectoryStore.recordExportDirectory(file);
-            WritableImage image = chart.snapshot(new SnapshotParameters(), null);
-            try {
-                ImageIO.write(SwingFXUtils.fromFXImage(image, null), "png", file);
-            } catch (IOException e) {
-                new Alert(Alert.AlertType.ERROR,
-                        "Failed to save image: " + e.getMessage()).showAndWait();
-            }
-        }
+        ChartUtils.saveNodeAsPng(chart, "phase_plot.png",
+                getScene() != null ? getScene().getWindow() : null);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SensitivityPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SensitivityPane.java
@@ -6,31 +6,21 @@ import systems.courant.sd.sweep.SensitivitySummary.ParameterImpact;
 import com.opencsv.CSVWriter;
 
 import javafx.collections.FXCollections;
-import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Insets;
-import javafx.scene.SnapshotParameters;
 import javafx.scene.chart.BarChart;
 import javafx.scene.chart.CategoryAxis;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
-import javafx.scene.control.Alert;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
-import javafx.scene.image.WritableImage;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
-import javafx.stage.FileChooser;
-import systems.courant.sd.app.LastDirectoryStore;
 
-import javax.imageio.ImageIO;
-
-import java.io.File;
-import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -38,6 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.BiFunction;
+
+import systems.courant.sd.app.canvas.ChartUtils;
 
 /**
  * Displays a sensitivity analysis as a tornado chart (horizontal bar chart ranked
@@ -158,58 +150,31 @@ public class SensitivityPane extends BorderPane {
     }
 
     private void saveChartAsPng(VBox content) {
-        FileChooser fileChooser = new FileChooser();
-        fileChooser.setTitle("Save Chart as PNG");
-        fileChooser.getExtensionFilters().add(
-                new FileChooser.ExtensionFilter("PNG Image", "*.png"));
-        fileChooser.setInitialFileName("sensitivity_chart.png");
-        LastDirectoryStore.applyExportDirectory(fileChooser);
-
-        File file = fileChooser.showSaveDialog(getScene() != null ? getScene().getWindow() : null);
-        if (file != null) {
-            LastDirectoryStore.recordExportDirectory(file);
-            WritableImage image = content.snapshot(new SnapshotParameters(), null);
-            try {
-                ImageIO.write(SwingFXUtils.fromFXImage(image, null), "png", file);
-            } catch (IOException e) {
-                new Alert(Alert.AlertType.ERROR,
-                        "Failed to save image: " + e.getMessage()).showAndWait();
-            }
-        }
+        ChartUtils.saveNodeAsPng(content, "sensitivity_chart.png",
+                getScene() != null ? getScene().getWindow() : null);
     }
 
     private void exportCsv() {
         if (currentImpacts == null || currentImpacts.isEmpty()) {
             return;
         }
-        FileChooser fileChooser = new FileChooser();
-        fileChooser.setTitle("Export Sensitivity CSV");
-        fileChooser.getExtensionFilters().add(
-                new FileChooser.ExtensionFilter("CSV Files", "*.csv"));
-        fileChooser.setInitialFileName("sensitivity.csv");
-        LastDirectoryStore.applyExportDirectory(fileChooser);
-
-        File file = fileChooser.showSaveDialog(getScene() != null ? getScene().getWindow() : null);
-        if (file != null) {
-            LastDirectoryStore.recordExportDirectory(file);
-            try (CSVWriter writer = new CSVWriter(new OutputStreamWriter(
-                    Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8))) {
-                writer.writeNext(new String[]{
-                        "Parameter", "Target Variable", "Impact (%)",
-                        "Min Output", "Max Output", "Baseline Output"});
-                for (ParameterImpact impact : currentImpacts) {
-                    writer.writeNext(new String[]{
-                            impact.parameterName(),
-                            impact.targetVariable(),
-                            String.valueOf(impact.impactFraction() * 100.0),
-                            String.valueOf(impact.minOutput()),
-                            String.valueOf(impact.maxOutput()),
-                            String.valueOf(impact.baselineOutput())});
-                }
-            } catch (IOException e) {
-                new Alert(Alert.AlertType.ERROR,
-                        "Failed to export CSV: " + e.getMessage()).showAndWait();
-            }
-        }
+        ChartUtils.showCsvSaveDialog("Export Sensitivity CSV", "sensitivity.csv",
+                getScene() != null ? getScene().getWindow() : null, file -> {
+                    try (CSVWriter writer = new CSVWriter(new OutputStreamWriter(
+                            Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8))) {
+                        writer.writeNext(new String[]{
+                                "Parameter", "Target Variable", "Impact (%)",
+                                "Min Output", "Max Output", "Baseline Output"});
+                        for (ParameterImpact impact : currentImpacts) {
+                            writer.writeNext(new String[]{
+                                    impact.parameterName(),
+                                    impact.targetVariable(),
+                                    String.valueOf(impact.impactFraction() * 100.0),
+                                    String.valueOf(impact.minOutput()),
+                                    String.valueOf(impact.maxOutput()),
+                                    String.valueOf(impact.baselineOutput())});
+                        }
+                    }
+                });
     }
 }


### PR DESCRIPTION
## Summary
- Extract `CsvExportHelper.writeRunResult()` for shared RunResult-to-CSV writing logic
- Refactor 5 result pane classes to use shared export utilities instead of duplicating FileChooser/CSVWriter/LastDirectoryStore/Alert patterns
- Net reduction of ~100 lines of duplicated boilerplate

Closes #291