### PR TITLE
Extract shared BuiltinFunctions constant

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/expr/BuiltinFunctions.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/expr/BuiltinFunctions.java
@@ -1,0 +1,33 @@
+package systems.courant.sd.model.expr;
+
+import java.util.Set;
+
+/**
+ * Canonical set of built-in function and keyword names (uppercase).
+ * Used by {@link ExprDependencies} and {@link ExprRenamer} to distinguish
+ * built-in names from model element references and lookup tables.
+ */
+public final class BuiltinFunctions {
+
+    /** Built-in function and keyword names (uppercase) that are not model elements. */
+    public static final Set<String> NAMES = Set.of(
+            "ABS", "SQRT", "LN", "EXP", "LOG", "SIN", "COS", "TAN",
+            "ARCSIN", "ARCCOS", "ARCTAN", "SIGN", "PI",
+            "INT", "ROUND", "MODULO", "QUANTUM", "POWER", "MIN", "MAX",
+            "SUM", "MEAN", "VMIN", "VMAX", "PROD",
+            "INITIAL",
+            "SMOOTH", "SMOOTHI", "SMOOTH3", "SMOOTH3I",
+            "DELAY1", "DELAY1I", "DELAY3", "DELAY3I", "DELAY_FIXED",
+            "STEP", "RAMP", "PULSE", "PULSE_TRAIN",
+            "TREND", "FORECAST", "NPV",
+            "RANDOM_NORMAL", "RANDOM_UNIFORM",
+            "XIDZ", "ZIDZ",
+            "SAMPLE_IF_TRUE", "FIND_ZERO",
+            "LOOKUP_AREA", "LOOKUP",
+            "IF", "TIME", "DT",
+            "NOT", "OR", "AND", "TRUE", "FALSE"
+    );
+
+    private BuiltinFunctions() {
+    }
+}

--- a/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprDependencies.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprDependencies.java
@@ -12,24 +12,7 @@ import java.util.Set;
  */
 public final class ExprDependencies {
 
-    /** Built-in function names (uppercase) that should not be treated as model element references. */
-    private static final Set<String> BUILTIN_FUNCTIONS = Set.of(
-            "ABS", "SQRT", "LN", "EXP", "LOG", "SIN", "COS", "TAN",
-            "ARCSIN", "ARCCOS", "ARCTAN", "SIGN",
-            "INT", "ROUND", "MODULO", "QUANTUM", "POWER", "MIN", "MAX",
-            "SUM", "MEAN", "VMIN", "VMAX", "PROD",
-            "INITIAL",
-            "SMOOTH", "SMOOTHI", "SMOOTH3", "SMOOTH3I",
-            "DELAY1", "DELAY1I", "DELAY3", "DELAY3I", "DELAY_FIXED",
-            "STEP", "RAMP", "PULSE", "PULSE_TRAIN",
-            "TREND", "FORECAST", "NPV",
-            "RANDOM_NORMAL", "RANDOM_UNIFORM",
-            "XIDZ", "ZIDZ",
-            "SAMPLE_IF_TRUE", "FIND_ZERO",
-            "NOT", "OR", "AND", "TRUE", "FALSE",
-            "LOOKUP_AREA",
-            "LOOKUP", "IF", "TIME", "DT", "PI"
-    );
+    private static final Set<String> BUILTIN_FUNCTIONS = BuiltinFunctions.NAMES;
 
     private ExprDependencies() {
     }

--- a/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprRenamer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/expr/ExprRenamer.java
@@ -14,22 +14,7 @@ import java.util.Set;
  */
 public final class ExprRenamer {
 
-    /** Built-in function names that should never be renamed. */
-    private static final Set<String> BUILTIN_FUNCTIONS = Set.of(
-            "ABS", "SQRT", "LN", "EXP", "LOG", "SIN", "COS", "TAN",
-            "ARCSIN", "ARCCOS", "ARCTAN", "SIGN", "PI",
-            "INT", "ROUND", "MODULO", "QUANTUM", "POWER", "MIN", "MAX",
-            "SUM", "MEAN", "VMIN", "VMAX", "PROD",
-            "XIDZ", "ZIDZ",
-            "SMOOTH", "SMOOTHI", "SMOOTH3", "SMOOTH3I",
-            "DELAY1", "DELAY1I", "DELAY3", "DELAY3I", "DELAY_FIXED",
-            "STEP", "RAMP", "PULSE", "PULSE_TRAIN",
-            "TREND", "FORECAST", "NPV",
-            "RANDOM_NORMAL", "RANDOM_UNIFORM",
-            "SAMPLE_IF_TRUE", "FIND_ZERO", "LOOKUP_AREA",
-            "LOOKUP", "IF", "TIME", "DT", "INITIAL",
-            "TRUE", "FALSE", "NOT", "OR", "AND"
-    );
+    private static final Set<String> BUILTIN_FUNCTIONS = BuiltinFunctions.NAMES;
 
     private ExprRenamer() {
     }


### PR DESCRIPTION
## Summary
- Create `BuiltinFunctions.NAMES` as single source of truth for built-in function names
- `ExprDependencies` and `ExprRenamer` now both reference it instead of maintaining duplicate sets

Closes #1141