### PR TITLE
Fix diamond dependency false positive in ModelReport cycle detection

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/ModelReport.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/ModelReport.java
@@ -110,6 +110,7 @@ public class ModelReport {
         for (Module sub : module.getSubModules().values()) {
             appendModule(builder, sub, indent + "  ", visited);
         }
+        visited.remove(module.getName());
     }
 
 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/ModelReportTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/ModelReportTest.java
@@ -149,7 +149,7 @@ class ModelReportTest {
         }
 
         @Test
-        void shouldPrintSharedSubModuleOnlyOnce() {
+        void shouldNotReportCycleForDiamondDependency() {
             Module parent = new Module("Parent");
             Module siblingA = new Module("SiblingA");
             Module siblingB = new Module("SiblingB");
@@ -163,10 +163,9 @@ class ModelReportTest {
 
             String report = ModelReport.create(model);
 
-            // "Module: Shared" should appear in the report, but the second occurrence
-            // should be detected as a cycle and skipped
+            // Diamond dependencies should not trigger false cycle detection
             assertThat(report).contains("Module: Shared");
-            assertThat(report).contains("cycle detected, skipping");
+            assertThat(report).doesNotContain("cycle detected");
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Use path-based cycle detection by removing modules from visited set after recursion
- Diamond-shaped module hierarchies no longer falsely reported as cycles
- Updated test to verify diamond dependencies are handled correctly

Closes #1097

## Test plan
- [x] Full test suite passes (145 tests, 0 failures)
- [x] SpotBugs clean
- [x] `shouldNotReportCycleForDiamondDependency` verifies diamond case
- [x] `shouldDetectModuleCycle` still catches true cycles