### PR TITLE
Add bounds check in LoopDominanceAnalysis column access

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/graph/LoopDominanceAnalysis.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/graph/LoopDominanceAnalysis.java
@@ -110,7 +110,9 @@ public record LoopDominanceAnalysis(
                 double[] curr = rows.get(step);
                 double sum = 0;
                 for (int col : cols) {
-                    sum += Math.abs(curr[col] - prev[col]);
+                    if (col < curr.length && col < prev.length) {
+                        sum += Math.abs(curr[col] - prev[col]);
+                    }
                 }
                 activity[loopIdx][step] = sum;
             }

--- a/courant-engine/src/test/java/systems/courant/sd/model/graph/LoopDominanceAnalysisTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/graph/LoopDominanceAnalysisTest.java
@@ -120,6 +120,29 @@ class LoopDominanceAnalysisTest {
         }
 
         @Test
+        void shouldHandleMismatchedColumnData() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("PP")
+                    .stock("Prey", 100, "Animal")
+                    .stock("Predators", 20, "Animal")
+                    .flow("Predation", "Prey * Predators * 0.01", "Day", "Prey", "Predators")
+                    .build();
+
+            FeedbackAnalysis analysis = FeedbackAnalysis.analyze(def);
+            // columnNames claims 3 columns but rows have only 2 entries
+            List<String> columns = List.of("Step", "Prey", "Predators");
+            List<double[]> rows = List.of(
+                    new double[]{0, 100},
+                    new double[]{1, 80});
+
+            LoopDominanceAnalysis result = LoopDominanceAnalysis.compute(columns, rows, analysis);
+
+            // Should not throw; should compute what it can
+            assertThat(result).isNotNull();
+            assertThat(result.score(0, 1)).isGreaterThanOrEqualTo(0);
+        }
+
+        @Test
         void shouldReturnMinusOneForZeroActivity() {
             ModelDefinition def = new ModelDefinitionBuilder()
                     .name("PP")


### PR DESCRIPTION
## Summary
- Add bounds check before accessing `curr[col]` and `prev[col]` in the per-step activity computation
- Prevents `ArrayIndexOutOfBoundsException` when simulation result rows have fewer columns than `columnNames` suggests
- Add test verifying graceful handling of mismatched column data

Closes #1037