### PR TITLE
Write catalog validation report to devdocs/quality/demos

### DIFF
--- a/courant-app/src/test/java/systems/courant/sd/app/models/CatalogModelValidationTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/models/CatalogModelValidationTest.java
@@ -133,7 +133,7 @@ class CatalogModelValidationTest {
         if (REPORT.isEmpty()) {
             return;
         }
-        Path reportDir = Path.of("target");
+        Path reportDir = Path.of("../devdocs/quality/demos");
         Files.createDirectories(reportDir);
         Path reportFile = reportDir.resolve("catalog-validation-report.txt");
 


### PR DESCRIPTION
## Summary

- Moves catalog validation report output from `courant-app/target/` (wiped on clean) to `devdocs/quality/demos/catalog-validation-report.txt`

## Test plan

- [x] Report written to correct location when run with `-Dvalidate.catalog=true`