### PR TITLE
Guard against null input in BehaviorModeClassifier

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/BehaviorModeClassifier.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/BehaviorModeClassifier.java
@@ -18,7 +18,7 @@ public final class BehaviorModeClassifier {
      * @return a short label describing the behavior, or empty string if unclassifiable
      */
     public static String classify(double[] values) {
-        if (values.length < 4) {
+        if (values == null || values.length < 4) {
             return "";
         }
 

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/BehaviorModeClassifierTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/BehaviorModeClassifierTest.java
@@ -142,5 +142,10 @@ class BehaviorModeClassifierTest {
         void shouldReturnEmptyForFourPointMixedSeries() {
             assertThat(BehaviorModeClassifier.classify(new double[]{1, 5, 2, 8})).isEmpty();
         }
+
+        @Test
+        void shouldReturnEmptyForNullInput() {
+            assertThat(BehaviorModeClassifier.classify(null)).isEmpty();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add null check to `classify()` to return empty string instead of NPE
- Add test for null input edge case

Closes #1095

## Test plan
- [x] Full test suite passes (146 tests, 0 failures)
- [x] SpotBugs clean
- [x] New test `shouldReturnEmptyForNullInput` covers the fix