### PR TITLE
Reduce simulation timeout check interval from 100 to 10 steps

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/Simulation.java
+++ b/courant-engine/src/main/java/systems/courant/sd/Simulation.java
@@ -243,7 +243,7 @@ public class Simulation {
                             "Simulation cancelled at step " + currentStep);
                 }
 
-                if (currentStep % 100 == 0 && System.currentTimeMillis() > deadlineMs) {
+                if (currentStep % 10 == 0 && System.currentTimeMillis() > deadlineMs) {
                     log.warn("Simulation timed out after {}ms at step {}/{}",
                             timeoutMs, currentStep, totalSteps);
                     throw new SimulationTimeoutException(


### PR DESCRIPTION
## Summary
- Reduce timeout check interval from every 100 steps to every 10 steps
- Prevents expensive models from overshooting the configured timeout significantly

Closes #795