### PR TITLE
Populate allNormalizedNames in VensimImporter pre-classification

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
@@ -338,7 +338,7 @@ public class VensimImporter implements ModelImporter {
             if (subMatcher.matches()) {
                 if (preClassifySubscriptedEquation(subMatcher, eq,
                         subscripts.subscriptDimensions, stockNames,
-                        constantValues)) {
+                        constantValues, allNormalizedNames)) {
                     continue;
                 }
             }
@@ -348,6 +348,7 @@ public class VensimImporter implements ModelImporter {
             if (eq.operator().equals(":") || eq.operator().equals("<->")) {
                 continue;
             }
+
             if (eq.operator().equals("()")) {
                 lookupNames.add(eqName);
                 continue;
@@ -376,7 +377,8 @@ public class VensimImporter implements ModelImporter {
             Matcher subMatcher, MdlEquation eq,
             Map<String, List<String>> subscriptDimensions,
             Set<String> stockNames,
-            Map<String, Double> constantValues) {
+            Map<String, Double> constantValues,
+            Set<String> allNormalizedNames) {
         String baseName = subMatcher.group(1).strip();
         String dimNameRaw = subMatcher.group(2).strip();
         String dimKey = VensimExprTranslator.normalizeName(dimNameRaw);
@@ -388,6 +390,7 @@ public class VensimImporter implements ModelImporter {
                     eq.expression(), labels.size());
             for (int li = 0; li < labels.size(); li++) {
                 String expandedName = normalizedBase + "_" + labels.get(li);
+                allNormalizedNames.add(expandedName);
                 if (isInteg) {
                     stockNames.add(expandedName);
                 }
@@ -415,6 +418,7 @@ public class VensimImporter implements ModelImporter {
             for (int ci = 0; ci < combos.size(); ci++) {
                 String expandedName = normalizedBase + "_"
                         + String.join("_", combos.get(ci));
+                allNormalizedNames.add(expandedName);
                 if (isInteg) {
                     stockNames.add(expandedName);
                 }
@@ -435,6 +439,7 @@ public class VensimImporter implements ModelImporter {
         if (isLabel) {
             String normalizedBase = VensimExprTranslator.normalizeName(baseName);
             String expandedName = normalizedBase + "_" + normalizedSub;
+            allNormalizedNames.add(expandedName);
             boolean isInteg = INTEG_PATTERN.matcher(eq.expression()).find();
             if (isInteg) {
                 stockNames.add(expandedName);

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
@@ -730,6 +730,47 @@ class VensimImporterTest {
             ImportResult result = importer.importModel(mdl, "Test");
             assertThat(result.warnings()).anyMatch(w -> w.contains("Duplicate normalized name"));
         }
+
+        @Test
+        void shouldWarnWhenStandaloneVariableClashesWithSubscriptExpandedName() {
+            // "Pop[Region]" expands to Pop_North, Pop_South in pre-classification.
+            // A standalone "Pop_North" variable should be detected as a duplicate.
+            String mdl = """
+                    Region : North, South
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    Pop[Region] = INTEG(1, 100)
+                    \t~\tPerson
+                    \t~\t
+                    \t|
+
+                    Pop_North = 42
+                    \t~\tPerson
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tDay
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tDay
+                    \t~\t
+                    \t|
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            assertThat(result.warnings()).anyMatch(w ->
+                    w.contains("Duplicate") && w.contains("Pop_North"));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Subscript-expanded names are now added to `allNormalizedNames` during pre-classification
- Duplicate detection in `buildModelDefinitions` now catches clashes between subscript-expanded and standalone variable names

Closes #1042