### PR TITLE
Reset stepHolder in createSimulation to prevent stale step values

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/CompiledModel.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/CompiledModel.java
@@ -128,6 +128,7 @@ public class CompiledModel {
      * Installs an event handler that keeps the compiled model's step counter in sync.
      */
     public Simulation createSimulation(TimeUnit timeStep, double duration, TimeUnit durationUnit) {
+        stepHolder[0] = 0;
         simTimeUnitHolder[0] = timeStep;
         Simulation sim = new Simulation(model, timeStep, durationUnit, duration);
         sim.setDt(dtHolder[0]);
@@ -140,6 +141,7 @@ public class CompiledModel {
      * Installs an event handler that keeps the compiled model's step counter in sync.
      */
     public Simulation createSimulation(TimeUnit timeStep, Quantity duration) {
+        stepHolder[0] = 0;
         simTimeUnitHolder[0] = timeStep;
         Simulation sim = new Simulation(model, timeStep, duration);
         sim.setDt(dtHolder[0]);
@@ -159,6 +161,7 @@ public class CompiledModel {
         }
         TimeUnit timeStep = unitRegistry.resolveTimeUnit(settings.timeStep());
         TimeUnit durationUnit = unitRegistry.resolveTimeUnit(settings.durationUnit());
+        stepHolder[0] = 0;
         simTimeUnitHolder[0] = timeStep;
         setDt(settings.dt());
         Simulation sim = new Simulation(model, timeStep, new Quantity(settings.duration(), durationUnit));

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ModelCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ModelCompilerTest.java
@@ -52,6 +52,31 @@ class ModelCompilerTest {
             // After draining, stock should be well below initial value
             assertThat(tank.getValue()).isBetween(25.0, 40.0);
         }
+
+        @Test
+        void shouldProduceSameResultsWhenSimulationRecreatedWithoutExplicitReset() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Drain Rerun")
+                    .stock("Tank", 100, "Thing")
+                    .flow("Drain", "Tank * 0.1", "Day", "Tank", null)
+                    .defaultSimulation("Day", 10, "Day")
+                    .build();
+
+            CompiledModel compiled = compiler.compile(def);
+
+            // First run
+            Simulation sim1 = compiled.createSimulation();
+            sim1.execute();
+            double firstResult = findStock(compiled.getModel(), "Tank").getValue();
+
+            // Second run — createSimulation should reset stepHolder internally
+            compiled.reset();
+            Simulation sim2 = compiled.createSimulation();
+            sim2.execute();
+            double secondResult = findStock(compiled.getModel(), "Tank").getValue();
+
+            assertThat(secondResult).isCloseTo(firstResult, within(1e-10));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Reset `stepHolder[0] = 0` in all `createSimulation()` overloads
- Prevents stale step counter from prior simulation runs from affecting formula initialization (SMOOTH, DELAY, TREND, etc.)

Closes #1148