### PR TITLE
Add null guard on NavigationStack.pop() in popNavigationLevel

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasNavigationFacade.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasNavigationFacade.java
@@ -138,6 +138,9 @@ public final class CanvasNavigationFacade {
     private void popNavigationLevel(boolean saveUndo) {
         ModelDefinition childDef = canvas.editor.toModelDefinition(canvas.canvasState().toViewDef());
         NavigationStack.Frame frame = navController.pop();
+        if (frame == null) {
+            return;
+        }
 
         canvas.undoManager.close();
         canvas.editor = frame.editor();


### PR DESCRIPTION
## Summary
- Add null check on the return value of `navController.pop()` to prevent NPE when the navigation stack is unexpectedly empty

Closes #1156