### PR TITLE
Fix floating-point imprecision in sweep point count

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ParameterSweepDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ParameterSweepDialog.java
@@ -140,7 +140,7 @@ public class ParameterSweepDialog extends Dialog<ParameterSweepDialog.Config> {
                 return "Step must be greater than zero.";
             }
             long pointCount = start == end ? 1
-                    : (long) Math.ceil((end - start) / step) + 1;
+                    : Math.round((end - start) / step) + 1;
             if (pointCount > 10_000) {
                 return "Too many points (" + pointCount + "). Maximum is 10,000.";
             }


### PR DESCRIPTION
## Summary
- Use `Math.round` instead of `Math.ceil` for sweep point count calculation
- Prevents floating-point division artifacts (e.g., `(1.0 - 0.0) / 0.1 = 10.000000000000002`) from incorrectly inflating the count

Closes #1147