### PR TITLE
Synchronize CsvSubscriber write and close operations

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/CsvSubscriber.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/CsvSubscriber.java
@@ -33,6 +33,7 @@ public class CsvSubscriber implements EventHandler, Closeable {
     private static final Logger logger = LoggerFactory.getLogger(CsvSubscriber.class);
 
     private final String filePath;
+    private final Object lock = new Object();
     private CSVWriter csvWriter;
     private boolean closed;
 
@@ -70,30 +71,32 @@ public class CsvSubscriber implements EventHandler, Closeable {
      */
     @Override
     public void handleTimeStepEvent(TimeStepEvent event) {
-        ensureWriter();
-        if (csvWriter == null) {
-            return;
-        }
-        Model model = event.getModel();
+        synchronized (lock) {
+            ensureWriter();
+            if (csvWriter == null) {
+                return;
+            }
+            Model model = event.getModel();
 
-        List<Double> stockValues = model.getStockValues();
-        List<Double> variableValues = model.getVariableValues();
+            List<Double> stockValues = model.getStockValues();
+            List<Double> variableValues = model.getVariableValues();
 
-        List<String> values = new ArrayList<>(2 + stockValues.size() + variableValues.size());
-        values.add(String.valueOf(event.getStep()));
-        values.add(event.getCurrentTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+            List<String> values = new ArrayList<>(2 + stockValues.size() + variableValues.size());
+            values.add(String.valueOf(event.getStep()));
+            values.add(event.getCurrentTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
 
-        for (Double stockValue : stockValues) {
-            values.add(String.valueOf(stockValue));
-        }
-        for (Double variableValue : variableValues) {
-            values.add(String.valueOf(variableValue));
-        }
-        csvWriter.writeNext(values.toArray(new String[0]));
-        if (csvWriter.checkError()) {
-            throw new CsvOutputException(
-                    "Failed to write CSV data row at step " + event.getStep(),
-                    csvWriter.getException());
+            for (Double stockValue : stockValues) {
+                values.add(String.valueOf(stockValue));
+            }
+            for (Double variableValue : variableValues) {
+                values.add(String.valueOf(variableValue));
+            }
+            csvWriter.writeNext(values.toArray(new String[0]));
+            if (csvWriter.checkError()) {
+                throw new CsvOutputException(
+                        "Failed to write CSV data row at step " + event.getStep(),
+                        csvWriter.getException());
+            }
         }
     }
 
@@ -102,25 +105,27 @@ public class CsvSubscriber implements EventHandler, Closeable {
      */
     @Override
     public void handleSimulationStartEvent(SimulationStartEvent event) {
-        ensureWriter();
-        if (csvWriter == null) {
-            return;
-        }
-        logger.info("Starting simulation: {}", event.getModel().getName());
+        synchronized (lock) {
+            ensureWriter();
+            if (csvWriter == null) {
+                return;
+            }
+            logger.info("Starting simulation: {}", event.getModel().getName());
 
-        Model model = event.getModel();
-        List<String> stockNames = model.getStockNames();
-        List<String> variableNames = model.getVariableNames();
+            Model model = event.getModel();
+            List<String> stockNames = model.getStockNames();
+            List<String> variableNames = model.getVariableNames();
 
-        List<String> values = new ArrayList<>(2 + stockNames.size() + variableNames.size());
-        values.add("Step");
-        values.add("Date time");
-        values.addAll(stockNames);
-        values.addAll(variableNames);
-        csvWriter.writeNext(values.toArray(new String[0]));
-        if (csvWriter.checkError()) {
-            throw new CsvOutputException(
-                    "Failed to write CSV header", csvWriter.getException());
+            List<String> values = new ArrayList<>(2 + stockNames.size() + variableNames.size());
+            values.add("Step");
+            values.add("Date time");
+            values.addAll(stockNames);
+            values.addAll(variableNames);
+            csvWriter.writeNext(values.toArray(new String[0]));
+            if (csvWriter.checkError()) {
+                throw new CsvOutputException(
+                        "Failed to write CSV header", csvWriter.getException());
+            }
         }
     }
 
@@ -138,15 +143,17 @@ public class CsvSubscriber implements EventHandler, Closeable {
      */
     @Override
     public void close() {
-        closed = true;
-        if (csvWriter != null) {
-            try {
-                csvWriter.flush();
-                csvWriter.close();
-            } catch (IOException e) {
-                logger.error("Failed to close CSV writer", e);
+        synchronized (lock) {
+            closed = true;
+            if (csvWriter != null) {
+                try {
+                    csvWriter.flush();
+                    csvWriter.close();
+                } catch (IOException e) {
+                    logger.error("Failed to close CSV writer", e);
+                }
+                csvWriter = null;
             }
-            csvWriter = null;
         }
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/CsvSubscriberTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/CsvSubscriberTest.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static systems.courant.sd.measure.Units.MINUTE;
 import static systems.courant.sd.measure.Units.THING;
@@ -172,6 +174,45 @@ public class CsvSubscriberTest {
         } finally {
             csvLogger.detachAppender(appender);
             appender.stop();
+        }
+    }
+
+    @Test
+    public void shouldNotThrowWhenClosedConcurrentlyWithWrite() throws Exception {
+        Model model = new Model("Concurrent");
+        Stock stock = new Stock("S", 50, THING);
+        model.addStock(stock);
+
+        String csvPath = tempDir.resolve("concurrent.csv").toString();
+        CsvSubscriber csv = new CsvSubscriber(csvPath);
+
+        Simulation sim = new Simulation(model, MINUTE, MINUTE, 1);
+        sim.addEventHandler(csv);
+
+        // Start simulation to initialize the writer
+        CountDownLatch started = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        Thread closer = new Thread(() -> {
+            try {
+                started.await();
+                csv.close();
+            } catch (Throwable t) {
+                error.set(t);
+            }
+        });
+        closer.start();
+        started.countDown();
+
+        // Run simulation concurrently with close — should not throw NPE
+        try {
+            sim.execute();
+        } catch (CsvOutputException ignored) {
+            // Acceptable — writer was closed mid-write
+        }
+        closer.join(5000);
+        if (error.get() != null) {
+            throw new AssertionError("Close thread threw", error.get());
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `synchronized` block around all `csvWriter`/`closed` field access to prevent NPE and data corruption under concurrent write + close
- Add concurrent close test

Closes #1140