### PR TITLE
Fix doubleArrayLiteral for NaN/Infinity values

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
@@ -454,18 +454,8 @@ public class DemoClassGenerator {
         sb.append("));\n");
     }
 
-    /**
-     * Formats a double for Java source code. Handles NaN and Infinity which cannot be
-     * written as bare literals.
-     */
     private static String formatDoubleForSource(double value) {
-        if (Double.isNaN(value)) {
-            return "Double.NaN";
-        }
-        if (Double.isInfinite(value)) {
-            return value > 0 ? "Double.POSITIVE_INFINITY" : "Double.NEGATIVE_INFINITY";
-        }
-        return String.valueOf(value);
+        return JavaSourceEscaper.formatDoubleForSource(value);
     }
 
     /**

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/JavaSourceEscaper.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/JavaSourceEscaper.java
@@ -34,7 +34,22 @@ public final class JavaSourceEscaper {
     }
 
     /**
+     * Formats a double value for use in Java source code.
+     * Handles NaN and Infinity which cannot be written as bare numeric literals.
+     */
+    public static String formatDoubleForSource(double value) {
+        if (Double.isNaN(value)) {
+            return "Double.NaN";
+        }
+        if (Double.isInfinite(value)) {
+            return value > 0 ? "Double.POSITIVE_INFINITY" : "Double.NEGATIVE_INFINITY";
+        }
+        return String.valueOf(value);
+    }
+
+    /**
      * Formats a double array as a Java source literal, e.g. {@code new double[]{1.0, 2.5, 3.7}}.
+     * Handles special values (NaN, Infinity) correctly.
      */
     public static String doubleArrayLiteral(double[] values) {
         if (values == null) {
@@ -46,7 +61,7 @@ public final class JavaSourceEscaper {
             if (i > 0) {
                 sb.append(", ");
             }
-            sb.append(values[i]);
+            sb.append(formatDoubleForSource(values[i]));
         }
         sb.append('}');
         return sb.toString();

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/JavaSourceEscaperTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/JavaSourceEscaperTest.java
@@ -57,6 +57,45 @@ class JavaSourceEscaperTest {
             assertThat(JavaSourceEscaper.doubleArrayLiteral(new double[]{1.0, 2.5, 3.7}))
                     .isEqualTo("new double[]{1.0, 2.5, 3.7}");
         }
+
+        @Test
+        void shouldFormatNaNAsDoubleNaN() {
+            assertThat(JavaSourceEscaper.doubleArrayLiteral(new double[]{1.0, Double.NaN, 3.0}))
+                    .isEqualTo("new double[]{1.0, Double.NaN, 3.0}");
+        }
+
+        @Test
+        void shouldFormatInfinityAsDoubleConstant() {
+            assertThat(JavaSourceEscaper.doubleArrayLiteral(
+                    new double[]{Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY}))
+                    .isEqualTo("new double[]{Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY}");
+        }
+    }
+
+    @Nested
+    class FormatDoubleForSource {
+
+        @Test
+        void shouldFormatNormalDouble() {
+            assertThat(JavaSourceEscaper.formatDoubleForSource(42.5)).isEqualTo("42.5");
+        }
+
+        @Test
+        void shouldFormatNaN() {
+            assertThat(JavaSourceEscaper.formatDoubleForSource(Double.NaN)).isEqualTo("Double.NaN");
+        }
+
+        @Test
+        void shouldFormatPositiveInfinity() {
+            assertThat(JavaSourceEscaper.formatDoubleForSource(Double.POSITIVE_INFINITY))
+                    .isEqualTo("Double.POSITIVE_INFINITY");
+        }
+
+        @Test
+        void shouldFormatNegativeInfinity() {
+            assertThat(JavaSourceEscaper.formatDoubleForSource(Double.NEGATIVE_INFINITY))
+                    .isEqualTo("Double.NEGATIVE_INFINITY");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Extract `formatDoubleForSource` as a public method on `JavaSourceEscaper` so special double values (NaN, ±Infinity) emit valid Java literals (`Double.NaN`, `Double.POSITIVE_INFINITY`, `Double.NEGATIVE_INFINITY`)
- Use it in `doubleArrayLiteral` instead of bare `sb.append(values[i])`
- `DemoClassGenerator` now delegates to the shared helper

## Test plan
- Added tests for NaN and Infinity in `doubleArrayLiteral`
- Added dedicated `FormatDoubleForSource` test class covering all special values
- Full test suite passes (141 tests)

Closes #1058