### PR TITLE
Fire element-added listener in all addXxxFrom methods

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
@@ -192,25 +192,33 @@ public class ModelEditor {
     /** @return the name of the created stock */
     public String addStockFrom(StockDef template) {
         checkFxThread();
-        return factory.addStockFrom(template);
+        String name = factory.addStockFrom(template);
+        fireElementAdded(name, "Stock");
+        return name;
     }
 
     /** @return the name of the created flow */
     public String addFlowFrom(FlowDef template, String source, String sink) {
         checkFxThread();
-        return factory.addFlowFrom(template, source, sink);
+        String name = factory.addFlowFrom(template, source, sink);
+        fireElementAdded(name, "Flow");
+        return name;
     }
 
     /** @return the name of the created auxiliary */
     public String addVariableFrom(VariableDef template, String equation) {
         checkFxThread();
-        return factory.addVariableFrom(template, equation);
+        String name = factory.addVariableFrom(template, equation);
+        fireElementAdded(name, "Variable");
+        return name;
     }
 
     /** @return the instance name of the created module */
     public String addModuleFrom(ModuleInstanceDef template) {
         checkFxThread();
-        return factory.addModuleFrom(template);
+        String name = factory.addModuleFrom(template);
+        fireElementAdded(name, "Module");
+        return name;
     }
 
     /** @return the instance name of the created module */
@@ -232,7 +240,9 @@ public class ModelEditor {
     /** @return the name of the created lookup table */
     public String addLookupFrom(LookupTableDef template) {
         checkFxThread();
-        return factory.addLookupFrom(template);
+        String name = factory.addLookupFrom(template);
+        fireElementAdded(name, "Lookup");
+        return name;
     }
 
     /** @return the name of the created CLD variable */
@@ -262,7 +272,9 @@ public class ModelEditor {
     /** @return the name of the created comment */
     public String addCommentFrom(CommentDef template) {
         checkFxThread();
-        return factory.addCommentFrom(template);
+        String name = factory.addCommentFrom(template);
+        fireElementAdded(name, "Comment");
+        return name;
     }
 
     /**

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelEditorTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelEditorTest.java
@@ -1542,6 +1542,37 @@ class ModelEditorTest {
 
             assertThat(name1).isNotEqualTo(name2);
         }
+
+        @Test
+        void shouldFireElementAddedForAllFromMethods() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("S", 100, "u")
+                    .flow("F", "0", "day", null, null)
+                    .variable("V", "1", "u")
+                    .lookupTable("L", new double[]{0, 1}, new double[]{0, 1}, "LINEAR")
+                    .build();
+            editor.loadFrom(def);
+
+            List<String> added = new ArrayList<>();
+            editor.addListener(new ModelEditListener() {
+                @Override
+                public void onElementAdded(String name, String typeName) {
+                    added.add(typeName + ":" + name);
+                }
+            });
+
+            String s = editor.addStockFrom(editor.getStocks().get(0));
+            String f = editor.addFlowFrom(editor.getFlows().get(0), null, null);
+            String v = editor.addVariableFrom(editor.getVariables().get(0), "1");
+            String l = editor.addLookupFrom(editor.getLookupTables().get(0));
+
+            assertThat(added).containsExactly(
+                    "Stock:" + s,
+                    "Flow:" + f,
+                    "Variable:" + v,
+                    "Lookup:" + l);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Add missing `fireElementAdded()` calls to `addStockFrom`, `addFlowFrom`, `addVariableFrom`, `addModuleFrom`, `addLookupFrom`, and `addCommentFrom`
- Listeners (e.g. activity log) are now notified for paste operations, matching parameterless `addXxx()` behavior
- Add test verifying all `From` methods fire the listener

Closes #1054