### PR TITLE
Parse and preserve polarity from Vensim connector lines (#1167)

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -353,6 +353,9 @@ public class ModelDefinitionSerializer {
                     if (!cr.controlPoints().isEmpty()) {
                         crNode.set("controlPoints", serializePointList(cr.controlPoints()));
                     }
+                    if (cr.polarity() != CausalLinkDef.Polarity.UNKNOWN) {
+                        crNode.put("polarity", cr.polarity().symbol());
+                    }
                     connectors.add(crNode);
                 }
                 node.set("connectors", connectors);
@@ -819,10 +822,15 @@ public class ModelDefinitionSerializer {
                 if (cr.has("controlPoints")) {
                     controlPoints = deserializePointList(cr.get("controlPoints"));
                 }
+                CausalLinkDef.Polarity polarity = CausalLinkDef.Polarity.UNKNOWN;
+                if (cr.has("polarity")) {
+                    polarity = CausalLinkDef.Polarity.fromSymbol(cr.get("polarity").asText());
+                }
                 connectors.add(new ConnectorRoute(
                         requiredText(cr, "from"),
                         requiredText(cr, "to"),
-                        controlPoints));
+                        controlPoints,
+                        polarity));
             }
         }
         List<FlowRoute> flowRoutes = new ArrayList<>();

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/SketchParser.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/SketchParser.java
@@ -3,6 +3,7 @@ package systems.courant.sd.io.vensim;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import systems.courant.sd.model.def.CausalLinkDef;
 import systems.courant.sd.model.def.CommentDef;
 import systems.courant.sd.model.def.ConnectorRoute;
 import systems.courant.sd.model.def.ElementPlacement;
@@ -280,7 +281,8 @@ public final class SketchParser {
 
     private static void parseConnectorLine(String[] parts, List<ConnectorRoute> connectors,
                                             Map<String, String> idToName) {
-        // Format: 1,id,fromId,toId,...
+        // Format: 1,id,fromId,toId[,shape,hidden,polarity,...]
+        // Polarity is at field [6] as an ASCII code: 43 = '+', 45 = '-', 0 = none
         if (parts.length < 4) {
             return;
         }
@@ -304,7 +306,21 @@ public final class SketchParser {
             return;
         }
 
-        connectors.add(new ConnectorRoute(from, to));
+        CausalLinkDef.Polarity polarity = CausalLinkDef.Polarity.UNKNOWN;
+        if (parts.length >= 7) {
+            try {
+                int code = Integer.parseInt(parts[6].strip());
+                polarity = switch (code) {
+                    case 43 -> CausalLinkDef.Polarity.POSITIVE;  // ASCII '+'
+                    case 45 -> CausalLinkDef.Polarity.NEGATIVE;  // ASCII '-'
+                    default -> CausalLinkDef.Polarity.UNKNOWN;
+                };
+            } catch (NumberFormatException e) {
+                // Non-numeric polarity field — default to UNKNOWN
+            }
+        }
+
+        connectors.add(new ConnectorRoute(from, to, polarity));
     }
 
     private static ElementType classifyElementType(String name, Set<String> stockNames,

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -3,6 +3,7 @@ package systems.courant.sd.io.vensim;
 import systems.courant.sd.io.ExportUtils;
 import systems.courant.sd.io.FormatUtils;
 import systems.courant.sd.model.def.VariableDef;
+import systems.courant.sd.model.def.CausalLinkDef;
 import systems.courant.sd.model.def.CldVariableDef;
 import systems.courant.sd.model.def.ConnectorRoute;
 import systems.courant.sd.model.def.ElementPlacement;
@@ -410,7 +411,12 @@ public final class VensimExporter {
             int id = nextId++;
             sb.append("1,").append(id).append(",")
                     .append(fromId).append(",")
-                    .append(toId).append("\n");
+                    .append(toId);
+            if (cr.polarity() != CausalLinkDef.Polarity.UNKNOWN) {
+                int polarityCode = cr.polarity() == CausalLinkDef.Polarity.POSITIVE ? 43 : 45;
+                sb.append(",1,0,").append(polarityCode);
+            }
+            sb.append("\n");
         }
 
         return sb.toString();

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
@@ -542,7 +542,7 @@ public class VensimImporter implements ModelImporter {
                 for (ConnectorRoute connector : view.connectors()) {
                     builder.causalLink(new CausalLinkDef(
                             connector.from(), connector.to(),
-                            CausalLinkDef.Polarity.UNKNOWN));
+                            connector.polarity()));
                 }
             }
         }

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/ConnectorRoute.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/ConnectorRoute.java
@@ -11,11 +11,13 @@ import java.util.Objects;
  * @param from the source element name
  * @param to the target element name
  * @param controlPoints optional intermediate control points for curved connectors
