### PR TITLE
Clear static chart state after showChart snapshot

### DIFF
--- a/courant-ui/src/main/java/systems/courant/sd/ui/ChartViewerApplication.java
+++ b/courant-ui/src/main/java/systems/courant/sd/ui/ChartViewerApplication.java
@@ -106,6 +106,9 @@ public class ChartViewerApplication extends Application {
      */
     public static void showChart() {
         ChartData snapshot = snapshot();
+        synchronized (LOCK) {
+            resetInternal();
+        }
         ensureFxRunning();
         Platform.runLater(() -> {
             ChartViewerApplication app = new ChartViewerApplication();


### PR DESCRIPTION
## Summary
- Reset static mutable fields after `showChart()` captures its snapshot
- Prevents stale simulation data from leaking into subsequent charts

Closes #959