### PR TITLE
Reject binary files in VensimImporter charset fallback

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
@@ -75,6 +75,9 @@ public class VensimImporter implements ModelImporter {
         } catch (CharacterCodingException e) {
             content = Files.readString(path, Charset.forName("windows-1252"));
         }
+        if (content.indexOf('\0') >= 0) {
+            throw new IOException("File appears to be binary, not a valid Vensim .mdl file: " + path);
+        }
         Path fileName = path.getFileName();
         String modelName = fileName != null ? fileName.toString() : path.toString();
         int dotPos = modelName.lastIndexOf('.');

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("VensimImporter")
 class VensimImporterTest {
@@ -3003,6 +3004,25 @@ class VensimImporterTest {
             java.nio.file.Files.deleteIfExists(secretFile);
             java.nio.file.Files.deleteIfExists(mdlPath);
             java.nio.file.Files.deleteIfExists(modelDir);
+            java.nio.file.Files.deleteIfExists(tempDir);
+        }
+    }
+
+    @Nested
+    @DisplayName("Binary file rejection")
+    class BinaryFileRejection {
+
+        @Test
+        void shouldRejectBinaryFileWithNulBytes() throws IOException {
+            Path tempDir = java.nio.file.Files.createTempDirectory("vensim-test");
+            Path binaryFile = tempDir.resolve("corrupt.mdl");
+            java.nio.file.Files.write(binaryFile, new byte[]{0x50, 0x4B, 0x00, 0x04, 0x00, 0x00});
+
+            assertThatThrownBy(() -> importer.importModel(binaryFile))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("binary");
+
+            java.nio.file.Files.deleteIfExists(binaryFile);
             java.nio.file.Files.deleteIfExists(tempDir);
         }
     }


### PR DESCRIPTION
## Summary
- After the windows-1252 charset fallback, check for NUL bytes that indicate binary content
- Throws `IOException` with a clear message instead of silently reading garbled data

Closes #1091