### PR TITLE
Return stub DoubleProperty instead of null from cursorTimeStepProperty

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/LoopDominancePane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/LoopDominancePane.java
@@ -14,6 +14,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TitledPane;
 import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.layout.Priority;
@@ -111,7 +112,8 @@ public final class LoopDominancePane extends VBox {
      * with other charts. Value is {@code Double.NaN} when no cursor is active.
      */
     public DoubleProperty cursorTimeStepProperty() {
-        return timeCursor != null ? timeCursor.cursorTimeStepProperty() : null;
+        return timeCursor != null ? timeCursor.cursorTimeStepProperty()
+                : new SimpleDoubleProperty(Double.NaN);
     }
 
     private void saveChartAsPng() {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SimulationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SimulationResultPane.java
@@ -28,6 +28,7 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
@@ -673,7 +674,8 @@ public class SimulationResultPane extends BorderPane {
      * with other charts. Value is {@code Double.NaN} when no cursor is active.
      */
     public DoubleProperty cursorTimeStepProperty() {
-        return timeCursor != null ? timeCursor.cursorTimeStepProperty() : null;
+        return timeCursor != null ? timeCursor.cursorTimeStepProperty()
+                : new SimpleDoubleProperty(Double.NaN);
     }
 
     private void addSectionHeader(VBox sidebar, String title) {


### PR DESCRIPTION
## Summary
- `SimulationResultPane.cursorTimeStepProperty()` and `LoopDominancePane.cursorTimeStepProperty()` now return a `SimpleDoubleProperty(NaN)` stub instead of `null` when the time cursor is uninitialized
- Prevents NPE in callers that bind without null-checking

Closes #1160