### PR TITLE
Reuse ThreadLocal Text node in FeedbackLoopRenderer

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/FeedbackLoopRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/FeedbackLoopRenderer.java
@@ -27,6 +27,9 @@ public final class FeedbackLoopRenderer {
             LayoutMetrics.LOOP_LABEL_FONT_SIZE);
     private static final double LABEL_PADDING = LayoutMetrics.LOOP_LABEL_PADDING;
 
+    /** Reusable Text node for measuring label width — avoids allocation per frame. */
+    private static final ThreadLocal<Text> MEASURE_TEXT = ThreadLocal.withInitial(Text::new);
+
     private FeedbackLoopRenderer() {
     }
 
@@ -52,8 +55,9 @@ public final class FeedbackLoopRenderer {
             case INDETERMINATE -> ColorPalette.LOOP_INDETERMINATE;
         };
 
-        Text textNode = new Text(label);
+        Text textNode = MEASURE_TEXT.get();
         textNode.setFont(LOOP_LABEL_FONT);
+        textNode.setText(label);
         double textWidth = textNode.getLayoutBounds().getWidth();
         double badgeW = textWidth + LABEL_PADDING * 2;
         double badgeH = 20;


### PR DESCRIPTION
## Summary
- Replace per-frame `new Text(label)` allocation with a reusable `ThreadLocal<Text>` for measuring label width
- Follows the same pattern already used in `ElementRenderer`
- Reduces GC pressure during rendering when loop highlighting is active

Closes #1055