+ * @param polarity the polarity of the causal link (positive, negative, or unknown)
  */
 public record ConnectorRoute(
         String from,
         String to,
-        List<double[]> controlPoints
+        List<double[]> controlPoints,
+        CausalLinkDef.Polarity polarity
 ) {
 
     public ConnectorRoute {
@@ -34,6 +36,9 @@ public record ConnectorRoute(
             }
             controlPoints = List.copyOf(cloned);
         }
+        if (polarity == null) {
+            polarity = CausalLinkDef.Polarity.UNKNOWN;
+        }
     }
 
     /**
@@ -49,13 +54,35 @@ public record ConnectorRoute(
     }
 
     /**
-     * Creates a straight connector with no intermediate control points.
+     * Creates a straight connector with no intermediate control points and unknown polarity.
      *
      * @param from the source element name
      * @param to   the target element name
      */
     public ConnectorRoute(String from, String to) {
-        this(from, to, List.of());
+        this(from, to, List.of(), CausalLinkDef.Polarity.UNKNOWN);
+    }
+
+    /**
+     * Creates a straight connector with the given polarity and no control points.
+     *
+     * @param from     the source element name
+     * @param to       the target element name
+     * @param polarity the polarity of the causal link
+     */
+    public ConnectorRoute(String from, String to, CausalLinkDef.Polarity polarity) {
+        this(from, to, List.of(), polarity);
+    }
+
+    /**
+     * Creates a connector with control points and unknown polarity.
+     *
+     * @param from          the source element name
+     * @param to            the target element name
+     * @param controlPoints intermediate control points for curved connectors
+     */
+    public ConnectorRoute(String from, String to, List<double[]> controlPoints) {
+        this(from, to, controlPoints, CausalLinkDef.Polarity.UNKNOWN);
     }
 
     @Override
@@ -68,12 +95,13 @@ public record ConnectorRoute(
         }
         return Objects.equals(from, that.from)
                 && Objects.equals(to, that.to)
+                && polarity == that.polarity
                 && PointListUtil.pointListEquals(controlPoints, that.controlPoints);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(from, to);
+        int result = Objects.hash(from, to, polarity);
         for (double[] point : controlPoints) {
             result = 31 * result + Arrays.hashCode(point);
         }

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
@@ -462,7 +462,8 @@ class VensimExporterTest {
                                             "Birth_Rate", systems.courant.sd.model.def.ElementType.CLD_VARIABLE, 100, 100),
                                     new systems.courant.sd.model.def.ElementPlacement(
                                             "Death_Rate", systems.courant.sd.model.def.ElementType.CLD_VARIABLE, 300, 100)),
-                            List.of(new systems.courant.sd.model.def.ConnectorRoute("Birth_Rate", "Population")),
+                            List.of(new systems.courant.sd.model.def.ConnectorRoute(
+                                    "Birth_Rate", "Population", CausalLinkDef.Polarity.POSITIVE)),
                             List.of()))
                     .build();
 
@@ -481,6 +482,64 @@ class VensimExporterTest {
             assertThat(result.definition().cldVariables()).hasSize(3);
             assertThat(result.definition().causalLinks()).hasSize(1);
             assertThat(result.definition().parameters()).isEmpty();
+        }
+
+        @Test
+        void shouldRoundTripCldPolarities() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Polarity CLD")
+                    .defaultSimulation("Year", 100, "Year")
+                    .cldVariable("A", "Variable A")
+                    .cldVariable("B", "Variable B")
+                    .cldVariable("C", "Variable C")
+                    .causalLink("A", "B", CausalLinkDef.Polarity.POSITIVE)
+                    .causalLink("B", "C", CausalLinkDef.Polarity.NEGATIVE)
+                    .causalLink("C", "A", CausalLinkDef.Polarity.UNKNOWN)
+                    .view(new systems.courant.sd.model.def.ViewDef("CLD",
+                            List.of(
+                                    new systems.courant.sd.model.def.ElementPlacement(
+                                            "A", systems.courant.sd.model.def.ElementType.CLD_VARIABLE, 100, 100),
+                                    new systems.courant.sd.model.def.ElementPlacement(
+                                            "B", systems.courant.sd.model.def.ElementType.CLD_VARIABLE, 200, 100),
+                                    new systems.courant.sd.model.def.ElementPlacement(
+                                            "C", systems.courant.sd.model.def.ElementType.CLD_VARIABLE, 300, 100)),
+                            List.of(
+                                    new systems.courant.sd.model.def.ConnectorRoute(
+                                            "A", "B", CausalLinkDef.Polarity.POSITIVE),
+                                    new systems.courant.sd.model.def.ConnectorRoute(
+                                            "B", "C", CausalLinkDef.Polarity.NEGATIVE),
+                                    new systems.courant.sd.model.def.ConnectorRoute(
+                                            "C", "A", CausalLinkDef.Polarity.UNKNOWN)),
+                            List.of()))
+                    .build();
+
+            String mdl = VensimExporter.toVensim(def);
+
+            // Verify polarity codes appear in the connector lines
+            assertThat(mdl).contains(",1,0,43");  // POSITIVE → ASCII 43
+            assertThat(mdl).contains(",1,0,45");  // NEGATIVE → ASCII 45
+
+            // Re-import and verify polarities are preserved
+            VensimImporter importer = new VensimImporter();
+            ImportResult result = importer.importModel(mdl, "Polarity CLD");
+            ModelDefinition roundTripped = result.definition();
+
+            assertThat(roundTripped.causalLinks()).hasSize(3);
+
+            CausalLinkDef link1 = roundTripped.causalLinks().stream()
+                    .filter(l -> l.from().equals("A") && l.to().equals("B"))
+                    .findFirst().orElseThrow();
+            assertThat(link1.polarity()).isEqualTo(CausalLinkDef.Polarity.POSITIVE);
+
+            CausalLinkDef link2 = roundTripped.causalLinks().stream()
+                    .filter(l -> l.from().equals("B") && l.to().equals("C"))
+                    .findFirst().orElseThrow();
+            assertThat(link2.polarity()).isEqualTo(CausalLinkDef.Polarity.NEGATIVE);
+
+            CausalLinkDef link3 = roundTripped.causalLinks().stream()
+                    .filter(l -> l.from().equals("C") && l.to().equals("A"))
+                    .findFirst().orElseThrow();
+            assertThat(link3.polarity()).isEqualTo(CausalLinkDef.Polarity.UNKNOWN);
         }
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
@@ -916,6 +916,70 @@ class VensimImporterTest {
         }
 
         @Test
