### PR TITLE
Guard SweepResultPane array access against stale index

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SweepResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SweepResultPane.java
@@ -91,10 +91,13 @@ public class SweepResultPane extends BorderPane {
             series.setName(paramName + " = " + ChartUtils.formatNumber(paramValue));
 
             for (int s = 0; s < run.getStepCount(); s++) {
-                double value = isStock
-                        ? run.getStockValuesAtStep(s)[colIndex]
-                        : run.getVariableValuesAtStep(s)[colIndex];
-                series.getData().add(new XYChart.Data<>(run.getStep(s), value));
+                double[] values = isStock
+                        ? run.getStockValuesAtStep(s)
+                        : run.getVariableValuesAtStep(s);
+                if (colIndex >= values.length) {
+                    break;
+                }
+                series.getData().add(new XYChart.Data<>(run.getStep(s), values[colIndex]));
             }
             allSeries.add(series);
         }


### PR DESCRIPTION
## Summary
- Add bounds check before accessing stock/variable value arrays in SweepResultPane
- Prevents `ArrayIndexOutOfBoundsException` when a variable is removed while sweep results are displayed

Closes #800