### PR TITLE
Synthesize CLD variables from causal links in legacy model files

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -42,8 +42,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Serializes and deserializes {@link ModelDefinition} to/from JSON.
@@ -522,6 +524,9 @@ public class ModelDefinitionSerializer {
         List<SubscriptDef> subscripts = deserializeSubscripts(root);
         List<CldVariableDef> cldVariables = deserializeCldVariables(root);
         List<CausalLinkDef> causalLinks = deserializeCausalLinks(root);
+        if (cldVariables.isEmpty() && !causalLinks.isEmpty()) {
+            cldVariables = synthesizeCldVariables(causalLinks);
+        }
         List<CommentDef> comments = deserializeComments(root);
 
         List<ViewDef> views = new ArrayList<>();
@@ -679,6 +684,24 @@ public class ModelDefinitionSerializer {
             }
         }
         return cldVariables;
+    }
+
+    /**
+     * Synthesizes CLD variable definitions from causal link endpoints when no
+     * explicit cldVariables array is present. This handles legacy model files
+     * that were imported before CLD variable tracking was added.
+     */
+    private List<CldVariableDef> synthesizeCldVariables(List<CausalLinkDef> causalLinks) {
+        Set<String> seen = new LinkedHashSet<>();
+        for (CausalLinkDef link : causalLinks) {
+            seen.add(link.from());
+            seen.add(link.to());
+        }
+        List<CldVariableDef> result = new ArrayList<>();
+        for (String name : seen) {
+            result.add(new CldVariableDef(name, null));
+        }
+        return result;
     }
 
     private List<CausalLinkDef> deserializeCausalLinks(JsonNode root) {

--- a/courant-engine/src/test/java/systems/courant/sd/io/json/ModelDefinitionSerializerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/json/ModelDefinitionSerializerTest.java
@@ -273,6 +273,39 @@ class ModelDefinitionSerializerTest {
     }
 
     @Test
+    void shouldSynthesizeCldVariablesFromCausalLinksWhenMissing() {
+        String json = """
+                {
+                  "name": "Legacy CLD",
+                  "causalLinks": [
+                    { "from": "A", "to": "B", "polarity": "POSITIVE" },
+                    { "from": "B", "to": "C", "polarity": "NEGATIVE" },
+                    { "from": "C", "to": "A", "polarity": "POSITIVE" }
+                  ]
+                }
+                """;
+        ModelDefinition def = serializer.fromJson(json);
+        assertThat(def.cldVariables()).hasSize(3);
+        assertThat(def.cldVariables().stream().map(CldVariableDef::name))
+                .containsExactlyInAnyOrder("A", "B", "C");
+        assertThat(def.causalLinks()).hasSize(3);
+    }
+
+    @Test
+    void shouldNotSynthesizeCldVariablesWhenAlreadyPresent() {
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("Explicit")
+                .cldVariable("X", "described")
+                .cldVariable("Y")
+                .causalLink("X", "Y", CausalLinkDef.Polarity.POSITIVE)
+                .build();
+
+        ModelDefinition roundTripped = serializer.fromJson(serializer.toJson(def));
+        assertThat(roundTripped.cldVariables()).hasSize(2);
+        assertThat(roundTripped.cldVariables().get(0).comment()).isEqualTo("described");
+    }
+
+    @Test
     void shouldRoundTripCausalLinkWithComment() {
         ModelDefinition def = new ModelDefinitionBuilder()
                 .name("Test")


### PR DESCRIPTION
## Summary

- Nine bundled CLD models (e.g., competition-faculty, cld-bankrun, cocaine-cld) have `causalLinks` but no `cldVariables` array, causing all CLD elements to be invisible on the canvas with 20+ validation errors per model
- When `ModelDefinitionSerializer` deserializes a model with causal links but no CLD variables, it now synthesizes the missing `CldVariableDef` entries from the unique element names in the links
- Models with explicit `cldVariables` arrays are unaffected

## Test plan

- [x] New test: `shouldSynthesizeCldVariablesFromCausalLinksWhenMissing` — verifies synthesis from causal link endpoints
- [x] New test: `shouldNotSynthesizeCldVariablesWhenAlreadyPresent` — verifies no interference with explicit CLD variables
- [x] Existing test: `shouldDeserializeModelWithoutCldFields` — verifies no synthesis when no causal links
- [x] All 141 tests pass
- [x] SpotBugs clean