### PR TITLE
Initialize simTimeUnitHolder at compile time from default simulation

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ModelCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ModelCompiler.java
@@ -261,6 +261,11 @@ public class ModelCompiler {
         context.addLiteralConstant("TIME_STEP", sim.dt());
         context.addLiteralConstant("INITIAL_TIME", sim.initialTime());
         context.addLiteralConstant("FINAL_TIME", sim.initialTime() + sim.duration());
+        // Pre-set simulation time unit so compile-time flow resolution uses
+        // the correct unit (not the flow's own unit as fallback).
+        if (sim.timeStep() != null) {
+            context.getSimTimeUnitHolder()[0] = unitRegistry.resolveTimeUnit(sim.timeStep());
+        }
     }
 
     // === Shared helpers ===


### PR DESCRIPTION
## Summary
- Set `simTimeUnitHolder[0]` during `injectSimulationConstants` when default simulation settings are available
- Ensures compile-time flow resolution uses the correct simulation time unit instead of falling back to the flow's own time unit

Closes #1143