### PR TITLE
Log IOException via SLF4J in CalibrateDialog CSV import

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CalibrateDialog.java
@@ -27,6 +27,9 @@ import java.util.List;
 import systems.courant.sd.app.canvas.HelpContextResolver;
 import systems.courant.sd.app.canvas.ParameterRowBase;
 import systems.courant.sd.app.canvas.Styles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import systems.courant.sd.io.ReferenceDataCsvReader;
 import systems.courant.sd.model.def.ReferenceDataset;
 
@@ -35,6 +38,8 @@ import systems.courant.sd.model.def.ReferenceDataset;
  * map columns to model stocks, set parameter bounds, and choose algorithm.
  */
 public class CalibrateDialog extends Dialog<CalibrateDialog.Config> {
+
+    private static final Logger logger = LoggerFactory.getLogger(CalibrateDialog.class);
 
     public record FitTarget(String stockName, String csvColumnName, double[] observedData) {
     }
@@ -241,6 +246,7 @@ public class CalibrateDialog extends Dialog<CalibrateDialog.Config> {
                 datasetLabel.setText("No columns mapped — import again");
             }
         } catch (IOException ex) {
+            logger.error("Failed to import CSV dataset: {}", ex.getMessage(), ex);
             datasetLabel.setText("Error: " + ex.getMessage());
         }
         fieldChangeCounter.set(fieldChangeCounter.get() + 1);


### PR DESCRIPTION
## Summary
- Add SLF4J logger to `CalibrateDialog` and log the full exception on CSV import failure
- Stack trace is now preserved for diagnostics instead of only showing a brief message to the user

Closes #1100

## Test plan
- [x] Full test suite passes (145 tests, 0 failures)
- [x] SpotBugs clean