+        void shouldExtractPolarityFromConnectorLines() {
+            String mdl = """
+                    A= 0
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    B= 0
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    C= 0
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tYear
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 100
+                    \t~\tYear
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tYear
+                    \t~\t
+                    \t|
+
+                    \\\\\\---///
+                    *View
+                    10,1,A,100,100
+                    10,2,B,200,100
+                    10,3,C,300,100
+                    1,4,1,2,1,0,43,0,2,64,0,-1--1--1,|12||0-0-0,1|(150,100)|
+                    1,5,2,3,1,0,45,0,2,64,0,-1--1--1,|12||0-0-0,1|(250,100)|
+                    1,6,3,1,1,0,0
+                    """;
+
+            ImportResult result = importer.importModel(mdl, "Test");
+            ModelDefinition def = result.definition();
+
+            assertThat(def.causalLinks()).hasSize(3);
+
+            CausalLinkDef link1 = def.causalLinks().get(0);
+            assertThat(link1.from()).isEqualTo("A");
+            assertThat(link1.to()).isEqualTo("B");
+            assertThat(link1.polarity()).isEqualTo(CausalLinkDef.Polarity.POSITIVE);
+
+            CausalLinkDef link2 = def.causalLinks().get(1);
+            assertThat(link2.from()).isEqualTo("B");
+            assertThat(link2.to()).isEqualTo("C");
+            assertThat(link2.polarity()).isEqualTo(CausalLinkDef.Polarity.NEGATIVE);
+
+            CausalLinkDef link3 = def.causalLinks().get(2);
+            assertThat(link3.from()).isEqualTo("C");
+            assertThat(link3.to()).isEqualTo("A");
+            assertThat(link3.polarity()).isEqualTo(CausalLinkDef.Polarity.UNKNOWN);
+        }
+
+        @Test
         void shouldClassifySketchElementsAsCldVariable() {
             String mdl = """
                     X= 0

--- a/courant-engine/src/test/java/systems/courant/sd/model/def/ConnectorRouteTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/def/ConnectorRouteTest.java
@@ -50,7 +50,7 @@ class ConnectorRouteTest {
         @Test
         @DisplayName("should treat null control points as empty list")
         void shouldTreatNullControlPointsAsEmpty() {
-            ConnectorRoute route = new ConnectorRoute("A", "B", null);
+            ConnectorRoute route = new ConnectorRoute("A", "B", (List<double[]>) null);
             assertThat(route.controlPoints()).isEmpty();
         }
     }


### PR DESCRIPTION
## Summary
- Vensim .mdl connector lines encode polarity as an ASCII code in field [6] (43='+', 45='-'). Previously ignored — all CLD causal links imported with UNKNOWN polarity.
- Adds polarity field to `ConnectorRoute`, parses it in `SketchParser`, uses it in `VensimImporter`, writes it back in `VensimExporter`, and serializes it in JSON format.
- Adds import test (polarity extraction from .mdl) and roundtrip test (export → re-import preserves +/−/unknown).

## Test plan
- [x] New test: `shouldExtractPolarityFromConnectorLines` — verifies +, −, and unknown polarity parsed from connector lines
- [x] New test: `shouldRoundTripCldPolarities` — export → re-import preserves all three polarity values
- [x] Full test suite passes (146 tests)
- [x] SpotBugs clean

Closes #1167