### PR TITLE
Export actual initial time instead of hardcoded zero

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -358,11 +358,12 @@ public final class VensimExporter {
         String durationUnit = sim != null ? sim.durationUnit() : "Day";
 
         // INITIAL TIME
-        sb.append(buildControlBlock("INITIAL TIME", "0", durationUnit,
+        double initialTime = sim != null ? sim.initialTime() : 0;
+        sb.append(buildControlBlock("INITIAL TIME", formatDouble(initialTime), durationUnit,
                 "The initial time for the simulation."));
 
         // FINAL TIME
-        sb.append(buildControlBlock("FINAL TIME", formatDouble(duration), durationUnit,
+        sb.append(buildControlBlock("FINAL TIME", formatDouble(initialTime + duration), durationUnit,
                 "The final time for the simulation."));
 
         // TIME STEP

--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
@@ -157,12 +157,12 @@ public final class XmileExporter {
 
         Element start = doc.createElementNS(
                 XmileConstants.NAMESPACE_URI, XmileConstants.START);
-        start.setTextContent("0");
+        start.setTextContent(formatDouble(sim.initialTime()));
         simSpecs.appendChild(start);
 
         Element stop = doc.createElementNS(
                 XmileConstants.NAMESPACE_URI, XmileConstants.STOP);
-        stop.setTextContent(formatDouble(sim.duration()));
+        stop.setTextContent(formatDouble(sim.initialTime() + sim.duration()));
         simSpecs.appendChild(stop);
 
         Element dt = doc.createElementNS(

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
@@ -8,6 +8,7 @@ import systems.courant.sd.model.def.FlowDef;
 import systems.courant.sd.model.def.LookupTableDef;
 import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.ModelDefinitionBuilder;
+import systems.courant.sd.model.def.SimulationSettings;
 import systems.courant.sd.model.def.StockDef;
 import systems.courant.sd.model.def.SubscriptDef;
 
@@ -405,6 +406,20 @@ class VensimExporterTest {
             assertThat(mdl).contains("INITIAL TIME  = 0");
             assertThat(mdl).contains("FINAL TIME  = 200");
             assertThat(mdl).contains("TIME STEP  = 1");
+        }
+
+        @Test
+        void shouldExportNonZeroInitialTime() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .defaultSimulation(new SimulationSettings(
+                            "Year", 50, "Year", 1.0, false, 1, 2000.0))
+                    .build();
+
+            String mdl = VensimExporter.toVensim(def);
+
+            assertThat(mdl).contains("INITIAL TIME  = 2000");
+            assertThat(mdl).contains("FINAL TIME  = 2050");
         }
 
         @Test

--- a/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileExporterTest.java
@@ -8,6 +8,7 @@ import systems.courant.sd.model.def.LookupTableDef;
 import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.ModelDefinitionBuilder;
 import systems.courant.sd.model.def.ModuleInstanceDef;
+import systems.courant.sd.model.def.SimulationSettings;
 import systems.courant.sd.model.def.StockDef;
 
 import org.junit.jupiter.api.DisplayName;
@@ -41,6 +42,19 @@ class XmileExporterTest {
             assertThat(xml).contains("<name>Test</name>");
             assertThat(xml).contains("time_units=\"day\"");
             assertThat(xml).contains("<stop>100</stop>");
+        }
+
+        @Test
+        void shouldExportNonZeroInitialTime() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .defaultSimulation(new SimulationSettings(
+                            "Year", 50, "Year", 1.0, false, 1, 2000.0))
+                    .build();
+
+            String xml = XmileExporter.toXmile(def);
+            assertThat(xml).contains("<start>2000</start>");
+            assertThat(xml).contains("<stop>2050</stop>");
         }
 
         @Test


### PR DESCRIPTION
## Summary
- XmileExporter: `<start>` now uses `sim.initialTime()` instead of "0"; `<stop>` uses `initialTime + duration`
- VensimExporter: `INITIAL TIME` now uses `sim.initialTime()`; `FINAL TIME` uses `initialTime + duration`
- Added tests for non-zero initial time (year 2000) in both exporters

Closes #1144