### PR TITLE
Include simulation and Monte Carlo results in exported reports

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -573,7 +573,8 @@ public class ModelWindow {
                         canvas.getCanvasState(), canvas.getEditor(),
                         canvas.getConnectors(),
                         canvas.analysis().getActiveLoopAnalysis(),
-                        stage, editor != null ? editor.getModelName() : null),
+                        stage, editor != null ? editor.getModelName() : null,
+                        dashboardPanel),
                 null, "menuExportReport");
         commandRegistry.add("Model Info", "File",
                 () -> ModelInfoDialog.show(editor, stage, this::updateTitle));

--- a/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
@@ -552,6 +552,11 @@ final class SimulationController {
                 (target, unused) -> SensitivitySummary.fromMonteCarlo(mcResult, target),
                 trackable.getFirst());
         dashboardPanel.showSensitivity(pane);
+
+        // Store sensitivity impacts for report export (using first trackable variable)
+        List<SensitivitySummary.ParameterImpact> impacts =
+                SensitivitySummary.fromMonteCarlo(mcResult, trackable.getFirst());
+        dashboardPanel.storeSensitivityImpacts(impacts);
     }
 
     private static List<String> collectTrackableNames(List<String> stocks, List<String> variables) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/DashboardPanel.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/DashboardPanel.java
@@ -6,6 +6,7 @@ import systems.courant.sd.model.graph.LoopDominanceAnalysis;
 import systems.courant.sd.sweep.MonteCarloResult;
 import systems.courant.sd.sweep.MultiSweepResult;
 import systems.courant.sd.sweep.OptimizationResult;
+import systems.courant.sd.sweep.SensitivitySummary;
 import systems.courant.sd.sweep.SweepResult;
 
 import javafx.geometry.Insets;
