### PR TITLE
Add defensive copies to ExtractedLookup record

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
@@ -144,7 +144,22 @@ public final class VensimExprTranslator {
      * @param xValues the x-axis data points
      * @param yValues the y-axis data points
      */
-    public record ExtractedLookup(String name, double[] xValues, double[] yValues) {}
+    public record ExtractedLookup(String name, double[] xValues, double[] yValues) {
+        public ExtractedLookup {
+            xValues = xValues.clone();
+            yValues = yValues.clone();
+        }
+
+        @Override
+        public double[] xValues() {
+            return xValues.clone();
+        }
+
+        @Override
+        public double[] yValues() {
+            return yValues.clone();
+        }
+    }
 
     private VensimExprTranslator() {
     }


### PR DESCRIPTION
## Summary
- Add compact canonical constructor that clones `xValues` and `yValues` arrays on construction
- Override accessor methods to return clones, preventing external mutation of lookup data

Closes #1098

## Test plan
- [x] Full test suite passes (145 tests, 0 failures)
- [x] SpotBugs clean