### PR TITLE
Don't set currentFile to non-JSON path after export

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/FileController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/FileController.java
@@ -233,7 +233,8 @@ final class FileController {
                     return;
                 }
             }
-            currentFile = file.toPath();
+            // Non-JSON exports are "export" operations — do not update currentFile,
+            // so that Ctrl+S continues to save in native JSON format.
             dirty = false;
             updateTitle.run();
             fireLogEvent.accept(l -> l.onModelSaved(name));

--- a/courant-app/src/test/java/systems/courant/sd/app/FileControllerSaveFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/FileControllerSaveFxTest.java
@@ -63,7 +63,7 @@ class FileControllerSaveFxTest {
     }
 
     @Test
-    @DisplayName("saveToChosenFile with .mdl clears dirty flag and updates currentFile")
+    @DisplayName("saveToChosenFile with .mdl clears dirty flag but does not change currentFile (#1139)")
     void shouldClearDirtyAfterVensimExport(FxRobot robot, @TempDir Path tempDir) throws Exception {
         loadTeacupModel();
 
@@ -71,18 +71,19 @@ class FileControllerSaveFxTest {
         WaitForAsyncUtils.waitForFxEvents();
         assertThat(window.isDirty()).isTrue();
 
+        Path previousFile = window.getCurrentFile();
         File mdlFile = tempDir.resolve("exported.mdl").toFile();
         Platform.runLater(() -> window.getFileController().saveToChosenFile(mdlFile));
         WaitForAsyncUtils.waitForFxEvents();
 
         assertThat(window.isDirty()).isFalse();
-        assertThat(window.getCurrentFile()).isEqualTo(mdlFile.toPath());
+        assertThat(window.getCurrentFile()).isEqualTo(previousFile);
         assertThat(Files.exists(mdlFile.toPath())).isTrue();
         assertThat(Files.size(mdlFile.toPath())).isGreaterThan(0);
     }
 
     @Test
-    @DisplayName("saveToChosenFile with .xmile clears dirty flag and updates currentFile")
+    @DisplayName("saveToChosenFile with .xmile clears dirty flag but does not change currentFile (#1139)")
     void shouldClearDirtyAfterXmileExport(FxRobot robot, @TempDir Path tempDir) throws Exception {
         loadTeacupModel();
 
@@ -90,18 +91,19 @@ class FileControllerSaveFxTest {
         WaitForAsyncUtils.waitForFxEvents();
         assertThat(window.isDirty()).isTrue();
 
+        Path previousFile = window.getCurrentFile();
         File xmileFile = tempDir.resolve("exported.xmile").toFile();
         Platform.runLater(() -> window.getFileController().saveToChosenFile(xmileFile));
         WaitForAsyncUtils.waitForFxEvents();
 
         assertThat(window.isDirty()).isFalse();
-        assertThat(window.getCurrentFile()).isEqualTo(xmileFile.toPath());
+        assertThat(window.getCurrentFile()).isEqualTo(previousFile);
         assertThat(Files.exists(xmileFile.toPath())).isTrue();
         assertThat(Files.size(xmileFile.toPath())).isGreaterThan(0);
     }
 
     @Test
-    @DisplayName("saveToChosenFile with .stmx clears dirty flag")
+    @DisplayName("saveToChosenFile with .stmx clears dirty flag but does not change currentFile (#1139)")
     void shouldClearDirtyAfterStmxExport(FxRobot robot, @TempDir Path tempDir) throws Exception {
         loadTeacupModel();
 
@@ -109,12 +111,13 @@ class FileControllerSaveFxTest {
         WaitForAsyncUtils.waitForFxEvents();
         assertThat(window.isDirty()).isTrue();
 
+        Path previousFile = window.getCurrentFile();
         File stmxFile = tempDir.resolve("exported.stmx").toFile();
         Platform.runLater(() -> window.getFileController().saveToChosenFile(stmxFile));
         WaitForAsyncUtils.waitForFxEvents();
 
         assertThat(window.isDirty()).isFalse();
-        assertThat(window.getCurrentFile()).isEqualTo(stmxFile.toPath());
+        assertThat(window.getCurrentFile()).isEqualTo(previousFile);
     }
 
     @Test
@@ -149,6 +152,67 @@ class FileControllerSaveFxTest {
         WaitForAsyncUtils.waitForFxEvents();
 
         assertThat(stage.getTitle()).doesNotContain("\u2022");
+    }
+
+    @Test
+    @DisplayName("save() after .mdl export does not overwrite the .mdl file with JSON (#1139)")
+    void shouldNotCorruptMdlFileOnSubsequentSave(FxRobot robot, @TempDir Path tempDir) throws Exception {
+        loadTeacupModel();
+
+        // First, save as JSON so currentFile is set
+        File jsonFile = tempDir.resolve("model.json").toFile();
+        Platform.runLater(() -> window.getFileController().saveToChosenFile(jsonFile));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(window.getCurrentFile()).isEqualTo(jsonFile.toPath());
+
+        // Export to .mdl
+        File mdlFile = tempDir.resolve("exported.mdl").toFile();
+        Platform.runLater(() -> window.getFileController().saveToChosenFile(mdlFile));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // currentFile should still point to the JSON file
+        assertThat(window.getCurrentFile()).isEqualTo(jsonFile.toPath());
+
+        // Mark dirty and Ctrl+S (save())
+        Platform.runLater(() -> {
+            window.getFileController().markDirty();
+            window.getFileController().save();
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // The .mdl file should still be valid Vensim, not JSON
+        ImportResult reimported = new VensimImporter().importModel(mdlFile.toPath());
+        assertThat(reimported.definition().stocks()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("save() after .xmile export does not overwrite the .xmile file with JSON (#1139)")
+    void shouldNotCorruptXmileFileOnSubsequentSave(FxRobot robot, @TempDir Path tempDir) throws Exception {
+        loadTeacupModel();
+
+        // First, save as JSON so currentFile is set
+        File jsonFile = tempDir.resolve("model.json").toFile();
+        Platform.runLater(() -> window.getFileController().saveToChosenFile(jsonFile));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Export to .xmile
+        File xmileFile = tempDir.resolve("exported.xmile").toFile();
+        Platform.runLater(() -> window.getFileController().saveToChosenFile(xmileFile));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // currentFile should still point to the JSON file
+        assertThat(window.getCurrentFile()).isEqualTo(jsonFile.toPath());
+
+        // Mark dirty and Ctrl+S (save())
+        Platform.runLater(() -> {
+            window.getFileController().markDirty();
+            window.getFileController().save();
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // The .xmile file should still be valid XMILE, not JSON
+        ImportResult reimported = new XmileImporter().importModel(xmileFile.toPath());
+        assertThat(reimported.definition().stocks()).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- After exporting to `.mdl`/`.xmile`, `saveToChosenFile` no longer sets `currentFile` to the exported path
- Prevents `save()` (Ctrl+S) from silently overwriting the exported file with JSON content
- Added regression tests verifying save() after export does not corrupt the exported file

Closes #1139

## Test plan
- [x] Existing export tests updated to verify `currentFile` is not changed on non-JSON export
- [x] New regression tests: `shouldNotCorruptMdlFileOnSubsequentSave`, `shouldNotCorruptXmileFileOnSubsequentSave`
- [x] Full test suite passes (1828 tests)
- [x] SpotBugs clean