### PR TITLE
Allow quoted identifiers as function calls in ExprParser

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprParser.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprParser.java
@@ -296,6 +296,23 @@ public class ExprParser {
         if (name.isEmpty()) {
             throw new ParseException("Empty quoted identifier", start - 1 + trimOffset);
         }
+
+        // Check for function-call syntax: `Quoted Name`(args)
+        skipWhitespace();
+        if (pos < input.length() && input.charAt(pos) == '(') {
+            pos++; // skip '('
+            List<Expr> args = new ArrayList<>();
+            skipWhitespace();
+            if (pos < input.length() && input.charAt(pos) != ')') {
+                args.add(parseExpr());
+                while (matchChar(',')) {
+                    args.add(parseExpr());
+                }
+            }
+            expectChar(')');
+            return new Expr.FunctionCall(name, args);
+        }
+
         return new Expr.Ref(name);
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/model/expr/ExprParserTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/expr/ExprParserTest.java
@@ -84,6 +84,16 @@ class ExprParserTest {
             Expr result = ExprParser.parse("`Coffee Temperature`");
             assertThat(result).isEqualTo(new Expr.Ref("Coffee Temperature"));
         }
+
+        @Test
+        void shouldParseQuotedIdentifierAsFunctionCall() {
+            Expr result = ExprParser.parse("`Effect of Density`(density)");
+            assertThat(result).isInstanceOf(Expr.FunctionCall.class);
+            Expr.FunctionCall call = (Expr.FunctionCall) result;
+            assertThat(call.name()).isEqualTo("Effect of Density");
+            assertThat(call.arguments()).hasSize(1);
+            assertThat(call.arguments().get(0)).isEqualTo(new Expr.Ref("density"));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- `parseQuotedIdentifier` now checks for a trailing `(` to support function-call syntax
- Enables lookup tables with space-containing names to use `table(input)` call syntax

Closes #1038