### PR TITLE
Add history tracking to Stock and clear it on reset

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/Simulation.java
+++ b/courant-engine/src/main/java/systems/courant/sd/Simulation.java
@@ -425,10 +425,13 @@ public class Simulation {
     }
 
     /**
-     * Clears recorded history from all flows and variables in the model.
+     * Clears recorded history from all stocks, flows, and variables in the model.
      * Call this before re-running a simulation to avoid stale history data.
      */
     public void clearHistory() {
+        for (Stock stock : model.getStocks()) {
+            stock.clearHistory();
+        }
         Set<Flow> seenFlows = Collections.newSetFromMap(new IdentityHashMap<>());
         Set<Variable> seenVars = Collections.newSetFromMap(new IdentityHashMap<>());
         for (Flow flow : model.getFlows()) {
@@ -495,6 +498,9 @@ public class Simulation {
     }
 
     private static void clearModuleHistory(Module module, Set<Flow> seenFlows, Set<Variable> seenVars) {
+        for (Stock stock : module.getStocks()) {
+            stock.clearHistory();
+        }
         for (Flow flow : module.getFlows()) {
             if (seenFlows.add(flow)) {
                 flow.clearHistory();

--- a/courant-engine/src/main/java/systems/courant/sd/model/Stock.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Stock.java
@@ -2,6 +2,8 @@ package systems.courant.sd.model;
 
 import systems.courant.sd.measure.Quantity;
 import systems.courant.sd.measure.Unit;
+
+import com.carrotsearch.hppc.DoubleArrayList;
 import com.google.common.base.Preconditions;
 
 import org.slf4j.Logger;
@@ -21,6 +23,7 @@ public class Stock extends Element {
     private final Set<Flow> inflows = new LinkedHashSet<>();
     private final Set<Flow> outflows = new LinkedHashSet<>();
 
+    private final DoubleArrayList history = new DoubleArrayList();
     private final Unit unit;
     private final double initialAmount;
     private double value;
@@ -158,6 +161,32 @@ public class Stock extends Element {
      */
     public void resetWarnings() {
         warnedNonFinite = false;
+    }
+
+    /**
+     * Records the current value of this stock in its history for the current time step.
+     */
+    public void recordValue() {
+        history.add(value);
+    }
+
+    /**
+     * Returns the recorded stock value at the given time step index, or 0 if the index is out of range.
+     *
+     * @param i the zero-based time step index
+     */
+    public double getHistoryAtTimeStep(long i) {
+        if (i < 0 || i >= history.size()) {
+            return 0;
+        }
+        return history.get((int) i);
+    }
+
+    /**
+     * Clears this stock's recorded history. Useful when re-running simulations.
+     */
+    public void clearHistory() {
+        history.clear();
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/CompiledModel.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/CompiledModel.java
@@ -179,6 +179,7 @@ public class CompiledModel {
         }
         for (Stock stock : model.getStocks()) {
             stock.resetToInitialValue();
+            stock.clearHistory();
         }
         for (Module module : model.getModules()) {
             resetModuleStocks(module);
@@ -219,6 +220,7 @@ public class CompiledModel {
     private static void resetModuleStocks(Module module) {
         for (Stock stock : module.getStocks()) {
             stock.resetToInitialValue();
+            stock.clearHistory();
         }
         for (Module child : module.getSubModules().values()) {
             resetModuleStocks(child);

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/CompiledModelTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/CompiledModelTest.java
@@ -232,6 +232,20 @@ class CompiledModelTest {
             // After reset, history should be cleared — returns 0 for out-of-range
             assertThat(rate.getHistoryAtTimeStep(0)).isEqualTo(0.0);
         }
+
+        @Test
+        void shouldClearStockHistory() {
+            population.recordValue();
+            population.setValue(200.0);
+            population.recordValue();
+            assertThat(population.getHistoryAtTimeStep(0)).isEqualTo(100.0);
+            assertThat(population.getHistoryAtTimeStep(1)).isEqualTo(200.0);
+
+            compiled.reset();
+
+            assertThat(population.getHistoryAtTimeStep(0)).isEqualTo(0.0);
+            assertThat(population.getHistoryAtTimeStep(1)).isEqualTo(0.0);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Add `recordValue()`, `getHistoryAtTimeStep()`, and `clearHistory()` methods to `Stock`, matching the existing pattern in `Flow` and `Variable`
- `CompiledModel.reset()` now clears stock history alongside flow/variable history
- `Simulation.clearHistory()` now clears stock history in top-level and module stocks
- Add test verifying stock history is cleared on reset

Closes #1040