### PR TITLE
Default empty initial guess to midpoint of bounds

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialog.java
@@ -379,7 +379,7 @@ public class CalibrateDialog extends Dialog<CalibrateDialog.Config> {
             double low = Double.parseDouble(lowerField.getText().trim());
             double high = Double.parseDouble(upperField.getText().trim());
             String guessText = guessField.getText().trim();
-            double guess = guessText.isEmpty() ? Double.NaN : Double.parseDouble(guessText);
+            double guess = guessText.isEmpty() ? (low + high) / 2.0 : Double.parseDouble(guessText);
             return new ParamConfig(getSelectedName(), low, high, guess);
         }
     }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/OptimizerDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/OptimizerDialog.java
@@ -305,7 +305,7 @@ public class OptimizerDialog extends Dialog<OptimizerDialog.Config> {
             double low = Double.parseDouble(lowerField.getText().trim());
             double high = Double.parseDouble(upperField.getText().trim());
             String guessText = guessField.getText().trim();
-            double guess = guessText.isEmpty() ? Double.NaN : Double.parseDouble(guessText);
+            double guess = guessText.isEmpty() ? (low + high) / 2.0 : Double.parseDouble(guessText);
             return new ParamConfig(getSelectedName(), low, high, guess);
         }
     }


### PR DESCRIPTION
## Summary
- When the initial-guess field is left blank in CalibrateDialog and OptimizerDialog, default to `(low + high) / 2.0` instead of `Double.NaN`
- Prevents silent NaN propagation through the optimizer

Closes #1093