### PR TITLE
Tolerate unbalanced closing paren in findTopLevelComma

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/FormatUtils.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/FormatUtils.java
@@ -56,10 +56,9 @@ public final class FormatUtils {
             if (c == '(') {
                 depth++;
             } else if (c == ')') {
-                if (depth == 0) {
-                    return -1;
+                if (depth > 0) {
+                    depth--;
                 }
-                depth--;
             } else if (c == ',' && depth == 0) {
                 return i;
             }

--- a/courant-engine/src/test/java/systems/courant/sd/io/FormatUtilsTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/FormatUtilsTest.java
@@ -81,7 +81,13 @@ class FormatUtilsTest {
         }
 
         @Test
-        void shouldReturnMinusOneOnClosingParenAtDepthZero() {
+        void shouldIgnoreUnbalancedClosingParenAtDepthZero() {
+            // Unbalanced ) should be ignored, not abort the search
+            assertThat(FormatUtils.findTopLevelComma("abc), d", 0)).isEqualTo(4);
+        }
+
+        @Test
+        void shouldReturnMinusOneWhenNoCommaAfterUnbalancedParen() {
             assertThat(FormatUtils.findTopLevelComma("abc)", 0)).isEqualTo(-1);
         }
 


### PR DESCRIPTION
## Summary
- Clamp depth to 0 instead of returning -1 when encountering `)` at depth 0
- Prevents lookup inlining from silently failing on malformed expressions

Closes #1151