@@ -85,6 +86,14 @@ public class DashboardPanel extends VBox {
     private final List<GhostRun> runHistory = new ArrayList<>();
     private static final int MAX_HISTORY = 5;
     private int runCounter;
+
+    // ── Stored results for report export ──────────────────────────────────
+    private SimulationRunner.SimulationResult lastSimResult;
+    private SweepResult lastSweepResult;
+    private MonteCarloResult lastMonteCarloResult;
+    private OptimizationResult lastOptimizationResult;
+    private LoopDominanceAnalysis lastDominanceResult;
+    private List<SensitivitySummary.ParameterImpact> lastSensitivityImpacts;
 
     public DashboardPanel() {
         Label placeholderLabel = new Label("Run a simulation to see results.");
@@ -183,6 +192,7 @@ public class DashboardPanel extends VBox {
                                      List<FlowDef> flows,
                                      List<ReferenceDataset> referenceDatasets) {
         clearStale();
+        this.lastSimResult = result;
         List<GhostRun> ghosts = List.copyOf(runHistory);
         SimulationResultPane pane = new SimulationResultPane(result, flows, ghosts,
                 this::clearRunHistory, referenceDatasets);
@@ -217,6 +227,7 @@ public class DashboardPanel extends VBox {
 
     public void showSweepResult(SweepResult result, String paramName) {
         clearStale();
+        this.lastSweepResult = result;
         SweepResultPane pane = new SweepResultPane(result, paramName);
         sweepTab = ensureTab(sweepTab, "Sweep", pane);
         resultTabs.getSelectionModel().select(sweepTab);
@@ -224,6 +235,7 @@ public class DashboardPanel extends VBox {
 
     public void showMonteCarloResult(MonteCarloResult result) {
         clearStale();
+        this.lastMonteCarloResult = result;
         MonteCarloResultPane pane = new MonteCarloResultPane(result);
         monteCarloTab = ensureTab(monteCarloTab, "Monte Carlo", pane);
         resultTabs.getSelectionModel().select(monteCarloTab);
@@ -231,6 +243,7 @@ public class DashboardPanel extends VBox {
 
     public void showOptimizationResult(OptimizationResult result) {
         clearStale();
+        this.lastOptimizationResult = result;
         OptimizationResultPane pane = new OptimizationResultPane(result);
         optimizationTab = ensureTab(optimizationTab, "Optimization", pane);
         resultTabs.getSelectionModel().select(optimizationTab);
@@ -257,10 +270,18 @@ public class DashboardPanel extends VBox {
         resultTabs.getSelectionModel().select(sensitivityTab);
     }
 
+    /**
+     * Stores sensitivity impacts for inclusion in exported reports.
+     */
+    public void storeSensitivityImpacts(List<SensitivitySummary.ParameterImpact> impacts) {
+        this.lastSensitivityImpacts = impacts;
+    }
+
     public void showLoopDominance(LoopDominanceAnalysis dominance) {
         if (dominance == null) {
             return;
         }
+        this.lastDominanceResult = dominance;
         LoopDominancePane pane = new LoopDominancePane(dominance);
         unbindCursors();
         dominanceCursor = pane.cursorTimeStepProperty();
@@ -314,6 +335,32 @@ public class DashboardPanel extends VBox {
      */
     public boolean hasResults() {
         return !resultTabs.getTabs().isEmpty();
+    }
+
+    // ── Result accessors for report export ──────────────────────────────
+
+    public SimulationRunner.SimulationResult getLastSimResult() {
+        return lastSimResult;
+    }
+
+    public SweepResult getLastSweepResult() {
+        return lastSweepResult;
+    }
+
+    public MonteCarloResult getLastMonteCarloResult() {
+        return lastMonteCarloResult;
+    }
+
+    public OptimizationResult getLastOptimizationResult() {
+        return lastOptimizationResult;
+    }
+
+    public LoopDominanceAnalysis getLastDominanceResult() {
+        return lastDominanceResult;
+    }
+
+    public List<SensitivitySummary.ParameterImpact> getLastSensitivityImpacts() {
+        return lastSensitivityImpacts;
     }
 
     private Tab ensureTab(Tab existing, String title, Node content) {
@@ -372,6 +419,12 @@ public class DashboardPanel extends VBox {
         runHistory.clear();
         runCounter = 0;
         stale = false;
+        lastSimResult = null;
+        lastSweepResult = null;
+        lastMonteCarloResult = null;
+        lastOptimizationResult = null;
+        lastDominanceResult = null;
+        lastSensitivityImpacts = null;
         staleBanner.setVisible(false);
         staleBanner.setManaged(false);
         resultTabs.setStyle("");

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ReportExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ReportExporter.java
@@ -4,6 +4,12 @@ import systems.courant.sd.app.LastDirectoryStore;
 import systems.courant.sd.model.def.ConnectorRoute;
 import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.graph.FeedbackAnalysis;
+import systems.courant.sd.sweep.MonteCarloResult;
+import systems.courant.sd.sweep.OptimizationResult;
+import systems.courant.sd.sweep.RunResult;
+import systems.courant.sd.sweep.SensitivitySummary.ParameterImpact;
+import systems.courant.sd.sweep.SweepResult;
+import systems.courant.sd.model.graph.LoopDominanceAnalysis;
 
 import javafx.scene.control.Alert;
 import javafx.stage.FileChooser;
@@ -13,11 +19,15 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles the UI flow for exporting model reports as HTML or PDF:
  * shows a file chooser, generates the report, and writes it to disk.
+ * When dashboard results are available, the exported report includes
+ * simulation results, Monte Carlo fan charts, sensitivity analysis, etc.
  */
 public final class ReportExporter {
 
@@ -26,6 +36,7 @@ public final class ReportExporter {
 
     /**
      * Exports a model report to an HTML file chosen by the user.
+     * Includes simulation results from the dashboard if available.
      *
      * @param canvasState  the canvas state for diagram rendering
      * @param editor       the model editor with current model data
@@ -33,12 +44,14 @@ public final class ReportExporter {
      * @param loopAnalysis optional feedback analysis (null if unavailable)
      * @param ownerWindow  the owner window for the file chooser
      * @param modelName    the model name (used for default filename)
+     * @param dashboard    the dashboard panel with stored results (null if unavailable)
      */
     public static void exportReport(CanvasState canvasState, ModelEditor editor,
                                     List<ConnectorRoute> connectors,
                                     FeedbackAnalysis loopAnalysis,
                                     Window ownerWindow,
-                                    String modelName) {
+                                    String modelName,
+                                    DashboardPanel dashboard) {
         FileChooser chooser = new FileChooser();
         chooser.setTitle("Export Report");
         chooser.getExtensionFilters().addAll(
@@ -64,7 +77,29 @@ public final class ReportExporter {
             String svgDiagram = SvgExporter.toSvgString(
                     canvasState, editor, connectors, loopAnalysis);
 
-            String html = ReportGenerator.generate(definition, svgDiagram);
+            // Build result sections from dashboard if results are available
+            String extraCss = null;
+            String extraSections = null;
+
+            if (dashboard != null && dashboard.hasResults()) {
+                RunResult singleRun = convertSimResult(dashboard.getLastSimResult());
+                SweepResult sweep = dashboard.getLastSweepResult();
+                MonteCarloResult monteCarlo = dashboard.getLastMonteCarloResult();
+                List<ParameterImpact> sensitivity = dashboard.getLastSensitivityImpacts();
+                OptimizationResult optimization = dashboard.getLastOptimizationResult();
+                LoopDominanceAnalysis dominance = dashboard.getLastDominanceResult();
+
+                String sections = ResultReportGenerator.generateSections(
+                        singleRun, sweep, monteCarlo, sensitivity,
+                        optimization, dominance);
+                if (!sections.isBlank()) {
+                    extraCss = ResultReportGenerator.getResultsCSS();
+                    extraSections = sections;
+                }
+            }
+
+            String html = ReportGenerator.generate(definition, svgDiagram,
+                    extraCss, extraSections);
 
             if (file.getName().toLowerCase().endsWith(".pdf")) {
                 PdfReportExporter.exportToPdf(html, file.toPath());
@@ -79,5 +114,64 @@ public final class ReportExporter {
             alert.initOwner(ownerWindow);
             alert.showAndWait();
         }
+    }
+
+    /**
+     * Converts a UI-level {@link SimulationRunner.SimulationResult} to a
+     * {@link RunResult} for report generation.
+     *
+     * @param simResult the simulation result (may be null)
+     * @return a RunResult, or null if input is null
+     */
+    static RunResult convertSimResult(SimulationRunner.SimulationResult simResult) {
+        if (simResult == null) {
+            return null;
+        }
+
+        List<String> columns = simResult.columnNames();
+        Set<String> stockNameSet = simResult.stockNames();
+
+        // Separate stock and variable names (first column is "Step")
+        List<String> stockNames = new ArrayList<>();
+        List<String> variableNames = new ArrayList<>();
+        List<Integer> stockIndices = new ArrayList<>();
+        List<Integer> variableIndices = new ArrayList<>();
+
+        for (int i = 1; i < columns.size(); i++) {
+            String name = columns.get(i);
+            if (stockNameSet.contains(name)) {
+                stockNames.add(name);
+                stockIndices.add(i);
+            } else {
+                variableNames.add(name);
+                variableIndices.add(i);
+            }
+        }
+
+        // Extract step values and snapshot arrays
+        List<double[]> rows = simResult.rows();
+        long[] steps = new long[rows.size()];
+        List<double[]> stockSnapshots = new ArrayList<>(rows.size());
+        List<double[]> variableSnapshots = new ArrayList<>(rows.size());
+
+        for (int r = 0; r < rows.size(); r++) {
+            double[] row = rows.get(r);
+            steps[r] = (long) row[0];
+
+            double[] stockVals = new double[stockIndices.size()];
+            for (int s = 0; s < stockIndices.size(); s++) {
+                stockVals[s] = row[stockIndices.get(s)];
+            }
+            stockSnapshots.add(stockVals);
+
+            double[] varVals = new double[variableIndices.size()];
+            for (int v = 0; v < variableIndices.size(); v++) {
+                varVals[v] = row[variableIndices.get(v)];
+            }
+            variableSnapshots.add(varVals);
+        }
+
+        return RunResult.fromTimeSeries(stockNames, variableNames, steps,
+                stockSnapshots, variableSnapshots);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ReportGenerator.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ReportGenerator.java
@@ -45,21 +45,39 @@ public final class ReportGenerator {
      * @return self-contained HTML string
      */
     public static String generate(ModelDefinition definition, String svgDiagram) {
-        return generate(definition, svgDiagram, EnumSet.allOf(Section.class));
+        return generate(definition, svgDiagram, EnumSet.allOf(Section.class), null, null);
+    }
+
+    /**
+     * Generates a complete HTML report with all sections plus additional content.
+     *
+     * @param definition        the model definition
+     * @param svgDiagram        optional SVG diagram content (null to omit diagram section)
+     * @param extraCss          additional CSS rules to include (null to omit)
+     * @param extraBodySections additional HTML sections to append after model sections (null to omit)
+     * @return self-contained HTML string
+     */
+    public static String generate(ModelDefinition definition, String svgDiagram,
+                                  String extraCss, String extraBodySections) {
+        return generate(definition, svgDiagram, EnumSet.allOf(Section.class),
+                extraCss, extraBodySections);
     }
 
     /**
      * Generates an HTML report with selected sections.
      *
-     * @param definition the model definition
-     * @param svgDiagram optional SVG diagram content (null to omit diagram section)
-     * @param sections   which sections to include
+     * @param definition        the model definition
+     * @param svgDiagram        optional SVG diagram content (null to omit diagram section)
+     * @param sections          which sections to include
+     * @param extraCss          additional CSS rules to include (null to omit)
+     * @param extraBodySections additional HTML sections to append after model sections (null to omit)
      * @return self-contained HTML string
      */
     public static String generate(ModelDefinition definition, String svgDiagram,
-                                  Set<Section> sections) {
+                                  Set<Section> sections, String extraCss,
+                                  String extraBodySections) {
         StringBuilder html = new StringBuilder(8192);
-        writeHeader(html, definition.name());
+        writeHeader(html, definition.name(), extraCss);
 
         html.append("<body>\n");
         html.append("<div class=\"container\">\n");
@@ -94,6 +112,13 @@ public final class ReportGenerator {
             writeSimulationSettings(html, definition.defaultSimulation());
         }
 
+        if (extraBodySections != null && !extraBodySections.isBlank()) {
+            html.append("\n<hr style=\"border:none;border-top:2px solid #2c5282;"
+                    + "margin:2rem 0;\">\n");
+            html.append("<h1 style=\"margin-top:1.5rem;\">Simulation Results</h1>\n");
+            html.append(extraBodySections);
+        }
+
         html.append("</div>\n");
         html.append("</body>\n</html>\n");
         return html.toString();
@@ -101,7 +126,7 @@ public final class ReportGenerator {
 
     // ── Header & CSS ────────────────────────────────────────────────────
 
-    private static void writeHeader(StringBuilder html, String title) {
+    private static void writeHeader(StringBuilder html, String title, String extraCss) {
         html.append("""
                 <!DOCTYPE html>
                 <html lang="en">
@@ -111,6 +136,9 @@ public final class ReportGenerator {
                 """);
         html.append("<title>").append(esc(title)).append(" — Model Report</title>\n");
         html.append(CSS);
+        if (extraCss != null && !extraCss.isBlank()) {
+            html.append("<style>\n").append(extraCss).append("</style>\n");
+        }
         html.append("</head>\n");
     }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ResultReportGenerator.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ResultReportGenerator.java
@@ -143,6 +143,55 @@ public final class ResultReportGenerator {
         return html.toString();
     }
 
+    /**
+     * Generates only the result section HTML fragments (no HTML/head/body wrapper).
+     * Used by {@link ReportExporter} to embed result sections into a combined report.
+     *
+     * @param singleRun     single simulation run result (null to omit)
+     * @param sweep         parameter sweep result (null to omit)
+     * @param monteCarlo    Monte Carlo result (null to omit)
+     * @param sensitivity   sensitivity impacts list (null or empty to omit)
+     * @param optimization  optimization result (null to omit)
+     * @param dominance     loop dominance analysis (null to omit)
+     * @return HTML section fragments
+     */
+    static String generateSections(RunResult singleRun,
+                                   SweepResult sweep,
+                                   MonteCarloResult monteCarlo,
+                                   List<ParameterImpact> sensitivity,
+                                   OptimizationResult optimization,
+                                   LoopDominanceAnalysis dominance) {
+        StringBuilder html = new StringBuilder(8192);
+        if (singleRun != null && singleRun.getStepCount() > 0) {
+            writeSimulationSection(html, singleRun);
+        }
+        if (sweep != null && sweep.getRunCount() > 0) {
+            writeSweepSection(html, sweep);
+        }
+        if (monteCarlo != null && monteCarlo.getRunCount() > 0) {
+            writeMonteCarloSection(html, monteCarlo);
+        }
+        if (sensitivity != null && !sensitivity.isEmpty()) {
+            writeSensitivitySection(html, sensitivity);
+        }
+        if (dominance != null && dominance.loopCount() > 0) {
+            writeLoopDominanceSection(html, dominance);
+        }
+        if (optimization != null) {
+            writeOptimizationSection(html, optimization);
+        }
+        return html.toString();
+    }
+
+    /**
+     * Returns the additional CSS rules needed for result report sections
+     * (charts, collapsible details, behavior badges, etc.) that are not
+     * included in the base model report CSS.
+     */
+    static String getResultsCSS() {
+        return RESULTS_EXTRA_CSS;
+    }
+
     // ── Phase 2: Single Run ────────────────────────────────────────────
 
     static void writeSimulationSection(StringBuilder html, RunResult run) {
@@ -1128,6 +1177,60 @@ public final class ResultReportGenerator {
     }
 
     // ── CSS ─────────────────────────────────────────────────────────────
+
+    /** Extra CSS rules needed by result sections but not present in ReportGenerator. */
+    private static final String RESULTS_EXTRA_CSS = """
+            h3 {
+                font-size: 1rem;
+                color: #4a5568;
+                margin-top: 1rem;
+                margin-bottom: 0.5rem;
+            }
+            .chart-svg {
+                width: 100%;
+                max-width: 800px;
+                height: auto;
+                margin: 1rem 0;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            }
+            details {
+                margin: 0.75rem 0;
+                border: 1px solid #e2e8f0;
+                border-radius: 4px;
+            }
+            details summary {
+                cursor: pointer;
+                padding: 0.5rem 0.75rem;
+                font-weight: 600;
+                color: #4a5568;
+                background: #f7fafc;
+                user-select: none;
+            }
+            details summary:hover { background: #edf2f7; }
+            details[open] summary { border-bottom: 1px solid #e2e8f0; }
+            details .element-table { margin-bottom: 0; }
+            .summary-text {
+                margin: 0.75rem 0;
+                font-size: 0.95rem;
+                color: #4a5568;
+                line-height: 1.5;
+            }
+            .behavior-badge {
+                display: inline-block;
+                padding: 0.15rem 0.5rem;
+                border-radius: 3px;
+                font-size: 0.8rem;
+                font-weight: 600;
+                color: white;
+            }
+            .behavior-growth { background: #27ae60; }
+            .behavior-decay { background: #e67e22; }
+            .behavior-goal { background: #2980b9; }
+            .behavior-oscillation { background: #8e44ad; }
+            .behavior-s-shaped { background: #16a085; }
+            .behavior-overshoot { background: #c0392b; }
+            .behavior-equilibrium { background: #95a5a6; }
+            """;
 
     private static final String CSS = """
             <style>

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ReportGeneratorTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ReportGeneratorTest.java
@@ -103,7 +103,8 @@ class ReportGeneratorTest {
             ModelDefinition def = buildFullModel();
             String html = ReportGenerator.generate(def, "<svg>diagram</svg>",
                     EnumSet.of(ReportGenerator.Section.STOCKS,
-                            ReportGenerator.Section.SIMULATION_SETTINGS));
+                            ReportGenerator.Section.SIMULATION_SETTINGS),
+                    null, null);
 
             assertThat(html).contains(">Stocks</h2>");
             assertThat(html).contains("Simulation Settings");
@@ -120,7 +121,8 @@ class ReportGeneratorTest {
         void shouldOmitDiagramWhenExcluded() {
             ModelDefinition def = buildFullModel();
             String html = ReportGenerator.generate(def, "<svg>diagram</svg>",
-                    EnumSet.of(ReportGenerator.Section.MODEL_INFO));
+                    EnumSet.of(ReportGenerator.Section.MODEL_INFO),
+                    null, null);
 
             assertThat(html).doesNotContain("Model Diagram");
             assertThat(html).doesNotContain("<svg>");

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/RunResult.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/RunResult.java
@@ -206,6 +206,38 @@ public class RunResult implements EventHandler {
         return max;
     }
 
+    /**
+     * Creates a RunResult from pre-captured time-series data.
+     * Used to convert UI-level simulation results into the engine result format
+     * for report generation.
+     *
+     * @param stockNames        ordered stock names
+     * @param variableNames     ordered variable names
+     * @param steps             step values for each recorded time step
+     * @param stockSnapshots    stock value arrays per step (same order as stockNames)
+     * @param variableSnapshots variable value arrays per step (same order as variableNames)
+     * @return a populated RunResult
+     */
+    public static RunResult fromTimeSeries(List<String> stockNames,
+                                           List<String> variableNames,
+                                           long[] steps,
+                                           List<double[]> stockSnapshots,
+                                           List<double[]> variableSnapshots) {
+        RunResult result = new RunResult(0.0);
+        result.stockNames = new ArrayList<>(stockNames);
+        result.variableNames = new ArrayList<>(variableNames);
+        for (long step : steps) {
+            result.steps.add(step);
+        }
+        for (double[] snapshot : stockSnapshots) {
+            result.stockSnapshots.add(snapshot.clone());
+        }
+        for (double[] snapshot : variableSnapshots) {
+            result.variableSnapshots.add(snapshot.clone());
+        }
+        return result;
+    }
+
     private static double[] toDoubleArray(List<Double> values) {
         double[] arr = new double[values.size()];
         for (int i = 0; i < arr.length; i++) {


### PR DESCRIPTION
## Summary
- **Export Report** now includes Phase 2/3/4 results (simulation time series, Monte Carlo fan charts, sensitivity tornado charts, sweep charts, optimization summaries) when dashboard results are available
- `DashboardPanel` stores result objects as they arrive; `ReportExporter` converts and passes them to `ResultReportGenerator.generateSections()`, which is injected into the Phase 1 model report
- Added `RunResult.fromTimeSeries()` factory to convert the app's `SimulationResult` format to the engine's `RunResult` for report generation

## Test plan
- [x] All existing tests pass
- [x] SpotBugs clean
- [ ] Run simulation, then Export Report — verify time series charts and summary tables appear
- [ ] Run Monte Carlo, then Export Report — verify fan charts and percentile tables appear
- [ ] Export Report with no results — verify model-only report unchanged