### PR TITLE
Fix delta > 1 catch-up loops in all stateful formulas

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/Delay1.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Delay1.java
@@ -50,6 +50,7 @@ public class Delay1 implements Formula, Resettable {
 
     private double stage;
     private double output;
+    private double lastInputVal;
     private boolean initialized;
     private long lastStep = -1;
 
@@ -100,6 +101,7 @@ public class Delay1 implements Formula, Resettable {
     public void reset() {
         stage = 0;
         output = 0;
+        lastInputVal = 0;
         initialized = false;
         lastStep = -1;
     }
@@ -115,19 +117,23 @@ public class Delay1 implements Formula, Resettable {
     public double getCurrentValue() {
         long step = currentStep.getAsLong();
         if (!initialized) {
-            double init = hasExplicitInitial ? explicitInitial : input.getAsDouble();
+            double inputAtInit = input.getAsDouble();
+            double init = hasExplicitInitial ? explicitInitial : inputAtInit;
             stage = init * delayTime;
             output = init;
+            lastInputVal = inputAtInit;
             initialized = true;
             lastStep = step;
         } else if (step > lastStep) {
             long delta = step - lastStep;
+            double currentInput = input.getAsDouble();
             for (long d = 0; d < delta; d++) {
-                double inputVal = input.getAsDouble();
+                double inputVal = (d < delta - 1) ? lastInputVal : currentInput;
                 double rate = stage / delayTime;
                 stage += inputVal - rate;
                 output = rate;
             }
+            lastInputVal = currentInput;
             lastStep = step;
         }
         return output;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Delay3.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Delay3.java
@@ -54,6 +54,7 @@ public class Delay3 implements Formula, Resettable {
     private double stage2;
     private double stage3;
     private double output;
+    private double lastInputVal;
     private boolean initialized;
     private long lastStep = -1;
 
@@ -106,6 +107,7 @@ public class Delay3 implements Formula, Resettable {
         stage2 = 0;
         stage3 = 0;
         output = 0;
+        lastInputVal = 0;
         initialized = false;
         lastStep = -1;
     }
@@ -121,19 +123,22 @@ public class Delay3 implements Formula, Resettable {
     public double getCurrentValue() {
         long step = currentStep.getAsLong();
         if (!initialized) {
-            double init = hasExplicitInitial ? explicitInitial : input.getAsDouble();
+            double inputAtInit = input.getAsDouble();
+            double init = hasExplicitInitial ? explicitInitial : inputAtInit;
             double stageTime = delayTime / 3.0;
             stage1 = init * stageTime;
             stage2 = init * stageTime;
             stage3 = init * stageTime;
             output = init;
+            lastInputVal = inputAtInit;
             initialized = true;
             lastStep = step;
         } else if (step > lastStep) {
             double stageTime = delayTime / 3.0;
             long delta = step - lastStep;
-            double inputVal = input.getAsDouble();
+            double currentInput = input.getAsDouble();
             for (long d = 0; d < delta; d++) {
+                double inputVal = (d < delta - 1) ? lastInputVal : currentInput;
                 // Compute outflow rates from current stage levels
                 double rate1 = stage1 / stageTime;
                 double rate2 = stage2 / stageTime;
@@ -146,6 +151,7 @@ public class Delay3 implements Formula, Resettable {
 
                 output = rate3;
             }
+            lastInputVal = currentInput;
             lastStep = step;
         }
         return output;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Forecast.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Forecast.java
@@ -97,18 +97,20 @@ public class Forecast implements Formula, Resettable {
             lastStep = step;
         } else if (step > lastStep) {
             long delta = step - lastStep;
+            double currentInput = input.getAsDouble();
             for (long d = 0; d < delta; d++) {
-                lastInputVal = input.getAsDouble();
-                averageInput += (lastInputVal - averageInput) / averagingTime;
+                double inputVal = (d < delta - 1) ? lastInputVal : currentInput;
+                averageInput += (inputVal - averageInput) / averagingTime;
                 double denom = averageInput * averagingTime;
                 if (Math.abs(denom) > 1e-15) {
-                    trend = (lastInputVal - averageInput) / denom;
+                    trend = (inputVal - averageInput) / denom;
                     // Clamp to prevent extreme values when averageInput is near zero
                     trend = Math.max(-10, Math.min(10, trend));
                 } else {
                     trend = 0;
                 }
             }
+            lastInputVal = currentInput;
             lastStep = step;
         }
         return lastInputVal * (1 + trend * horizon);

--- a/courant-engine/src/main/java/systems/courant/sd/model/Npv.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Npv.java
@@ -37,6 +37,7 @@ public class Npv implements Formula, Resettable {
 
     private double accumulated;
     private double cumulativeDiscount;
+    private double lastStreamVal;
     private boolean initialized;
     private long lastStep = -1;
 
@@ -102,6 +103,7 @@ public class Npv implements Formula, Resettable {
     public void reset() {
         accumulated = initialValue;
         cumulativeDiscount = 1.0;
+        lastStreamVal = 0;
         initialized = false;
         lastStep = -1;
     }
@@ -117,19 +119,21 @@ public class Npv implements Formula, Resettable {
         long step = currentStep.getAsLong();
         if (!initialized) {
             cumulativeDiscount = 1.0;
-            accumulated = initialValue + stream.getAsDouble() * factor;
+            lastStreamVal = stream.getAsDouble();
+            accumulated = initialValue + lastStreamVal * factor;
             initialized = true;
             lastStep = step;
         } else if (step > lastStep) {
             long delta = step - lastStep;
             double discountMultiplier = 1 + discountRate;
-            double streamVal = stream.getAsDouble();
-            // Compound discount for all elapsed steps
+            double currentStreamVal = stream.getAsDouble();
+            // Compound discount and accumulate payment at each sub-step
             for (long d = 0; d < delta; d++) {
+                double streamVal = (d < delta - 1) ? lastStreamVal : currentStreamVal;
                 cumulativeDiscount *= discountMultiplier;
+                accumulated += streamVal * factor / cumulativeDiscount;
             }
-            // Add only the current step's payment at the final discount level
-            accumulated += streamVal * factor / cumulativeDiscount;
+            lastStreamVal = currentStreamVal;
             lastStep = step;
         }
         return accumulated;

--- a/courant-engine/src/main/java/systems/courant/sd/model/SampleIfTrue.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/SampleIfTrue.java
@@ -24,6 +24,8 @@ public class SampleIfTrue implements Formula, Resettable {
     private final LongSupplier currentStep;
 
     private double heldValue;
+    private double lastConditionVal;
+    private double lastInputVal;
     private boolean initialized;
     private long lastStep = -1;
 
@@ -55,6 +57,8 @@ public class SampleIfTrue implements Formula, Resettable {
     @Override
     public void reset() {
         heldValue = 0;
+        lastConditionVal = 0;
+        lastInputVal = 0;
         initialized = false;
         lastStep = -1;
     }
@@ -65,17 +69,28 @@ public class SampleIfTrue implements Formula, Resettable {
         if (!initialized) {
             initialized = true;
             lastStep = step;
-            double c = condition.getAsDouble();
-            if (c != 0.0 && !Double.isNaN(c)) {
-                heldValue = input.getAsDouble();
+            lastConditionVal = condition.getAsDouble();
+            if (lastConditionVal != 0.0 && !Double.isNaN(lastConditionVal)) {
+                lastInputVal = input.getAsDouble();
+                heldValue = lastInputVal;
             } else {
+                lastInputVal = initialValue;
                 heldValue = initialValue;
             }
         } else if (step > lastStep) {
-            double c = condition.getAsDouble();
-            if (c != 0.0 && !Double.isNaN(c)) {
-                heldValue = input.getAsDouble();
+            long delta = step - lastStep;
+            double currentCondition = condition.getAsDouble();
+            for (long d = 0; d < delta; d++) {
+                boolean isFinalStep = (d == delta - 1);
+                double c = isFinalStep ? currentCondition : lastConditionVal;
+                if (c != 0.0 && !Double.isNaN(c)) {
+                    if (isFinalStep) {
+                        lastInputVal = input.getAsDouble();
+                    }
+                    heldValue = lastInputVal;
+                }
             }
+            lastConditionVal = currentCondition;
             lastStep = step;
         }
         return heldValue;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Smooth.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Smooth.java
@@ -46,6 +46,7 @@ public class Smooth implements Formula, Resettable {
     private final boolean hasExplicitInitial;
 
     private double smoothed;
+    private double lastInputVal;
     private boolean initialized;
     private long lastStep = -1;
     private boolean warnedNonPositive;
@@ -128,6 +129,7 @@ public class Smooth implements Formula, Resettable {
     @Override
     public void reset() {
         smoothed = 0;
+        lastInputVal = 0;
         initialized = false;
         lastStep = -1;
         warnedNonPositive = false;
@@ -145,12 +147,14 @@ public class Smooth implements Formula, Resettable {
     public double getCurrentValue() {
         long step = currentStep.getAsLong();
         if (!initialized) {
-            smoothed = hasExplicitInitial ? explicitInitial : input.getAsDouble();
+            double inputAtInit = input.getAsDouble();
+            smoothed = hasExplicitInitial ? explicitInitial : inputAtInit;
+            lastInputVal = inputAtInit;
             initialized = true;
             lastStep = step;
         } else if (step > lastStep) {
             long delta = step - lastStep;
-            double inputVal = input.getAsDouble();
+            double currentInput = input.getAsDouble();
             double st = smoothingTime.getAsDouble();
             if (st <= 0) {
                 if (!warnedNonPositive) {
@@ -160,8 +164,10 @@ public class Smooth implements Formula, Resettable {
                 st = 1.0;
             }
             for (long i = 0; i < delta; i++) {
+                double inputVal = (i < delta - 1) ? lastInputVal : currentInput;
                 smoothed += (inputVal - smoothed) / st;
             }
+            lastInputVal = currentInput;
             lastStep = step;
         }
         return smoothed;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Smooth3.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Smooth3.java
@@ -51,6 +51,7 @@ public class Smooth3 implements Formula, Resettable {
     private double stage1;
     private double stage2;
     private double stage3;
+    private double lastInputVal;
     private boolean initialized;
     private long lastStep = -1;
     private boolean warnedNonPositive;
@@ -122,6 +123,7 @@ public class Smooth3 implements Formula, Resettable {
         stage1 = 0;
         stage2 = 0;
         stage3 = 0;
+        lastInputVal = 0;
         initialized = false;
         lastStep = -1;
         warnedNonPositive = false;
@@ -138,10 +140,12 @@ public class Smooth3 implements Formula, Resettable {
     public double getCurrentValue() {
         long step = currentStep.getAsLong();
         if (!initialized) {
-            double init = hasExplicitInitial ? explicitInitial : input.getAsDouble();
+            double inputAtInit = input.getAsDouble();
+            double init = hasExplicitInitial ? explicitInitial : inputAtInit;
             stage1 = init;
             stage2 = init;
             stage3 = init;
+            lastInputVal = inputAtInit;
             initialized = true;
             lastStep = step;
         } else if (step > lastStep) {
@@ -155,12 +159,14 @@ public class Smooth3 implements Formula, Resettable {
             }
             double stageTime = st / 3.0;
             long delta = step - lastStep;
-            double inputVal = input.getAsDouble();
+            double currentInput = input.getAsDouble();
             for (long i = 0; i < delta; i++) {
+                double inputVal = (i < delta - 1) ? lastInputVal : currentInput;
                 stage1 += (inputVal - stage1) / stageTime;
                 stage2 += (stage1 - stage2) / stageTime;
                 stage3 += (stage2 - stage3) / stageTime;
             }
+            lastInputVal = currentInput;
             lastStep = step;
         }
         return stage3;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Trend.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Trend.java
@@ -35,6 +35,7 @@ public class Trend implements Formula, Resettable {
 
     private double averageInput;
     private double trend;
+    private double lastInputVal;
     private boolean initialized;
     private long lastStep = -1;
 
@@ -71,6 +72,7 @@ public class Trend implements Formula, Resettable {
     public void reset() {
         averageInput = 0;
         trend = 0;
+        lastInputVal = 0;
         initialized = false;
         lastStep = -1;
     }
@@ -86,19 +88,20 @@ public class Trend implements Formula, Resettable {
     public double getCurrentValue() {
         long step = currentStep.getAsLong();
         if (!initialized) {
-            double inputVal = input.getAsDouble();
+            lastInputVal = input.getAsDouble();
             // Initialize average so that the initial trend is correct:
             // trend = (input - avg) / (avg * avgTime)
             // => avg = input / (1 + initialTrend * avgTime)
             double denom = 1 + initialTrend * averagingTime;
-            averageInput = denom != 0 ? inputVal / denom : inputVal;
+            averageInput = denom != 0 ? lastInputVal / denom : lastInputVal;
             trend = initialTrend;
             initialized = true;
             lastStep = step;
         } else if (step > lastStep) {
             long delta = step - lastStep;
+            double currentInput = input.getAsDouble();
             for (long d = 0; d < delta; d++) {
-                double inputVal = input.getAsDouble();
+                double inputVal = (d < delta - 1) ? lastInputVal : currentInput;
                 averageInput += (inputVal - averageInput) / averagingTime;
                 double denom = averageInput * averagingTime;
                 if (Math.abs(denom) > 1e-15) {
@@ -109,6 +112,7 @@ public class Trend implements Formula, Resettable {
                     trend = 0;
                 }
             }
+            lastInputVal = currentInput;
             lastStep = step;
         }
         return trend;

--- a/courant-engine/src/test/java/systems/courant/sd/model/Delay1Test.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/Delay1Test.java
@@ -123,7 +123,7 @@ public class Delay1Test {
     }
 
     @Test
-    public void shouldReadInputEachIterationInCatchUpLoop() {
+    public void shouldReadInputOncePerCatchUpCall() {
         int[] step = {0};
         int[] readCount = {0};
         Delay1 formula = Delay1.of(() -> { readCount[0]++; return 100; }, 6, 100, () -> step[0]);
@@ -131,11 +131,11 @@ public class Delay1Test {
         formula.getCurrentValue(); // initialize
         readCount[0] = 0;
 
-        // Jump by 5 steps — input should be read once per catch-up iteration
+        // Jump by 5 steps — input should be read once (zero-order hold for intermediate steps)
         step[0] = 5;
         formula.getCurrentValue();
-        assertEquals(5, readCount[0],
-                "Input should be read once per catch-up iteration");
+        assertEquals(1, readCount[0],
+                "Input should be read once per getCurrentValue call (zero-order hold)");
     }
 
     @Test

--- a/courant-engine/src/test/java/systems/courant/sd/model/ForecastTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/ForecastTest.java
@@ -45,7 +45,7 @@ class ForecastTest {
     }
 
     @Test
-    void shouldReadInputEachIterationInCatchUpLoop() {
+    void shouldReadInputOncePerCatchUpCall() {
         int[] step = {0};
         int[] readCount = {0};
         Forecast forecast = Forecast.of(() -> { readCount[0]++; return 100; }, 5, 3, 0, () -> step[0]);
@@ -53,11 +53,11 @@ class ForecastTest {
         forecast.getCurrentValue(); // initialize (1 read)
         readCount[0] = 0;
 
-        // Jump by 5 steps — input should be read once per catch-up iteration
+        // Jump by 5 steps — input should be read once (zero-order hold for intermediate steps)
         step[0] = 5;
         forecast.getCurrentValue();
-        assertEquals(5, readCount[0],
-                "Input should be read once per catch-up iteration");
+        assertEquals(1, readCount[0],
+                "Input should be read once per getCurrentValue call (zero-order hold)");
     }
 
     @Test

--- a/courant-engine/src/test/java/systems/courant/sd/model/NpvTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/NpvTest.java
@@ -75,7 +75,7 @@ class NpvTest {
     }
 
     @Test
-    void shouldOnlyAddOnePaymentWhenSkippingSteps() {
+    void shouldAccumulatePaymentAtEachSubStepWhenSkipping() {
         int[] step1 = {0};
         int[] step2 = {0};
         Npv stepped = Npv.of(() -> 100, 0.1, () -> step1[0]);
@@ -90,16 +90,12 @@ class NpvTest {
         step1[0] = 3;
         double steppedVal = stepped.getCurrentValue();
 
-        // Skip directly from 0 to 3: adds only one payment (at step 3's discount)
+        // Skip directly from 0 to 3: should accumulate payments at each sub-step
         skipped.getCurrentValue(); // step 0
         step2[0] = 3;
         double skippedVal = skipped.getCurrentValue();
 
-        // Skipped should be less than stepped because it missed two payments
-        assertThat(skippedVal).isLessThan(steppedVal);
-
-        // Skipped = 100 (step 0) + 100 / 1.1^3
-        double expectedSkipped = 100 + 100 / Math.pow(1.1, 3);
-        assertThat(skippedVal).isCloseTo(expectedSkipped, within(1e-9));
+        // With constant stream, skipped should equal stepped (zero-order hold)
+        assertThat(skippedVal).isCloseTo(steppedVal, within(1e-9));
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/model/StatefulFormulaCatchUpTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/StatefulFormulaCatchUpTest.java
@@ -1,0 +1,192 @@
+package systems.courant.sd.model;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import systems.courant.sd.model.compile.Resettable;
+
+import java.util.function.DoubleSupplier;
+import java.util.function.LongSupplier;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Parameterized test that verifies all stateful formula classes produce consistent
+ * results regardless of savePer (step increment). Compares savePer=1 baseline
+ * against savePer=2, where the input changes only at save points so that
+ * zero-order hold produces exact results.
+ *
+ * <p>This is the structural regression test for issue #1061.
+ */
+public class StatefulFormulaCatchUpTest {
+
+    private static final int TOTAL_STEPS = 20;
+    private static final double TOLERANCE = 1e-9;
+
+    /**
+     * Input function that changes only at even steps (save points for savePer=2).
+     * This ensures the zero-order hold is exact: at odd (intermediate) steps,
+     * the held value IS the correct value.
+     */
+    private static double inputAtStep(long step) {
+        // Piecewise constant: changes at even steps only
+        long savePoint = (step / 2) * 2; // round down to nearest even
+        return 50 + savePoint * 5;       // 50, 50, 60, 60, 70, 70, ...
+    }
+
+    /**
+     * A condition function for SampleIfTrue that is true at even steps.
+     */
+    private static double conditionAtStep(long step) {
+        return (step % 4 == 0) ? 1.0 : 0.0;
+    }
+
+    record FormulaFactory(String name,
+                          java.util.function.BiFunction<DoubleSupplier, LongSupplier, Formula> create) {
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    static Stream<Arguments> formulaFactories() {
+        return Stream.of(
+                Arguments.of(new FormulaFactory("Delay1", (input, step) ->
+                        Delay1.of(input, 6, step))),
+                Arguments.of(new FormulaFactory("Delay1I", (input, step) ->
+                        Delay1.of(input, 6, 50, step))),
+                Arguments.of(new FormulaFactory("Delay3", (input, step) ->
+                        Delay3.of(input, 6, step))),
+                Arguments.of(new FormulaFactory("Delay3I", (input, step) ->
+                        Delay3.of(input, 6, 50, step))),
+                Arguments.of(new FormulaFactory("Smooth", (input, step) ->
+                        Smooth.of(input, 5, step))),
+                Arguments.of(new FormulaFactory("SmoothI", (input, step) ->
+                        Smooth.of(input, 5, 50, step))),
+                Arguments.of(new FormulaFactory("Smooth3", (input, step) ->
+                        Smooth3.of(input, 5, step))),
+                Arguments.of(new FormulaFactory("Smooth3I", (input, step) ->
+                        Smooth3.of(input, 5, 50, step))),
+                Arguments.of(new FormulaFactory("Trend", (input, step) ->
+                        Trend.of(input, 5, 0, step))),
+                Arguments.of(new FormulaFactory("Forecast", (input, step) ->
+                        Forecast.of(input, 5, 3, 0, step))),
+                Arguments.of(new FormulaFactory("Npv", (input, step) ->
+                        Npv.of(input, 0.05, step))),
+                Arguments.of(new FormulaFactory("SampleIfTrue", (input, step) -> {
+                    long[] currentStep = {0};
+                    // Wire condition to the same step counter
+                    DoubleSupplier condition = () -> conditionAtStep(currentStep[0]);
+                    // We need a way to sync currentStep — use a wrapper
+                    LongSupplier stepWrapper = () -> {
+                        currentStep[0] = step.getAsLong();
+                        return currentStep[0];
+                    };
+                    return SampleIfTrue.of(condition, input, 0, stepWrapper);
+                }))
+        );
+    }
+
+    @ParameterizedTest(name = "{0}: savePer=1 vs savePer=2")
+    @MethodSource("formulaFactories")
+    void shouldMatchBaselineWhenSavePerIs2(FormulaFactory factory) {
+        // --- Run with savePer=1 (baseline) ---
+        long[] stepHolder1 = {0};
+        Formula baseline = factory.create().apply(
+                () -> inputAtStep(stepHolder1[0]),
+                () -> stepHolder1[0]);
+
+        double[] baselineResults = new double[TOTAL_STEPS + 1];
+        baselineResults[0] = baseline.getCurrentValue(); // step 0
+        for (int s = 1; s <= TOTAL_STEPS; s++) {
+            stepHolder1[0] = s;
+            baselineResults[s] = baseline.getCurrentValue();
+        }
+
+        // --- Run with savePer=2 ---
+        long[] stepHolder2 = {0};
+        Formula catchUp = factory.create().apply(
+                () -> inputAtStep(stepHolder2[0]),
+                () -> stepHolder2[0]);
+
+        double[] catchUpResults = new double[TOTAL_STEPS + 1];
+        catchUpResults[0] = catchUp.getCurrentValue(); // step 0
+        for (int s = 2; s <= TOTAL_STEPS; s += 2) {
+            stepHolder2[0] = s;
+            catchUpResults[s] = catchUp.getCurrentValue();
+        }
+
+        // Compare at save points (every 2 steps)
+        for (int s = 0; s <= TOTAL_STEPS; s += 2) {
+            assertEquals(baselineResults[s], catchUpResults[s], TOLERANCE,
+                    factory.name() + " mismatch at step " + s
+                            + ": baseline=" + baselineResults[s]
+                            + " catchUp=" + catchUpResults[s]);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}: savePer=1 vs savePer=4")
+    @MethodSource("formulaFactories")
+    void shouldMatchBaselineWhenSavePerIs4(FormulaFactory factory) {
+        // Use input that changes only at multiples of 4
+        java.util.function.LongFunction<Double> input4 = step -> {
+            long savePoint = (step / 4) * 4;
+            return 50 + savePoint * 5.0;
+        };
+        java.util.function.LongFunction<Double> condition4 = step ->
+                (step % 8 == 0) ? 1.0 : 0.0;
+
+        // --- Run with savePer=1 (baseline) ---
+        long[] stepHolder1 = {0};
+        Formula baseline;
+        if (factory.name().equals("SampleIfTrue")) {
+            baseline = SampleIfTrue.of(
+                    () -> condition4.apply(stepHolder1[0]),
+                    () -> input4.apply(stepHolder1[0]),
+                    0, () -> stepHolder1[0]);
+        } else {
+            baseline = factory.create().apply(
+                    () -> input4.apply(stepHolder1[0]),
+                    () -> stepHolder1[0]);
+        }
+
+        int totalSteps = 20;
+        double[] baselineResults = new double[totalSteps + 1];
+        baselineResults[0] = baseline.getCurrentValue();
+        for (int s = 1; s <= totalSteps; s++) {
+            stepHolder1[0] = s;
+            baselineResults[s] = baseline.getCurrentValue();
+        }
+
+        // --- Run with savePer=4 ---
+        long[] stepHolder2 = {0};
+        Formula catchUp;
+        if (factory.name().equals("SampleIfTrue")) {
+            catchUp = SampleIfTrue.of(
+                    () -> condition4.apply(stepHolder2[0]),
+                    () -> input4.apply(stepHolder2[0]),
+                    0, () -> stepHolder2[0]);
+        } else {
+            catchUp = factory.create().apply(
+                    () -> input4.apply(stepHolder2[0]),
+                    () -> stepHolder2[0]);
+        }
+
+        double[] catchUpResults = new double[totalSteps + 1];
+        catchUpResults[0] = catchUp.getCurrentValue();
+        for (int s = 4; s <= totalSteps; s += 4) {
+            stepHolder2[0] = s;
+            catchUpResults[s] = catchUp.getCurrentValue();
+        }
+
+        // Compare at save points (every 4 steps)
+        for (int s = 0; s <= totalSteps; s += 4) {
+            assertEquals(baselineResults[s], catchUpResults[s], TOLERANCE,
+                    factory.name() + " mismatch at step " + s
+                            + ": baseline=" + baselineResults[s]
+                            + " catchUp=" + catchUpResults[s]);
+        }
+    }
+}

--- a/courant-engine/src/test/java/systems/courant/sd/model/TrendTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/TrendTest.java
@@ -29,7 +29,7 @@ class TrendTest {
     }
 
     @Test
-    void shouldReadInputEachIterationInCatchUpLoop() {
+    void shouldReadInputOncePerCatchUpCall() {
         int[] step = {0};
         int[] readCount = {0};
         Trend trend = Trend.of(() -> { readCount[0]++; return 100; }, 5, 0, () -> step[0]);
@@ -37,11 +37,11 @@ class TrendTest {
         trend.getCurrentValue(); // initialize (1 read)
         readCount[0] = 0;
 
-        // Jump by 5 steps — input should be read once per catch-up iteration
+        // Jump by 5 steps — input should be read once (zero-order hold for intermediate steps)
         step[0] = 5;
         trend.getCurrentValue();
-        assertEquals(5, readCount[0],
-                "Input should be read once per catch-up iteration");
+        assertEquals(1, readCount[0],
+                "Input should be read once per getCurrentValue call (zero-order hold)");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Apply zero-order hold pattern to all 8 stateful formula classes (Delay1, Delay3, Smooth, Smooth3, Trend, Forecast, Npv, SampleIfTrue) so they handle `delta > 1` correctly when `savePer > 1`
- Each class now tracks `lastInputVal`, uses the held value for intermediate sub-steps, and reads the current input only for the final sub-step
- NPV now accumulates a discounted payment at every sub-step instead of only the last (critical correctness fix)
- SampleIfTrue gets a proper catch-up loop with held condition/input tracking
- Add parameterized `StatefulFormulaCatchUpTest` comparing `savePer=1` vs `savePer=2` and `savePer=4` across all formula types

Closes #1061, closes #644, closes #1029, closes #1030, closes #1049

## Test plan
- [x] All 2299 existing tests pass
- [x] New parameterized test covers all 8 formula types at savePer=2 and savePer=4
- [x] SpotBugs clean