### PR TITLE
Skip code generation for CLD models

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipeline.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipeline.java
@@ -55,17 +55,24 @@ public class ImportPipeline {
             validationErrors.forEach(e -> log.warn("  - {}", e));
         }
 
-        // Stage 3: Trial compile
-        log.info("Trial-compiling model");
-        List<String> trialCompileErrors = trialCompile(definition);
-        if (!trialCompileErrors.isEmpty()) {
-            log.warn("{} trial-compile error(s):", trialCompileErrors.size());
-            trialCompileErrors.forEach(e -> log.warn("  - {}", e));
+        // Stage 3: Trial compile (skip for CLD models — they have no executable logic)
+        boolean isCld = !definition.cldVariables().isEmpty() && definition.stocks().isEmpty();
+        List<String> trialCompileErrors;
+        if (isCld) {
+            log.info("CLD model detected — skipping trial compile and code generation");
+            trialCompileErrors = List.of();
+        } else {
+            log.info("Trial-compiling model");
+            trialCompileErrors = trialCompile(definition);
+            if (!trialCompileErrors.isEmpty()) {
+                log.warn("{} trial-compile error(s):", trialCompileErrors.size());
+                trialCompileErrors.forEach(e -> log.warn("  - {}", e));
+            }
         }
 
         // Stage 4: Generate output (Java source or JSON)
         String source;
-        if (config.generateCode()) {
+        if (config.generateCode() && !isCld) {
             log.info("Generating Java class: {}", config.className());
             String packageName = resolvePackageName(config.category());
             Path srcFileName = config.sourceFile().getFileName();
@@ -87,7 +94,7 @@ public class ImportPipeline {
         if (config.dryRun()) {
             log.info("Dry run — skipping file write");
         } else {
-            if (config.generateCode()) {
+            if (config.generateCode() && !isCld) {
                 String packageName = resolvePackageName(config.category());
                 outputFile = resolveOutputPath(config.outputDir(), packageName, config.className());
             } else {

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/ImportPipelineTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/ImportPipelineTest.java
@@ -207,6 +207,32 @@ class ImportPipelineTest {
         assertThat(result.outputFile()).isNull();
     }
 
+    @Test
+    void shouldSkipCodeGenerationForCldModel() throws IOException {
+        Path cldFile = Path.of("../courant-engine/src/test/resources/vensim/simple-cld.mdl")
+                .toAbsolutePath().normalize();
+
+        assumeTrue(Files.exists(cldFile), "CLD test fixture not available");
+
+        ModelMetadata metadata = ModelMetadata.builder()
+                .source("Test CLD")
+                .license("CC-BY-SA-4.0")
+                .build();
+
+        PipelineConfig config = new PipelineConfig(
+                cldFile, metadata, "causalloop", "SimpleCld",
+                tempDir, false, false);
+
+        ImportPipeline pipeline = new ImportPipeline();
+        PipelineResult result = pipeline.execute(config);
+
+        assertThat(result.definition().cldVariables()).isNotEmpty();
+        // Should produce JSON, not Java code
+        assertThat(result.generatedSource()).doesNotContain("public class");
+        assertThat(result.generatedSource()).contains("\"cldVariables\"");
+        assertThat(result.outputFile().toString()).endsWith(".json");
+    }
+
     @Nested
     @DisplayName("Package and path resolution")
     class PackageAndPathResolution {


### PR DESCRIPTION
## Summary
- Detect CLD models during import (non-empty `cldVariables` + no stocks)
- Skip trial compilation and Java code generation for CLD models
- Produce JSON output instead, since CLDs are qualitative diagrams with no executable logic

Closes #1116