### PR TITLE
Replace Thread.sleep with deterministic waiting in tests

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/UndoManager.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/UndoManager.java
@@ -109,6 +109,17 @@ public class UndoManager implements AutoCloseable {
     }
 
     /**
+     * Waits for the most recent undo entry's background compression to complete.
+     * Visible for testing — avoids timing-dependent {@code Thread.sleep} in tests.
+     */
+    void awaitCompression() {
+        UndoEntry top = undoStack.peek();
+        if (top != null) {
+            top.future().join();
+        }
+    }
+
+    /**
      * Saves the current state tentatively, without clearing the redo stack.
      * Use this when the operation may be rejected or may fail, so that
      * redo history is preserved if the undo entry is later discarded.

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowComplexModelFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowComplexModelFxTest.java
@@ -17,6 +17,7 @@ import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,33 +52,21 @@ class WorkflowComplexModelFxTest {
         WaitForAsyncUtils.waitForFxEvents();
     }
 
-    private void waitForDashboardResults(FxRobot robot) {
-        long deadline = System.currentTimeMillis() + 30_000;
-        while (System.currentTimeMillis() < deadline) {
+    private void waitForDashboardResults(FxRobot robot) throws TimeoutException {
+        WaitForAsyncUtils.waitFor(30, TimeUnit.SECONDS, () -> {
             WaitForAsyncUtils.waitForFxEvents();
             var tabs = robot.lookup("#dashboardResultTabs").tryQueryAs(TabPane.class);
-            if (tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty()) {
-                return;
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        throw new AssertionError("Dashboard results did not appear within 30 seconds");
+            return tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty();
+        });
     }
 
-    private void triggerValidation(FxRobot robot) {
+    private void triggerValidation(FxRobot robot) throws TimeoutException {
         robot.push(KeyCode.CONTROL, KeyCode.B);
         WaitForAsyncUtils.waitForFxEvents();
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        WaitForAsyncUtils.waitForFxEvents();
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> {
+            WaitForAsyncUtils.waitForFxEvents();
+            return robot.lookup("#validationTable").tryQuery().isPresent();
+        });
         // Restore focus to main window (validation dialog is a separate stage)
         Platform.runLater(() -> {
             stage.toFront();
@@ -91,7 +80,7 @@ class WorkflowComplexModelFxTest {
 
     @Test
     @DisplayName("Aging Chain: load → validate → simulate")
-    void shouldSimulateAgingChain(FxRobot robot) {
+    void shouldSimulateAgingChain(FxRobot robot) throws Exception {
         loadExample("Aging Chain", "demographics/aging-chain.json");
         assertThat(stage.getTitle()).contains("Aging");
 
@@ -111,7 +100,7 @@ class WorkflowComplexModelFxTest {
 
     @Test
     @DisplayName("Predator Prey: load → simulate → verify multiple stocks")
-    void shouldSimulatePredatorPrey(FxRobot robot) {
+    void shouldSimulatePredatorPrey(FxRobot robot) throws Exception {
         loadExample("Predator Prey", "ecology/predator-prey.json");
         assertThat(stage.getTitle()).contains("Predator Prey");
 
@@ -129,7 +118,7 @@ class WorkflowComplexModelFxTest {
 
     @Test
     @DisplayName("S-Shaped Growth: load → simulate")
-    void shouldSimulateSShapedGrowth(FxRobot robot) {
+    void shouldSimulateSShapedGrowth(FxRobot robot) throws Exception {
         loadExample("S-Shaped Growth", "population/s-shaped-growth.json");
 
         Platform.runLater(() -> {
@@ -148,7 +137,7 @@ class WorkflowComplexModelFxTest {
 
     @Test
     @DisplayName("Kaibab Deer: load → validate → simulate")
-    void shouldSimulateKaibabDeer(FxRobot robot) {
+    void shouldSimulateKaibabDeer(FxRobot robot) throws Exception {
         loadExample("Kaibab Deer", "ecology/kaibab-deer.json");
 
         triggerValidation(robot);
@@ -167,7 +156,7 @@ class WorkflowComplexModelFxTest {
 
     @Test
     @DisplayName("Supply Chain Bullwhip: load → simulate")
-    void shouldSimulateSupplyChain(FxRobot robot) {
+    void shouldSimulateSupplyChain(FxRobot robot) throws Exception {
         loadExample("Supply Chain Bullwhip", "supply-chain/supply-chain-bullwhip.json");
 
         Platform.runLater(() -> {
@@ -186,7 +175,7 @@ class WorkflowComplexModelFxTest {
 
     @Test
     @DisplayName("Load and simulate four models in sequence")
-    void shouldHandleSequentialModelSimulations(FxRobot robot) {
+    void shouldHandleSequentialModelSimulations(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
         Platform.runLater(() -> {
             stage.toFront();
@@ -230,7 +219,7 @@ class WorkflowComplexModelFxTest {
 
     @Test
     @DisplayName("Load → simulate → validate → switch model — no state leaks")
-    void shouldNotLeakStateBetweenModels(FxRobot robot) {
+    void shouldNotLeakStateBetweenModels(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
         triggerValidation(robot);
         Platform.runLater(() -> {
@@ -292,7 +281,7 @@ class WorkflowComplexModelFxTest {
 
     @Test
     @DisplayName("Predator Prey simulation creates Phase Plot tab")
-    void shouldShowPhasePlotForTwoStockModel(FxRobot robot) {
+    void shouldShowPhasePlotForTwoStockModel(FxRobot robot) throws Exception {
         loadExample("Predator Prey", "ecology/predator-prey.json");
 
         Platform.runLater(() -> {

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowFileOperationsFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowFileOperationsFxTest.java
@@ -18,6 +18,7 @@ import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,22 +53,12 @@ class WorkflowFileOperationsFxTest {
         WaitForAsyncUtils.waitForFxEvents();
     }
 
-    private void waitForDashboardResults(FxRobot robot) {
-        long deadline = System.currentTimeMillis() + 15_000;
-        while (System.currentTimeMillis() < deadline) {
+    private void waitForDashboardResults(FxRobot robot) throws TimeoutException {
+        WaitForAsyncUtils.waitFor(30, TimeUnit.SECONDS, () -> {
             WaitForAsyncUtils.waitForFxEvents();
             var tabs = robot.lookup("#dashboardResultTabs").tryQueryAs(TabPane.class);
-            if (tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty()) {
-                return;
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        throw new AssertionError("Dashboard results did not appear within 15 seconds");
+            return tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty();
+        });
     }
 
     // ── New model ────────────────────────────────────────────────────────
@@ -122,7 +113,7 @@ class WorkflowFileOperationsFxTest {
 
     @Test
     @DisplayName("New model clears dashboard results")
-    void shouldClearDashboardOnNew(FxRobot robot) {
+    void shouldClearDashboardOnNew(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         robot.push(KeyCode.CONTROL, KeyCode.R);

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowModelBuildFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowModelBuildFxTest.java
@@ -18,6 +18,9 @@ import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -55,29 +58,19 @@ class WorkflowModelBuildFxTest {
         robot.push(KeyCode.CONTROL, KeyCode.R);
     }
 
-    private void waitForDashboardResults(FxRobot robot) {
-        long deadline = System.currentTimeMillis() + 15_000;
-        while (System.currentTimeMillis() < deadline) {
+    private void waitForDashboardResults(FxRobot robot) throws TimeoutException {
+        WaitForAsyncUtils.waitFor(30, TimeUnit.SECONDS, () -> {
             WaitForAsyncUtils.waitForFxEvents();
             var tabs = robot.lookup("#dashboardResultTabs").tryQueryAs(TabPane.class);
-            if (tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty()) {
-                return;
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        throw new AssertionError("Dashboard results did not appear within 15 seconds");
+            return tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty();
+        });
     }
 
     // ── Simple model builds ──────────────────────────────────────────────
 
     @Test
     @DisplayName("Single stock with constant drain: build → configure → simulate")
-    void shouldBuildAndSimulateDrainModel(FxRobot robot) {
+    void shouldBuildAndSimulateDrainModel(FxRobot robot) throws Exception {
         initEditor();
         ModelEditor editor = window.getEditor();
 
@@ -104,7 +97,7 @@ class WorkflowModelBuildFxTest {
 
     @Test
     @DisplayName("Stock with inflow and outflow: build → simulate → verify dirty")
-    void shouldBuildBathtubFromScratch(FxRobot robot) {
+    void shouldBuildBathtubFromScratch(FxRobot robot) throws Exception {
         initEditor();
         ModelEditor editor = window.getEditor();
 
@@ -130,7 +123,7 @@ class WorkflowModelBuildFxTest {
 
     @Test
     @DisplayName("Two interacting stocks: build → simulate")
-    void shouldBuildTwoStockModel(FxRobot robot) {
+    void shouldBuildTwoStockModel(FxRobot robot) throws Exception {
         initEditor();
         ModelEditor editor = window.getEditor();
 
@@ -156,7 +149,7 @@ class WorkflowModelBuildFxTest {
 
     @Test
     @DisplayName("Stock + auxiliary + flow referencing auxiliary")
-    void shouldBuildModelWithAuxiliary(FxRobot robot) {
+    void shouldBuildModelWithAuxiliary(FxRobot robot) throws Exception {
         initEditor();
         ModelEditor editor = window.getEditor();
 
@@ -180,7 +173,7 @@ class WorkflowModelBuildFxTest {
 
     @Test
     @DisplayName("Exponential growth model with renamed elements")
-    void shouldBuildExponentialGrowthModel(FxRobot robot) {
+    void shouldBuildExponentialGrowthModel(FxRobot robot) throws Exception {
         initEditor();
         ModelEditor editor = window.getEditor();
 
@@ -213,7 +206,7 @@ class WorkflowModelBuildFxTest {
 
     @Test
     @DisplayName("Build → simulate → add element → simulate again")
-    void shouldSupportIterativeRefinement(FxRobot robot) {
+    void shouldSupportIterativeRefinement(FxRobot robot) throws Exception {
         initEditor();
         ModelEditor editor = window.getEditor();
 
@@ -249,7 +242,7 @@ class WorkflowModelBuildFxTest {
 
     @Test
     @DisplayName("Build → simulate → rename element → simulate again")
-    void shouldSimulateAfterRenaming(FxRobot robot) {
+    void shouldSimulateAfterRenaming(FxRobot robot) throws Exception {
         initEditor();
         ModelEditor editor = window.getEditor();
 
@@ -280,7 +273,7 @@ class WorkflowModelBuildFxTest {
 
     @Test
     @DisplayName("Build → simulate → change equation → simulate → verify ghost runs")
-    void shouldTrackGhostRunsAcrossChanges(FxRobot robot) {
+    void shouldTrackGhostRunsAcrossChanges(FxRobot robot) throws Exception {
         initEditor();
         ModelEditor editor = window.getEditor();
 
@@ -310,7 +303,7 @@ class WorkflowModelBuildFxTest {
 
     @Test
     @DisplayName("Valid hand-built model passes validation")
-    void shouldValidateCorrectModel(FxRobot robot) {
+    void shouldValidateCorrectModel(FxRobot robot) throws Exception {
         initEditor();
         ModelEditor editor = window.getEditor();
 
@@ -325,12 +318,10 @@ class WorkflowModelBuildFxTest {
 
         robot.push(KeyCode.CONTROL, KeyCode.B);
         WaitForAsyncUtils.waitForFxEvents();
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        WaitForAsyncUtils.waitForFxEvents();
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> {
+            WaitForAsyncUtils.waitForFxEvents();
+            return robot.lookup("#validationTable").tryQuery().isPresent();
+        });
         Platform.runLater(() -> window.getCanvas().requestFocus());
         WaitForAsyncUtils.waitForFxEvents();
 
@@ -340,7 +331,7 @@ class WorkflowModelBuildFxTest {
 
     @Test
     @DisplayName("Model with undefined reference shows validation errors")
-    void shouldDetectUndefinedReference(FxRobot robot) {
+    void shouldDetectUndefinedReference(FxRobot robot) throws Exception {
         initEditor();
         ModelEditor editor = window.getEditor();
 
@@ -358,12 +349,10 @@ class WorkflowModelBuildFxTest {
         WaitForAsyncUtils.waitForFxEvents();
         robot.push(KeyCode.CONTROL, KeyCode.B);
         WaitForAsyncUtils.waitForFxEvents();
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        WaitForAsyncUtils.waitForFxEvents();
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> {
+            WaitForAsyncUtils.waitForFxEvents();
+            return robot.lookup("#validationTable").tryQuery().isPresent();
+        });
         Platform.runLater(() -> window.getCanvas().requestFocus());
         WaitForAsyncUtils.waitForFxEvents();
 

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowSimulationFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowSimulationFxTest.java
@@ -17,6 +17,7 @@ import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -55,33 +56,21 @@ class WorkflowSimulationFxTest {
         robot.push(KeyCode.CONTROL, KeyCode.R);
     }
 
-    private void waitForDashboardResults(FxRobot robot) {
-        long deadline = System.currentTimeMillis() + 15_000;
-        while (System.currentTimeMillis() < deadline) {
+    private void waitForDashboardResults(FxRobot robot) throws TimeoutException {
+        WaitForAsyncUtils.waitFor(30, TimeUnit.SECONDS, () -> {
             WaitForAsyncUtils.waitForFxEvents();
             var tabs = robot.lookup("#dashboardResultTabs").tryQueryAs(TabPane.class);
-            if (tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty()) {
-                return;
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        throw new AssertionError("Dashboard results did not appear within 15 seconds");
+            return tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty();
+        });
     }
 
-    private void triggerValidation(FxRobot robot) {
+    private void triggerValidation(FxRobot robot) throws TimeoutException {
         robot.push(KeyCode.CONTROL, KeyCode.B);
         WaitForAsyncUtils.waitForFxEvents();
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        WaitForAsyncUtils.waitForFxEvents();
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> {
+            WaitForAsyncUtils.waitForFxEvents();
+            return robot.lookup("#validationTable").tryQuery().isPresent();
+        });
         // Restore focus to main window (validation dialog is a separate stage)
         Platform.runLater(() -> {
             stage.toFront();
@@ -95,7 +84,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Bathtub: dashboard shows results after Ctrl+R")
-    void shouldShowResultsAfterSimulation(FxRobot robot) {
+    void shouldShowResultsAfterSimulation(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
         assertThat(stage.getTitle()).contains("Bathtub");
 
@@ -110,7 +99,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Bathtub: placeholder disappears after simulation")
-    void shouldHidePlaceholderAfterSimulation(FxRobot robot) {
+    void shouldHidePlaceholderAfterSimulation(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         triggerSimulation(robot);
@@ -122,7 +111,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Coffee Cooling: simulation runs successfully")
-    void shouldRunCoffeeCooling(FxRobot robot) {
+    void shouldRunCoffeeCooling(FxRobot robot) throws Exception {
         loadExample("Coffee Cooling", "introductory/coffee-cooling.json");
         assertThat(stage.getTitle()).contains("Coffee Cooling");
 
@@ -135,7 +124,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Exponential Growth: simulation runs successfully")
-    void shouldRunExponentialGrowth(FxRobot robot) {
+    void shouldRunExponentialGrowth(FxRobot robot) throws Exception {
         loadExample("Exponential Growth", "introductory/exponential-growth.json");
         assertThat(stage.getTitle()).contains("Exponential Growth");
 
@@ -148,7 +137,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Goal Seeking: simulation runs successfully")
-    void shouldRunGoalSeeking(FxRobot robot) {
+    void shouldRunGoalSeeking(FxRobot robot) throws Exception {
         loadExample("Goal Seeking", "introductory/goal-seeking.json");
 
         triggerSimulation(robot);
@@ -162,7 +151,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Dashboard tab is automatically selected after simulation")
-    void shouldSwitchToDashboardTab(FxRobot robot) {
+    void shouldSwitchToDashboardTab(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         triggerSimulation(robot);
@@ -177,7 +166,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Running simulation twice produces ghost overlay header")
-    void shouldShowGhostRunsAfterSecondRun(FxRobot robot) {
+    void shouldShowGhostRunsAfterSecondRun(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         triggerSimulation(robot);
@@ -194,7 +183,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Editing model after simulation shows stale banner")
-    void shouldShowStaleBannerAfterEdit(FxRobot robot) {
+    void shouldShowStaleBannerAfterEdit(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         triggerSimulation(robot);
@@ -212,7 +201,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Re-running simulation clears stale banner")
-    void shouldClearStaleBannerOnRerun(FxRobot robot) {
+    void shouldClearStaleBannerOnRerun(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         triggerSimulation(robot);
@@ -230,7 +219,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Clicking Re-run link triggers new simulation")
-    void shouldRerunViaLink(FxRobot robot) {
+    void shouldRerunViaLink(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         triggerSimulation(robot);
@@ -250,7 +239,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Loading new example clears previous simulation results")
-    void shouldClearResultsOnNewModel(FxRobot robot) {
+    void shouldClearResultsOnNewModel(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         triggerSimulation(robot);
@@ -264,7 +253,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Can run simulation on new model after switching")
-    void shouldRunAfterSwitchingModels(FxRobot robot) {
+    void shouldRunAfterSwitchingModels(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
         triggerSimulation(robot);
         waitForDashboardResults(robot);
@@ -283,7 +272,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Valid model shows clean validation status")
-    void shouldShowCleanValidation(FxRobot robot) {
+    void shouldShowCleanValidation(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         triggerValidation(robot);
@@ -294,7 +283,7 @@ class WorkflowSimulationFxTest {
 
     @Test
     @DisplayName("Can run simulation after successful validation")
-    void shouldRunAfterValidation(FxRobot robot) {
+    void shouldRunAfterValidation(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         triggerValidation(robot);

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowSimulationSettingsFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowSimulationSettingsFxTest.java
@@ -20,6 +20,7 @@ import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -54,22 +55,12 @@ class WorkflowSimulationSettingsFxTest {
         WaitForAsyncUtils.waitForFxEvents();
     }
 
-    private void waitForDashboardResults(FxRobot robot) {
-        long deadline = System.currentTimeMillis() + 15_000;
-        while (System.currentTimeMillis() < deadline) {
+    private void waitForDashboardResults(FxRobot robot) throws TimeoutException {
+        WaitForAsyncUtils.waitFor(30, TimeUnit.SECONDS, () -> {
             WaitForAsyncUtils.waitForFxEvents();
             var tabs = robot.lookup("#dashboardResultTabs").tryQueryAs(TabPane.class);
-            if (tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty()) {
-                return;
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        throw new AssertionError("Dashboard results did not appear within 15 seconds");
+            return tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty();
+        });
     }
 
     // ── Settings dialog via menu ─────────────────────────────────────────
@@ -98,7 +89,7 @@ class WorkflowSimulationSettingsFxTest {
 
     @Test
     @DisplayName("Change duration in settings, then simulate successfully")
-    void shouldApplyChangedDuration(FxRobot robot) {
+    void shouldApplyChangedDuration(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         robot.clickOn("Simulate");
@@ -210,7 +201,7 @@ class WorkflowSimulationSettingsFxTest {
 
     @Test
     @DisplayName("Setting settings programmatically then running succeeds")
-    void shouldRunWithProgrammaticSettings(FxRobot robot) {
+    void shouldRunWithProgrammaticSettings(FxRobot robot) throws Exception {
         Platform.runLater(() -> window.getFileController().newModel());
         WaitForAsyncUtils.waitForFxEvents();
         ModelEditor editor = window.getEditor();

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowSweepAnalysisFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowSweepAnalysisFxTest.java
@@ -23,6 +23,8 @@ import org.testfx.util.WaitForAsyncUtils;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -94,44 +96,21 @@ class WorkflowSweepAnalysisFxTest {
         WaitForAsyncUtils.waitForFxEvents();
     }
 
-    private void waitForDashboardResults(FxRobot robot) {
-        long deadline = System.currentTimeMillis() + 15_000;
-        while (System.currentTimeMillis() < deadline) {
+    private void waitForDashboardResults(FxRobot robot) throws TimeoutException {
+        WaitForAsyncUtils.waitFor(15, TimeUnit.SECONDS, () -> {
             WaitForAsyncUtils.waitForFxEvents();
             var tabs = robot.lookup("#dashboardResultTabs").tryQueryAs(TabPane.class);
-            if (tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty()) {
-                return;
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        throw new AssertionError("Dashboard results did not appear within 15 seconds");
+            return tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty();
+        });
     }
 
-    private void waitForDashboardTab(FxRobot robot, String tabName) {
-        long deadline = System.currentTimeMillis() + 15_000;
-        while (System.currentTimeMillis() < deadline) {
+    private void waitForDashboardTab(FxRobot robot, String tabName) throws TimeoutException {
+        WaitForAsyncUtils.waitFor(15, TimeUnit.SECONDS, () -> {
             WaitForAsyncUtils.waitForFxEvents();
             var tabs = robot.lookup("#dashboardResultTabs").tryQueryAs(TabPane.class);
-            if (tabs.isPresent() && tabs.get().isVisible()) {
-                boolean found = tabs.get().getTabs().stream()
-                        .anyMatch(t -> tabName.equals(t.getText()));
-                if (found) {
-                    return;
-                }
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        throw new AssertionError("Dashboard tab '" + tabName + "' did not appear within 15 seconds");
+            return tabs.isPresent() && tabs.get().isVisible()
+                    && tabs.get().getTabs().stream().anyMatch(t -> tabName.equals(t.getText()));
+        });
     }
 
     // ── Parameter identification ─────────────────────────────────────────
@@ -183,7 +162,7 @@ class WorkflowSweepAnalysisFxTest {
 
     @Test
     @DisplayName("Simulate model, then open sweep dialog — both workflows accessible")
-    void shouldAccessBothSimAndSweepWorkflows(FxRobot robot) {
+    void shouldAccessBothSimAndSweepWorkflows(FxRobot robot) throws Exception {
         buildSweepableModel();
 
         // Run simulation
@@ -335,7 +314,7 @@ class WorkflowSweepAnalysisFxTest {
 
     @Test
     @DisplayName("Build → validate → simulate → modify → re-simulate (full cycle)")
-    void shouldCompleteFullAnalysisCycle(FxRobot robot) {
+    void shouldCompleteFullAnalysisCycle(FxRobot robot) throws Exception {
         buildSweepableModel();
 
         // Validate
@@ -346,12 +325,10 @@ class WorkflowSweepAnalysisFxTest {
         WaitForAsyncUtils.waitForFxEvents();
         robot.push(KeyCode.CONTROL, KeyCode.B);
         WaitForAsyncUtils.waitForFxEvents();
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        WaitForAsyncUtils.waitForFxEvents();
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> {
+            WaitForAsyncUtils.waitForFxEvents();
+            return robot.lookup("#validationTable").tryQuery().isPresent();
+        });
 
         Label validationLabel = robot.lookup("#statusValidation").queryAs(Label.class);
         assertThat(validationLabel.getText()).contains("No issues");

--- a/courant-app/src/test/java/systems/courant/sd/app/WorkflowViewNavigationFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/WorkflowViewNavigationFxTest.java
@@ -18,6 +18,7 @@ import org.testfx.framework.junit5.Start;
 import org.testfx.util.WaitForAsyncUtils;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,22 +53,12 @@ class WorkflowViewNavigationFxTest {
         WaitForAsyncUtils.waitForFxEvents();
     }
 
-    private void waitForDashboardResults(FxRobot robot) {
-        long deadline = System.currentTimeMillis() + 15_000;
-        while (System.currentTimeMillis() < deadline) {
+    private void waitForDashboardResults(FxRobot robot) throws TimeoutException {
+        WaitForAsyncUtils.waitFor(30, TimeUnit.SECONDS, () -> {
             WaitForAsyncUtils.waitForFxEvents();
             var tabs = robot.lookup("#dashboardResultTabs").tryQueryAs(TabPane.class);
-            if (tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty()) {
-                return;
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        throw new AssertionError("Dashboard results did not appear within 15 seconds");
+            return tabs.isPresent() && tabs.get().isVisible() && !tabs.get().getTabs().isEmpty();
+        });
     }
 
     // ── Toolbar tool switching ───────────────────────────────────────────
@@ -165,7 +156,7 @@ class WorkflowViewNavigationFxTest {
 
     @Test
     @DisplayName("Simulation switches to Dashboard, can switch back to Properties")
-    void shouldSwitchTabsAfterSimulation(FxRobot robot) {
+    void shouldSwitchTabsAfterSimulation(FxRobot robot) throws Exception {
         loadExample("Bathtub", "introductory/bathtub.json");
 
         robot.push(KeyCode.CONTROL, KeyCode.R);
@@ -209,7 +200,7 @@ class WorkflowViewNavigationFxTest {
 
     @Test
     @DisplayName("Ctrl+N → load → Ctrl+B → Ctrl+R full keyboard workflow")
-    void shouldCompleteFullKeyboardWorkflow(FxRobot robot) {
+    void shouldCompleteFullKeyboardWorkflow(FxRobot robot) throws Exception {
         robot.push(KeyCode.CONTROL, KeyCode.N);
         WaitForAsyncUtils.waitForFxEvents();
         assertThat(stage.getTitle()).contains("Untitled");
@@ -219,12 +210,10 @@ class WorkflowViewNavigationFxTest {
 
         robot.push(KeyCode.CONTROL, KeyCode.B);
         WaitForAsyncUtils.waitForFxEvents();
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        WaitForAsyncUtils.waitForFxEvents();
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> {
+            WaitForAsyncUtils.waitForFxEvents();
+            return robot.lookup("#validationTable").tryQuery().isPresent();
+        });
 
         Platform.runLater(() -> {
             stage.toFront();

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/UndoManagerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/UndoManagerTest.java
@@ -364,9 +364,7 @@ class UndoManagerTest {
             UndoManager.Snapshot original = new UndoManager.Snapshot(model, view);
 
             manager.pushUndo(original, "Add water");
-
-            // Wait for background compression to finish
-            Thread.sleep(200);
+            manager.awaitCompression();
 
             UndoManager.Snapshot restored = manager.undo(snapshot("Current")).orElseThrow();
 
@@ -381,7 +379,7 @@ class UndoManagerTest {
         void shouldNotBlockIndefinitelyOnDecompress() throws Exception {
             // Push and wait for compression, then undo — should complete without blocking
             manager.pushUndo(snapshot("S1"), "Test");
-            Thread.sleep(200); // wait for compression
+            manager.awaitCompression();
             UndoManager.Snapshot result = manager.undo(snapshot("Current")).orElseThrow();
             assertSnapshotName(result, "S1");
         }
@@ -471,9 +469,7 @@ class UndoManagerTest {
             UndoManager.Snapshot original = new UndoManager.Snapshot(model, view);
 
             manager.pushUndo(original, "With metadata");
-
-            // Wait for background compression to complete
-            Thread.sleep(200);
+            manager.awaitCompression();
 
             UndoManager.Snapshot restored = manager.undo(snapshot("Current")).orElseThrow();
 
@@ -665,9 +661,7 @@ class UndoManagerTest {
         void shouldClearRawSnapshotAfterCompression() throws Exception {
             UndoManager.Snapshot snap = snapshot("S1");
             manager.pushUndo(snap, "Test");
-
-            // Wait for compression to complete and callback to fire
-            Thread.sleep(300);
+            manager.awaitCompression();
 
             // Undo should still work — it will use the compressed data path
             UndoManager.Snapshot result = manager.undo(snapshot("Current")).orElseThrow();


### PR DESCRIPTION
## Summary
- Eliminated all 17 `Thread.sleep` calls across 8 courant-app test files
- UndoManagerTest: added `awaitCompression()` to wait for background futures
- 7 Workflow*FxTest files: replaced poll+sleep loops with `WaitForAsyncUtils.waitFor()` and validation sleeps with node-presence polling
- Net: -203 lines, +123 lines (simpler, more reliable test code)

Closes #772