### PR TITLE
Fix Quantity equals/hashCode contract for cross-unit equality

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/measure/Quantity.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/Quantity.java
@@ -274,14 +274,13 @@ public final class Quantity {
         Quantity quantity = (Quantity) o;
 
         if (!getDimension().equals(quantity.getDimension())) return false;
-        if (unit.equals(quantity.unit)) {
-            return Double.compare(value, quantity.value) == 0;
-        }
         if (!unit.supportsBaseConversion() || !quantity.unit.supportsBaseConversion()) {
-            // Units that don't support base-unit conversion (e.g., Fahrenheit vs Celsius)
-            return false;
+            // Units that don't support base-unit conversion (e.g., Fahrenheit):
+            // only equal if same unit and same raw value
+            return unit.equals(quantity.unit)
+                    && Double.compare(value, quantity.value) == 0;
         }
-        return Double.compare(quantity.inBaseUnits().getValue(), inBaseUnits().getValue()) == 0;
+        return Double.compare(inBaseUnits().getValue(), quantity.inBaseUnits().getValue()) == 0;
     }
 
     /**

--- a/courant-engine/src/test/java/systems/courant/sd/measure/QuantityTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/QuantityTest.java
@@ -4,6 +4,7 @@ import systems.courant.sd.measure.units.length.LengthUnits;
 import org.junit.jupiter.api.Test;
 
 import static systems.courant.sd.measure.Units.GALLON_US;
+import static systems.courant.sd.measure.Units.KILOMETER;
 import static systems.courant.sd.measure.Units.LITER;
 import static systems.courant.sd.measure.Units.METER;
 import static systems.courant.sd.measure.Units.MILE;
@@ -138,6 +139,23 @@ public class QuantityTest {
         Quantity c = new Quantity(1, GALLON_US);
         assertTrue(a.isCompatibleWith(b));
         assertFalse(a.isCompatibleWith(c));
+    }
+
+    @Test
+    public void shouldMaintainEqualsHashCodeContractForCrossUnitEquality() {
+        Quantity meters = new Quantity(1000, METER);
+        Quantity km = new Quantity(1, KILOMETER);
+        // Cross-unit equals must imply same hashCode
+        assertEquals(meters, km);
+        assertEquals(meters.hashCode(), km.hashCode());
+    }
+
+    @Test
+    public void shouldMaintainEqualsHashCodeContractForSameUnit() {
+        Quantity a = new Quantity(500, METER);
+        Quantity b = new Quantity(500, METER);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Remove same-unit shortcut in `equals()` so both `equals` and `hashCode` always use base-unit values
- Ensures the equals/hashCode contract holds for cross-unit comparisons (e.g., 1000m == 1km)

Closes #879