### PR TITLE
Log warning when TarjanSCC truncates at MAX_DEPTH

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/graph/TarjanSCC.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/graph/TarjanSCC.java
@@ -1,5 +1,8 @@
 package systems.courant.sd.model.graph;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,6 +20,8 @@ import java.util.Set;
  * to avoid duplicating the algorithm.
  */
 public final class TarjanSCC {
+
+    private static final Logger log = LoggerFactory.getLogger(TarjanSCC.class);
 
     /** Maximum recursion depth for graph traversal, matching ExprParser.MAX_DEPTH. */
     private static final int MAX_DEPTH = 200;
@@ -73,6 +78,8 @@ public final class TarjanSCC {
             Map<String, Integer> lowlink, Set<String> onStack,
             Deque<String> stack, List<Set<String>> result, int depth) {
         if (depth > MAX_DEPTH) {
+            log.warn("SCC traversal truncated at depth {} for node '{}' — "
+                    + "feedback loops in deep dependency chains may go undetected", depth, v);
             nodeIndex.put(v, index[0]);
             lowlink.put(v, index[0]);
             index[0]++;

--- a/courant-engine/src/test/java/systems/courant/sd/model/graph/TarjanSCCTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/graph/TarjanSCCTest.java
@@ -80,4 +80,25 @@ class TarjanSCCTest {
         assertThat(sccs).hasSize(1);
         assertThat(sccs.get(0)).containsExactlyInAnyOrder("X", "Y", "Z");
     }
+
+    @Test
+    void shouldNotCrashOnDeepChainExceedingMaxDepth() {
+        // Build a linear chain of 250 nodes (exceeds MAX_DEPTH=200)
+        int count = 250;
+        Set<String> nodes = new LinkedHashSet<>();
+        Map<String, Set<String>> graph = new LinkedHashMap<>();
+        for (int i = 0; i < count; i++) {
+            String name = "N" + i;
+            nodes.add(name);
+            if (i < count - 1) {
+                graph.put(name, Set.of("N" + (i + 1)));
+            }
+        }
+        // Close the cycle so all nodes form one SCC
+        graph.put("N" + (count - 1), Set.of("N0"));
+
+        // Should complete without StackOverflowError
+        List<Set<String>> sccs = TarjanSCC.findAll(nodes, graph);
+        assertThat(sccs).isNotEmpty();
+    }
 }


### PR DESCRIPTION
## Summary
- Add SLF4J warning when `strongconnect` truncates traversal beyond MAX_DEPTH=200
- Identifies the truncated node so users can diagnose incomplete SCC detection in large models
- Add test verifying deep chains beyond MAX_DEPTH don't crash

Closes #1036