### PR TITLE
Fix combinatorial overflow in MultiParameterSweepDialog

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/MultiParameterSweepDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/MultiParameterSweepDialog.java
@@ -166,7 +166,11 @@ public class MultiParameterSweepDialog extends Dialog<MultiParameterSweepDialog.
         long product = 1;
         for (ParamConfig p : params) {
             int count = ParameterSweep.linspace(p.start(), p.end(), p.step()).length;
-            product *= count;
+            try {
+                product = Math.multiplyExact(product, count);
+            } catch (ArithmeticException e) {
+                return Long.MAX_VALUE;
+            }
             if (product > 10_000_000) {
                 return product;
             }


### PR DESCRIPTION
## Summary
- Use `Math.multiplyExact` in `computeCombinations` to detect long overflow instead of silently wrapping around
- Returns `Long.MAX_VALUE` on overflow so the `MAX_COMBINATIONS` guard always fires correctly

Closes #1101

## Test plan
- [x] Full test suite passes (145 tests, 0 failures)
- [x] SpotBugs clean