### PR TITLE
Fix context menu blocked by ChartTimeCursor overlay

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/ChartTimeCursor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/ChartTimeCursor.java
@@ -8,6 +8,7 @@ import javafx.scene.Node;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
 import javafx.scene.control.Label;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
@@ -66,11 +67,10 @@ public final class ChartTimeCursor {
         cursorLabel.setMouseTransparent(true);
 
         overlay = new Pane(cursorLine, cursorLabel);
-        overlay.setMouseTransparent(false);
+        overlay.setMouseTransparent(true);
         overlay.setPickOnBounds(false);
-        overlay.setStyle("-fx-background-color: transparent;");
 
-        overlay.setOnMouseMoved(event -> {
+        chart.addEventHandler(MouseEvent.MOUSE_MOVED, event -> {
             Node plotArea = chart.lookup(".chart-plot-background");
             if (plotArea == null) {
                 return;
@@ -85,7 +85,7 @@ public final class ChartTimeCursor {
             }
         });
 
-        overlay.setOnMouseExited(event -> cursorTimeStep.set(Double.NaN));
+        chart.addEventHandler(MouseEvent.MOUSE_EXITED, event -> cursorTimeStep.set(Double.NaN));
 
         cursorTimeStep.addListener((obs, oldVal, newVal) -> updateCursorDisplay(newVal.doubleValue()));
     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/ChartTimeCursorFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/ChartTimeCursorFxTest.java
@@ -2,10 +2,12 @@ package systems.courant.sd.app.canvas.charts;
 
 import javafx.application.Platform;
 import javafx.beans.property.DoubleProperty;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Line;
 import javafx.stage.Stage;
@@ -149,5 +151,17 @@ class ChartTimeCursorFxTest {
         double value = cursor.cursorTimeStepProperty().get();
         // Should have a valid numeric value (not NaN) since we're over the chart
         assertThat(value).isNotNaN();
+    }
+
+    @Test
+    @DisplayName("Overlay is mouse-transparent so chart receives context menu events")
+    void overlayIsMouseTransparent(FxRobot robot) {
+        StackPane wrapper = (StackPane) chart.getParent();
+        // The overlay is the second child in the StackPane (after the chart)
+        Node overlay = wrapper.getChildren().get(1);
+        assertThat(overlay).isInstanceOf(Pane.class);
+        assertThat(overlay.isMouseTransparent())
+                .as("Overlay must be mouse-transparent to allow context menu events through")
+                .isTrue();
     }
 }


### PR DESCRIPTION
## Summary
- The cursor overlay pane intercepted right-click events because it had `mouseTransparent=false` with a transparent CSS background, making it a pick target
- Moved mouse tracking from the overlay to the chart via `addEventHandler` and set the overlay to `mouseTransparent=true` so it serves only as a drawing surface
- Fixes context menus on both SimulationResultPane and LoopDominancePane

## Test plan
- [x] Added test verifying overlay is mouse-transparent
- [x] All 1829 existing tests pass
- [x] SpotBugs clean

Closes #1192