### PR TITLE
Fix incorrect @throws in IndexedValue.divide Javadoc

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/IndexedValue.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/IndexedValue.java
@@ -281,9 +281,9 @@ public final class IndexedValue {
 
     /**
      * Divides every element by a scalar value.
+     * If the scalar is zero, elements become {@code NaN}.
      *
      * @param scalar the divisor
-     * @throws ArithmeticException if the scalar is zero
      */
     public IndexedValue divide(double scalar) {
         return divide(scalar(scalar));


### PR DESCRIPTION
## Summary
- Remove incorrect `@throws ArithmeticException` from `IndexedValue.divide(double)` Javadoc
- Document that division by zero returns NaN, consistent with actual implementation

Closes #1057