### PR TITLE
Remove simulation control variables from canvas on Vensim import

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -388,6 +388,9 @@ public class ModelDefinitionSerializer {
         if (settings.savePer() != 1) {
             node.put("savePer", settings.savePer());
         }
+        if (settings.initialTime() != 0.0) {
+            node.put("initialTime", settings.initialTime());
+        }
         return node;
     }
 
@@ -751,13 +754,15 @@ public class ModelDefinitionSerializer {
         double dt = s.has("dt") ? s.get("dt").asDouble() : 1.0;
         boolean strict = s.has("strictMode") && s.get("strictMode").asBoolean();
         long savePerVal = s.has("savePer") ? s.get("savePer").asLong() : 1;
+        double initTime = s.has("initialTime") ? s.get("initialTime").asDouble() : 0.0;
         return new SimulationSettings(
                 requiredText(s, "timeStep"),
                 requiredDouble(s, "duration"),
                 requiredText(s, "durationUnit"),
                 dt,
                 strict,
-                savePerVal);
+                savePerVal,
+                initTime);
     }
 
     private ModelMetadata deserializeMetadata(JsonNode root) {

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
@@ -116,10 +116,11 @@ public class VensimImporter implements ModelImporter {
 
         ModelDefinitionBuilder builder = new ModelDefinitionBuilder()
                 .name(modelName)
-                .defaultSimulation(sim.timeUnit, sim.duration, sim.timeUnit, sim.timeStep);
+                .defaultSimulation(new systems.courant.sd.model.def.SimulationSettings(
+                        sim.timeUnit, sim.duration, sim.timeUnit, sim.timeStep,
+                        false, 1, sim.initialTime));
 
         registerEquivalenceDimensions(subscripts, builder);
-        injectSimulationConstants(builder, sim);
 
         PreClassificationResult preClassification = preClassifyEquations(
                 equations, subscripts, sim, warnings);
@@ -305,13 +306,6 @@ public class VensimImporter implements ModelImporter {
                 builder.subscript(displayName, labels);
             }
         }
-    }
-
-    private void injectSimulationConstants(ModelDefinitionBuilder builder,
-                                            SimulationSettings sim) {
-        builder.constant("TIME_STEP", sim.timeStep, sim.timeUnit);
-        builder.constant("INITIAL_TIME", sim.initialTime, sim.timeUnit);
-        builder.constant("FINAL_TIME", sim.finalTime, sim.timeUnit);
     }
 
     private PreClassificationResult preClassifyEquations(

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ModelCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ModelCompiler.java
@@ -20,6 +20,7 @@ import systems.courant.sd.model.def.LookupTableDef;
 import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.ModuleInstanceDef;
 import systems.courant.sd.model.def.PortDef;
+import systems.courant.sd.model.def.SimulationSettings;
 import systems.courant.sd.model.def.StockDef;
 import systems.courant.sd.model.expr.ExprParser;
 import systems.courant.sd.model.expr.ParseException;
@@ -122,6 +123,10 @@ public class ModelCompiler {
     private void compileInto(ModelDefinition def, Model model,
                              CompilationContext context,
                              List<Resettable> resettables, long[] stepHolder) {
+        // Inject simulation-derived constants (TIME_STEP, INITIAL_TIME, FINAL_TIME)
+        // so formulas can reference them without requiring explicit variable definitions.
+        injectSimulationConstants(def, context);
+
         // Stocks — create all first, then evaluate initial expressions
         // (expressions may reference other stocks)
         for (StockDef sDef : def.stocks()) {
@@ -246,6 +251,16 @@ public class ModelCompiler {
         }
 
         parentModel.addModule(module);
+    }
+
+    private void injectSimulationConstants(ModelDefinition def, CompilationContext context) {
+        SimulationSettings sim = def.defaultSimulation();
+        if (sim == null) {
+            return;
+        }
+        context.addLiteralConstant("TIME_STEP", sim.dt());
+        context.addLiteralConstant("INITIAL_TIME", sim.initialTime());
+        context.addLiteralConstant("FINAL_TIME", sim.initialTime() + sim.duration());
     }
 
     // === Shared helpers ===

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/DefinitionValidator.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/DefinitionValidator.java
@@ -125,11 +125,15 @@ public final class DefinitionValidator {
         }
     }
 
+    private static final Set<String> SIMULATION_CONSTANTS =
+            Set.of("TIME_STEP", "INITIAL_TIME", "FINAL_TIME");
+
     private static Set<String> buildKnownNames(Set<String> allNames, ModelDefinition def) {
         Set<String> knownNames = new HashSet<>(allNames);
         for (ModuleInstanceDef module : def.modules()) {
             knownNames.addAll(module.outputBindings().values());
         }
+        knownNames.addAll(SIMULATION_CONSTANTS);
         return knownNames;
     }
 

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/SimulationSettings.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/SimulationSettings.java
@@ -12,6 +12,9 @@ package systems.courant.sd.model.def;
  *                     reverting to the previous value. Defaults to false.
  * @param savePer      the recording interval in steps. Only every Nth step is recorded
  *                     to history and fires time step events. Defaults to 1 (record all).
+ * @param initialTime  the simulation start time as a numeric value (e.g., 0 or 1990).
+ *                     Defaults to 0. Used to derive INITIAL_TIME and FINAL_TIME constants
+ *                     for models that reference them in equations.
  */
 public record SimulationSettings(
         String timeStep,
@@ -19,29 +22,39 @@ public record SimulationSettings(
         String durationUnit,
         double dt,
         boolean strictMode,
-        long savePer
+        long savePer,
+        double initialTime
 ) {
 
     /**
-     * Creates simulation settings with dt defaulting to 1.0, strictMode off, and savePer 1.
+     * Creates simulation settings with dt defaulting to 1.0, strictMode off, savePer 1,
+     * and initialTime 0.
      */
     public SimulationSettings(String timeStep, double duration, String durationUnit) {
-        this(timeStep, duration, durationUnit, 1.0, false, 1);
+        this(timeStep, duration, durationUnit, 1.0, false, 1, 0.0);
     }
 
     /**
-     * Creates simulation settings with strictMode off and savePer 1.
+     * Creates simulation settings with strictMode off, savePer 1, and initialTime 0.
      */
     public SimulationSettings(String timeStep, double duration, String durationUnit, double dt) {
-        this(timeStep, duration, durationUnit, dt, false, 1);
+        this(timeStep, duration, durationUnit, dt, false, 1, 0.0);
     }
 
     /**
-     * Creates simulation settings with savePer defaulting to 1.
+     * Creates simulation settings with savePer defaulting to 1 and initialTime 0.
      */
     public SimulationSettings(String timeStep, double duration, String durationUnit, double dt,
                               boolean strictMode) {
-        this(timeStep, duration, durationUnit, dt, strictMode, 1);
+        this(timeStep, duration, durationUnit, dt, strictMode, 1, 0.0);
+    }
+
+    /**
+     * Creates simulation settings with initialTime defaulting to 0.
+     */
+    public SimulationSettings(String timeStep, double duration, String durationUnit, double dt,
+                              boolean strictMode, long savePer) {
+        this(timeStep, duration, durationUnit, dt, strictMode, savePer, 0.0);
     }
 
     public SimulationSettings {
@@ -62,6 +75,9 @@ public record SimulationSettings(
         }
         if (savePer < 1) {
             throw new IllegalArgumentException("savePer must be >= 1, got " + savePer);
+        }
+        if (Double.isNaN(initialTime) || Double.isInfinite(initialTime)) {
+            throw new IllegalArgumentException("initialTime must be finite, got " + initialTime);
         }
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
@@ -480,7 +480,7 @@ class VensimExporterTest {
 
             assertThat(result.definition().cldVariables()).hasSize(3);
             assertThat(result.definition().causalLinks()).hasSize(1);
-            assertThat(result.definition().parameters()).hasSize(3); // only built-in constants
+            assertThat(result.definition().parameters()).isEmpty();
         }
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
@@ -106,7 +106,7 @@ class VensimImporterTest {
                     """;
 
             ImportResult result = importer.importModel(mdl, "Test");
-            assertThat(result.definition().parameters()).hasSize(1 + 3); // +3 built-in constants
+            assertThat(result.definition().parameters()).hasSize(1);
             VariableDef c = result.definition().parameters().stream()
                     .filter(cd -> cd.name().equals("alpha"))
                     .findFirst().orElseThrow();
@@ -138,7 +138,7 @@ class VensimImporterTest {
                     """;
 
             ImportResult result = importer.importModel(mdl, "Test");
-            assertThat(result.definition().parameters()).hasSize(1 + 3); // +3 built-in constants
+            assertThat(result.definition().parameters()).hasSize(1);
             assertThat(result.definition().parameters().stream()
                     .map(VariableDef::name)).contains("Pi");
         }
@@ -178,8 +178,8 @@ class VensimImporterTest {
                     """;
 
             ImportResult result = importer.importModel(mdl, "Test");
-            // 1 formula variable + 2 user constants + 3 built-in constants = 6
-            assertThat(result.definition().variables()).hasSize(6);
+            // 1 formula variable + 2 user constants
+            assertThat(result.definition().variables()).hasSize(3);
             VariableDef v = result.definition().variables().stream()
                     .filter(a -> !a.isLiteral()).findFirst().orElseThrow();
             assertThat(v.name()).isEqualTo("rate");
@@ -212,8 +212,8 @@ class VensimImporterTest {
 
             ImportResult result = importer.importModel(mdl, "Test");
             assertThat(result.warnings()).anyMatch(w -> w.contains("imported as constant 0"));
-            // Data variable creates a placeholder variable (value 0) plus 3 built-in constants
-            assertThat(result.definition().variables()).hasSize(4);
+            // Data variable creates a placeholder variable (value 0)
+            assertThat(result.definition().variables()).hasSize(1);
             // All variables are literal (no formula auxes)
             assertThat(result.definition().variables().stream().filter(a -> !a.isLiteral()).toList())
                     .isEmpty();
@@ -475,17 +475,14 @@ class VensimImporterTest {
             assertThat(stock.name()).isEqualTo("Teacup Temperature");
             assertThat(stock.initialValue()).isEqualTo(180.0);
 
-            // 2 user constants + 3 built-in constants (TIME_STEP, INITIAL_TIME, FINAL_TIME)
-            assertThat(def.parameters()).hasSize(2 + 3);
+            assertThat(def.parameters()).hasSize(2);
             Set<String> constantNames = def.parameters().stream()
                     .map(VariableDef::name)
                     .collect(Collectors.toSet());
-            assertThat(constantNames).contains(
-                    "Room Temperature", "Characteristic Time",
-                    "TIME_STEP", "INITIAL_TIME", "FINAL_TIME");
+            assertThat(constantNames).contains("Room Temperature", "Characteristic Time");
 
-            // All variables: 1 formula + 2 user constants + 3 built-in constants = 6
-            assertThat(def.variables()).hasSize(6);
+            // All variables: 1 formula + 2 user constants
+            assertThat(def.variables()).hasSize(3);
             assertThat(def.variables().stream().filter(a -> !a.isLiteral()).toList())
                     .hasSize(1)
                     .first().extracting(VariableDef::name).isEqualTo("Heat Loss to Room");
@@ -520,17 +517,15 @@ class VensimImporterTest {
             assertThat(stockNames).containsExactlyInAnyOrder(
                     "Susceptible", "Infected", "Recovered");
 
-            // 3 user constants + 3 built-in constants (TIME_STEP, INITIAL_TIME, FINAL_TIME)
-            assertThat(def.parameters()).hasSize(3 + 3);
+            assertThat(def.parameters()).hasSize(3);
             Set<String> constantNames = def.parameters().stream()
                     .map(VariableDef::name)
                     .collect(Collectors.toSet());
             assertThat(constantNames).contains(
-                    "Contact Rate", "Recovery Time", "Total Population",
-                    "TIME_STEP", "INITIAL_TIME", "FINAL_TIME");
+                    "Contact Rate", "Recovery Time", "Total Population");
 
-            // 6 literal-valued constants (Infection Rate and Recovery Rate are now flows)
-            assertThat(def.variables()).hasSize(6);
+            // 3 literal-valued constants (Infection Rate and Recovery Rate are now flows)
+            assertThat(def.variables()).hasSize(3);
             assertThat(def.variables().stream().filter(a -> !a.isLiteral()).toList()).isEmpty();
 
             // 4 flows: Susceptible/Recovered each get a net flow,
@@ -615,7 +610,7 @@ class VensimImporterTest {
                     """;
 
             ImportResult result = importer.importModel(mdl, "Test");
-            assertThat(result.definition().parameters()).hasSize(1 + 3); // +3 built-in constants
+            assertThat(result.definition().parameters()).hasSize(1);
             VariableDef c = result.definition().parameters().stream()
                     .filter(cd -> cd.name().equals("alpha"))
                     .findFirst().orElseThrow();
@@ -647,7 +642,7 @@ class VensimImporterTest {
                     """;
 
             ImportResult result = importer.importModel(mdl, "Test");
-            assertThat(result.definition().parameters()).hasSize(1 + 3); // +3 built-in constants
+            assertThat(result.definition().parameters()).hasSize(1);
             VariableDef c = result.definition().parameters().stream()
                     .filter(cd -> cd.name().equals("alpha"))
                     .findFirst().orElseThrow();
@@ -684,12 +679,10 @@ class VensimImporterTest {
                     """;
 
             ImportResult result = importer.importModel(mdl, "Test");
-            // System vars should not appear as user model elements, but 3 built-in constants are injected
-            assertThat(result.definition().parameters()).hasSize(1 + 3); // +3 built-in constants
+            // System vars should not appear as model elements
+            assertThat(result.definition().parameters()).hasSize(1);
             assertThat(result.definition().parameters().stream()
-                    .map(VariableDef::name)
-                    .filter(n -> !Set.of("TIME_STEP", "INITIAL_TIME", "FINAL_TIME").contains(n))
-                    .toList()).containsExactly("x");
+                    .map(VariableDef::name).toList()).containsExactly("x");
             assertThat(result.definition().defaultSimulation().duration()).isEqualTo(10.0);
         }
     }
@@ -853,8 +846,8 @@ class VensimImporterTest {
             // No stocks, flows, or formula variables in CLD mode; only built-in constants
             assertThat(def.stocks()).isEmpty();
             assertThat(def.flows()).isEmpty();
-            assertThat(def.variables().stream().filter(a -> !a.isLiteral()).toList()).isEmpty();
-            assertThat(def.parameters()).hasSize(3); // only built-in constants
+            assertThat(def.variables()).isEmpty();
+            assertThat(def.parameters()).isEmpty();
 
             // Should have CLD variables
             assertThat(def.cldVariables()).hasSize(2);
@@ -983,11 +976,11 @@ class VensimImporterTest {
             assertThat(names).containsExactlyInAnyOrder(
                     "Population", "Birth Rate", "Death Rate", "Resources");
 
-            // No stocks, flows, or formula variables; only built-in constants
+            // No stocks, flows, formula variables, or parameters
             assertThat(def.stocks()).isEmpty();
             assertThat(def.flows()).isEmpty();
-            assertThat(def.variables().stream().filter(a -> !a.isLiteral()).toList()).isEmpty();
-            assertThat(def.parameters()).hasSize(3); // only built-in constants
+            assertThat(def.variables()).isEmpty();
+            assertThat(def.parameters()).isEmpty();
 
             // 4 causal links from sketch connectors
             assertThat(def.causalLinks()).hasSize(4);


### PR DESCRIPTION
## Summary
- Stop injecting TIME_STEP, INITIAL_TIME, FINAL_TIME as explicit model variables during Vensim import
- Add `initialTime` field to `SimulationSettings` to preserve the simulation start time
- Derive and inject system constants in `ModelCompiler` from simulation settings, keeping them available for formula compilation
- Register system constant names in `DefinitionValidator` so references pass structural validation
- Serialize/deserialize `initialTime` in JSON format (backward-compatible with old files)

This removes visual clutter from the canvas and eliminates spurious unused-parameter warnings for imported Vensim models.

Closes #1120