### PR TITLE
Import Vensim sketch annotations as Comment elements

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/SketchParser.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/SketchParser.java
@@ -3,6 +3,7 @@ package systems.courant.sd.io.vensim;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import systems.courant.sd.model.def.CommentDef;
 import systems.courant.sd.model.def.ConnectorRoute;
 import systems.courant.sd.model.def.ElementPlacement;
 import systems.courant.sd.model.def.ElementType;
@@ -23,13 +24,27 @@ import java.util.Set;
  *   <li>{@code *View Name} — new view declaration</li>
  *   <li>{@code 10,id,name,x,y,...} — variable/stock placement</li>
  *   <li>{@code 11,id,...,x,y,...} — flow valve placement</li>
- *   <li>{@code 12,id,...} — cloud (source/sink, skipped)</li>
+ *   <li>{@code 12,id,0,x,y,...} — text annotation (text on next line)</li>
+ *   <li>{@code 12,id,48|2,...} — cloud (source/sink, skipped)</li>
  *   <li>{@code 1,id,from,to,...} — connector arrow</li>
  * </ul>
  */
 public final class SketchParser {
 
     private static final Logger logger = LoggerFactory.getLogger(SketchParser.class);
+
+    /**
+     * Result of parsing sketch lines, containing view definitions and comment definitions.
+     *
+     * @param views the parsed view definitions (element placements, connectors, flow routes)
+     * @param comments the comment definitions extracted from sketch text annotations
+     */
+    public record ParseResult(List<ViewDef> views, List<CommentDef> comments) {
+        public ParseResult {
+            views = List.copyOf(views);
+            comments = List.copyOf(comments);
+        }
+    }
 
     private SketchParser() {
     }
@@ -61,7 +76,28 @@ public final class SketchParser {
     public static List<ViewDef> parse(List<String> sketchLines, Set<String> stockNames,
                                        Set<String> flowNames, Set<String> lookupNames,
                                        Set<String> cldVariableNames) {
+        return parseWithComments(sketchLines, stockNames, flowNames, lookupNames,
+                cldVariableNames).views();
+    }
+
+    /**
+     * Parses sketch lines into view definitions and comment definitions.
+     *
+     * <p>Text annotations (type 12, subtype 0) are converted to {@link CommentDef} elements
+     * with their original canvas positions preserved as {@link ElementPlacement} entries.
+     *
+     * @param sketchLines the raw sketch lines from the .mdl file
+     * @param stockNames the set of known stock names (normalized) for type classification
+     * @param flowNames the set of known flow names (normalized) for type classification
+     * @param lookupNames the set of known lookup table names (normalized) for type classification
+     * @param cldVariableNames the set of CLD variable names (normalized) for type classification
+     * @return a parse result containing view definitions and comment definitions
+     */
+    public static ParseResult parseWithComments(List<String> sketchLines, Set<String> stockNames,
+                                                 Set<String> flowNames, Set<String> lookupNames,
+                                                 Set<String> cldVariableNames) {
         List<ViewDef> views = new ArrayList<>();
+        List<CommentDef> comments = new ArrayList<>();
 
         String currentViewName = null;
         List<ElementPlacement> elements = new ArrayList<>();
@@ -69,8 +105,8 @@ public final class SketchParser {
         List<FlowRoute> flowRoutes = new ArrayList<>();
         Map<String, String> idToName = new HashMap<>();
 
-        for (String line : sketchLines) {
-            String trimmed = line.strip();
+        for (int i = 0; i < sketchLines.size(); i++) {
+            String trimmed = sketchLines.get(i).strip();
             if (trimmed.isEmpty()) {
                 continue;
             }
@@ -108,12 +144,10 @@ public final class SketchParser {
                 case 10 -> parseElementLine(parts, elements, idToName,
                         stockNames, flowNames, lookupNames, cldVariableNames);
                 case 11 -> parseFlowValveLine(parts, elements, flowRoutes, idToName);
-                case 12 -> {
-                    // Cloud (source/sink boundary) — skip
-                }
+                case 12 -> i = parseType12Line(parts, i, sketchLines, elements, comments);
                 case 1 -> parseConnectorLine(parts, connectors, idToName);
                 default -> {
-                    // Other line types (annotations, etc.) — skip
+                    // Other line types — skip
                 }
             }
         }
@@ -123,7 +157,65 @@ public final class SketchParser {
             views.add(new ViewDef(currentViewName, elements, connectors, flowRoutes));
         }
 
-        return views;
+        return new ParseResult(views, comments);
+    }
+
+    /**
+     * Parses a type 12 line. Subtype 0 lines are text annotations with the text on the
+     * following line. Other subtypes (48, 2, etc.) are clouds and are skipped.
+     *
+     * @return the updated line index (advanced past the text line for subtype 0)
+     */
+    private static int parseType12Line(String[] parts, int currentIndex,
+                                        List<String> sketchLines,
+                                        List<ElementPlacement> elements,
+                                        List<CommentDef> comments) {
+        // Format: 12,id,subtype,x,y,width,height,...
+        if (parts.length < 7) {
+            return currentIndex;
+        }
+
+        int subtype;
+        try {
+            subtype = Integer.parseInt(parts[2].strip());
+        } catch (NumberFormatException e) {
+            return currentIndex;
+        }
+
+        if (subtype != 0) {
+            // Cloud (source/sink boundary) — skip
+            return currentIndex;
+        }
+
+        // Subtype 0 = text annotation; text is on the next line
+        double x;
+        double y;
+        double width;
+        double height;
+        try {
+            x = Double.parseDouble(parts[3].strip());
+            y = Double.parseDouble(parts[4].strip());
+            width = Double.parseDouble(parts[5].strip()) * 2;
+            height = Double.parseDouble(parts[6].strip()) * 2;
+        } catch (NumberFormatException e) {
+            return currentIndex;
+        }
+
+        // Read annotation text from next line
+        int nextIndex = currentIndex + 1;
+        if (nextIndex >= sketchLines.size()) {
+            return currentIndex;
+        }
+        String text = sketchLines.get(nextIndex).strip();
+        if (text.isEmpty()) {
+            return currentIndex;
+        }
+
+        String name = "Comment " + (comments.size() + 1);
+        comments.add(new CommentDef(name, text));
+        elements.add(new ElementPlacement(name, ElementType.COMMENT, x, y, width, height));
+
+        return nextIndex;
     }
 
     private static void parseElementLine(String[] parts, List<ElementPlacement> elements,

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
@@ -8,6 +8,7 @@ import systems.courant.sd.model.def.ReferenceDataset;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.CausalLinkDef;
 import systems.courant.sd.model.def.CldVariableDef;
+import systems.courant.sd.model.def.CommentDef;
 import systems.courant.sd.model.def.ConnectorRoute;
 import systems.courant.sd.model.def.FlowDef;
 import systems.courant.sd.model.def.LookupTableDef;
@@ -532,10 +533,10 @@ public class VensimImporter implements ModelImporter {
         if (sketchLines.isEmpty()) {
             return;
         }
-        List<ViewDef> views = SketchParser.parse(
+        SketchParser.ParseResult result = SketchParser.parseWithComments(
                 sketchLines, stockNames, sketchFlowNames, lookupNames,
                 cldVariableNames);
-        for (ViewDef view : views) {
+        for (ViewDef view : result.views()) {
             builder.view(view);
             if (isCld) {
                 for (ConnectorRoute connector : view.connectors()) {
@@ -544,6 +545,9 @@ public class VensimImporter implements ModelImporter {
                             CausalLinkDef.Polarity.UNKNOWN));
                 }
             }
+        }
+        for (CommentDef comment : result.comments()) {
+            builder.comment(comment);
         }
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/SketchParserTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/SketchParserTest.java
@@ -1,0 +1,152 @@
+package systems.courant.sd.io.vensim;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import systems.courant.sd.model.def.CommentDef;
+import systems.courant.sd.model.def.ElementPlacement;
+import systems.courant.sd.model.def.ElementType;
+import systems.courant.sd.model.def.ViewDef;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SketchParser")
+class SketchParserTest {
+
+    @Nested
+    @DisplayName("Text annotations")
+    class TextAnnotations {
+
+        @Test
+        void shouldParseTextAnnotationAsComment() {
+            List<String> lines = List.of(
+                    "*Main",
+                    "12,26,0,618,433,50,30,8,7,0,8,-1,0,0,0,0-0-0,0-0-0,|8||0-0-0",
+                    "Hello world"
+            );
+
+            SketchParser.ParseResult result = SketchParser.parseWithComments(
+                    lines, Set.of(), Set.of(), Set.of(), Set.of());
+
+            assertThat(result.comments()).hasSize(1);
+            CommentDef comment = result.comments().getFirst();
+            assertThat(comment.name()).isEqualTo("Comment 1");
+            assertThat(comment.text()).isEqualTo("Hello world");
+        }
+
+        @Test
+        void shouldPlaceCommentElementInView() {
+            List<String> lines = List.of(
+                    "*Main",
+                    "12,26,0,618,433,50,30,8,7,0,8,-1,0,0,0",
+                    "Annotation text"
+            );
+
+            SketchParser.ParseResult result = SketchParser.parseWithComments(
+                    lines, Set.of(), Set.of(), Set.of(), Set.of());
+
+            ViewDef view = result.views().getFirst();
+            assertThat(view.elements()).hasSize(1);
+            ElementPlacement ep = view.elements().getFirst();
+            assertThat(ep.type()).isEqualTo(ElementType.COMMENT);
+            assertThat(ep.x()).isEqualTo(618);
+            assertThat(ep.y()).isEqualTo(433);
+            assertThat(ep.width()).isEqualTo(100);
+            assertThat(ep.height()).isEqualTo(60);
+        }
+
+        @Test
+        void shouldParseMultipleAnnotations() {
+            List<String> lines = List.of(
+                    "*Main",
+                    "12,26,0,100,200,40,16,8,7,0,24,-1,0,0,0",
+                    "First note",
+                    "12,27,0,300,400,37,16,8,7,0,24,-1,0,0,0",
+                    "Second note"
+            );
+
+            SketchParser.ParseResult result = SketchParser.parseWithComments(
+                    lines, Set.of(), Set.of(), Set.of(), Set.of());
+
+            assertThat(result.comments()).hasSize(2);
+            assertThat(result.comments().get(0).text()).isEqualTo("First note");
+            assertThat(result.comments().get(0).name()).isEqualTo("Comment 1");
+            assertThat(result.comments().get(1).text()).isEqualTo("Second note");
+            assertThat(result.comments().get(1).name()).isEqualTo("Comment 2");
+        }
+
+        @Test
+        void shouldSkipCloudLines() {
+            List<String> lines = List.of(
+                    "*Main",
+                    "12,4,48,105,546,10,8,0,3,0,0,-1,0,0,0",
+                    "12,24,2,608,447,23,23,5,3,0,0,-1,0,0,0"
+            );
+
+            SketchParser.ParseResult result = SketchParser.parseWithComments(
+                    lines, Set.of(), Set.of(), Set.of(), Set.of());
+
+            assertThat(result.comments()).isEmpty();
+            assertThat(result.views().getFirst().elements()).isEmpty();
+        }
+
+        @Test
+        void shouldMixAnnotationsWithModelElements() {
+            List<String> lines = List.of(
+                    "*Main",
+                    "10,1,Population,200,300,40,20,3,3,0,0,0,0,0,0",
+                    "12,26,0,400,500,30,15,8,7,0,8,-1,0,0,0",
+                    "Note about population",
+                    "12,4,48,105,546,10,8,0,3,0,0,-1,0,0,0"
+            );
+
+            SketchParser.ParseResult result = SketchParser.parseWithComments(
+                    lines, Set.of("Population"), Set.of(), Set.of(), Set.of());
+
+            ViewDef view = result.views().getFirst();
+            assertThat(view.elements()).hasSize(2);
+            assertThat(view.elements().get(0).type()).isEqualTo(ElementType.STOCK);
+            assertThat(view.elements().get(1).type()).isEqualTo(ElementType.COMMENT);
+            assertThat(result.comments()).hasSize(1);
+        }
+
+        @Test
+        void shouldReturnEmptyCommentsWhenNoAnnotations() {
+            List<String> lines = List.of(
+                    "*Main",
+                    "10,1,Stock1,200,300,40,20,3,3,0,0,0,0,0,0"
+            );
+
+            SketchParser.ParseResult result = SketchParser.parseWithComments(
+                    lines, Set.of("Stock1"), Set.of(), Set.of(), Set.of());
+
+            assertThat(result.comments()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Backward compatibility")
+    class BackwardCompatibility {
+
+        @Test
+        void shouldReturnViewsFromLegacyParseMethod() {
+            List<String> lines = List.of(
+                    "*Main",
+                    "10,1,Var1,100,200,40,20,3,3,0,0,0,0,0,0",
+                    "12,26,0,300,400,50,30,8,7,0,8,-1,0,0,0",
+                    "Some annotation"
+            );
+
+            List<ViewDef> views = SketchParser.parse(
+                    lines, Set.of(), Set.of(), Set.of(), Set.of());
+
+            assertThat(views).hasSize(1);
+            // Legacy parse returns views with comment placements included
+            assertThat(views.getFirst().elements()).hasSize(2);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Parse Vensim sketch type 12 subtype 0 lines as text annotations
- Convert them to `CommentDef` elements with original canvas positions preserved as `ElementPlacement(COMMENT)`
- Clouds (subtypes 48, 2, etc.) continue to be skipped
- Added `ParseResult` record to `SketchParser` to return both views and comments

Closes #1119

## Test plan
- [x] Full test suite passes
- [x] SpotBugs clean
- [x] 7 new `SketchParserTest` tests covering annotation parsing, cloud skipping, mixed content, and backward compatibility