### PR TITLE
Guard against empty expanded list in subscript expansion

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExprTranslator.java
@@ -1051,6 +1051,10 @@ public final class VensimExprTranslator {
                 expanded.add(innerExpr.replace(dimName + "!", label));
             }
 
+            if (expanded.isEmpty()) {
+                break;
+            }
+
             String replacement;
             if (joinOp != null) {
                 replacement = "(" + String.join(joinOp, expanded) + ")";


### PR DESCRIPTION
## Summary
- Add `isEmpty` check on the expanded list before calling `getLast()` in VensimExprTranslator subscript expansion
- Prevents `NoSuchElementException` on unexpected subscript dimension configurations

Closes #1089