### PR TITLE
Regenerate TU Delft example models via BatchImportCli pipeline

### DIFF
--- a/courant-app/src/main/resources/models/catalog.json
+++ b/courant-app/src/main/resources/models/catalog.json
@@ -77,6 +77,25 @@
       }
     },
     {
+      "id": "cocaine-flow",
+      "name": "Cocaine Flow",
+      "displayName": "Cocaine Flow",
+      "description": "Simple drug flow model with import, use, and confiscation rates demonstrating balancing feedback",
+      "category": "introductory",
+      "difficulty": "introductory",
+      "path": "introductory/cocaine-flow.json",
+      "tags": [
+        "stock-and-flow",
+        "balancing-feedback"
+      ],
+      "elements": {
+        "stocks": 1,
+        "flows": 3,
+        "variables": 1,
+        "parameters": 3
+      }
+    },
+    {
       "id": "inventory-oscillation",
       "name": "Inventory Oscillation",
       "displayName": "Inventory Oscillation",
@@ -113,6 +132,84 @@
         "flows": 4,
         "variables": 0,
         "parameters": 4
+      }
+    },
+    {
+      "id": "muskrat-plague",
+      "name": "Muskrat Plague",
+      "displayName": "Muskrat Plague",
+      "description": "Muskrat population dynamics with trapping and licensing, illustrating negative feedback through harvest pressure",
+      "category": "ecology",
+      "difficulty": "intermediate",
+      "path": "ecology/muskrat-plague.json",
+      "tags": [
+        "population-dynamics",
+        "negative-feedback"
+      ],
+      "elements": {
+        "stocks": 1,
+        "flows": 2,
+        "variables": 3,
+        "parameters": 5
+      }
+    },
+    {
+      "id": "kaibab-deer",
+      "name": "Kaibab Deer",
+      "displayName": "Kaibab Deer",
+      "description": "Deer population on the Kaibab Plateau (1900-1950) limited by predation, using a lookup table for kill rate",
+      "category": "ecology",
+      "difficulty": "intermediate",
+      "path": "ecology/kaibab-deer.json",
+      "tags": [
+        "population-dynamics",
+        "lookup-table"
+      ],
+      "elements": {
+        "stocks": 1,
+        "flows": 2,
+        "variables": 4,
+        "parameters": 4
+      }
+    },
+    {
+      "id": "bluefin-tuna-overfishing",
+      "name": "Bluefin Tuna Overfishing",
+      "displayName": "Bluefin Tuna Overfishing",
+      "description": "Two-stock model of Northern Bluefin Tuna overfishing with fleet adjustment creating overshoot-and-collapse",
+      "category": "ecology",
+      "difficulty": "advanced",
+      "path": "ecology/bluefin-tuna-overfishing.json",
+      "tags": [
+        "overshoot",
+        "collapse",
+        "delay"
+      ],
+      "elements": {
+        "stocks": 2,
+        "flows": 5,
+        "variables": 12,
+        "parameters": 8
+      }
+    },
+    {
+      "id": "ecological-overshoot",
+      "name": "Ecological Overshoot",
+      "displayName": "Ecological Overshoot",
+      "description": "Consumer population depletes renewable resource, creating classic overshoot-and-collapse dynamics",
+      "category": "ecology",
+      "difficulty": "intermediate",
+      "path": "ecology/ecological-overshoot.json",
+      "tags": [
+        "overshoot",
+        "collapse",
+        "renewable-resource"
+      ],
+      "elements": {
+        "stocks": 2,
+        "flows": 4,
+        "variables": 6,
+        "parameters": 9
       }
     },
     {

--- a/courant-app/src/main/resources/models/ecology/bluefin-tuna-overfishing.json
+++ b/courant-app/src/main/resources/models/ecology/bluefin-tuna-overfishing.json
@@ -1,0 +1,417 @@
+{
+  "name" : "1412_OverfishingOfNBFTunaEN",
+  "stocks" : [ {
+    "name" : "Tuna Biomass",
+    "comment" : "Tuna Biomass",
+    "initialValue" : 100000.0,
+    "unit" : "ton"
+  }, {
+    "name" : "Official Number of Tuna Ships",
+    "comment" : "Official Number of Tuna Ships",
+    "initialValue" : 15000.0,
+    "unit" : "Ship"
+  } ],
+  "flows" : [ {
+    "name" : "Tuna Biomass inflow 1",
+    "equation" : "growth_existing_tuna_biomass",
+    "timeUnit" : "Year",
+    "sink" : "Tuna Biomass"
+  }, {
+    "name" : "Tuna Biomass inflow 2",
+    "equation" : "tuna_recruitment",
+    "timeUnit" : "Year",
+    "sink" : "Tuna Biomass"
+  }, {
+    "name" : "Tuna Biomass outflow 3",
+    "equation" : "natural_deaths",
+    "timeUnit" : "Year",
+    "source" : "Tuna Biomass"
+  }, {
+    "name" : "Tuna Biomass outflow 4",
+    "equation" : "tuna_catch",
+    "timeUnit" : "Year",
+    "source" : "Tuna Biomass"
+  }, {
+    "name" : "Official Number of Tuna Ships net flow",
+    "comment" : "Net flow for Official Number of Tuna Ships",
+    "equation" : "net_increase_official_number_of_tuna_ships",
+    "timeUnit" : "Year",
+    "sink" : "Official Number of Tuna Ships"
+  } ],
+  "variables" : [ {
+    "name" : "effect",
+    "comment" : "effect",
+    "equation" : "LOOKUP(effect_lookup, perceived_state_of_tuna_fishery)",
+    "unit" : "Dmnl"
+  }, {
+    "name" : "fraction tuna catch",
+    "comment" : "fraction tuna catch",
+    "equation" : "average_efficiency_tuna_ships*total_number_of_tuna_ships",
+    "unit" : "1/Year"
+  }, {
+    "name" : "average efficiency tuna ships",
+    "comment" : "average efficiency tuna ships",
+    "equation" : "4.0E-6",
+    "unit" : "1/Ship/Year"
+  }, {
+    "name" : "perceived state of tuna fishery",
+    "comment" : "perceived state of tuna fishery",
+    "equation" : "SMOOTHI(most_recent_perception_concerning_tuna_fishery, delay_time, initial_state_tuna_fishery )",
+    "unit" : "Dmnl"
+  }, {
+    "name" : "growth existing tuna biomass",
+    "comment" : "growth existing tuna biomass",
+    "equation" : "Tuna_Biomass*tuna_growth_rate",
+    "unit" : "ton/Year"
+  }, {
+    "name" : "illegal tuna ships",
+    "comment" : "illegal tuna ships",
+    "equation" : "10000-STEP(10000,2010)*0",
+    "unit" : "Ship"
+  }, {
+    "name" : "implementation time delay",
+    "comment" : "implementation time delay",
+    "equation" : "2",
+    "unit" : "Year"
+  }, {
+    "name" : "initial state tuna fishery",
+    "comment" : "initial state tuna fishery",
+    "equation" : "10",
+    "unit" : "Dmnl"
+  }, {
+    "name" : "most recent perception concerning tuna fishery",
+    "comment" : "most recent perception concerning tuna fishery",
+    "equation" : "LOOKUP(change_in_tuna_perception_lookup, ratio_of_biomass_to_unfished_biomass)",
+    "unit" : "Dmnl"
+  }, {
+    "name" : "natural deaths",
+    "comment" : "natural deaths",
+    "equation" : "Tuna_Biomass*ratio_of_biomass_to_unfished_biomass/normal_death_rate",
+    "unit" : "ton/Year"
+  }, {
+    "name" : "net increase official number of tuna ships",
+    "comment" : "net increase official number of tuna ships",
+    "equation" : "proposed_change_in_the_number_of_tuna_ships/implementation_time_delay",
+    "unit" : "Ship/Year"
+  }, {
+    "name" : "normal death rate",
+    "comment" : "normal death rate",
+    "equation" : "20",
+    "unit" : "Year"
+  }, {
+    "name" : "unfished biomass 1990",
+    "comment" : "unfished biomass 1990",
+    "equation" : "100000",
+    "unit" : "ton"
+  }, {
+    "name" : "tuna recruitment",
+    "comment" : "tuna recruitment",
+    "equation" : "DELAY_FIXED( Tuna_Biomass*tuna_recruitment_rate,4,Tuna_Biomass*tuna_recruitment_rate)",
+    "unit" : "ton/Year"
+  }, {
+    "name" : "tuna recruitment rate",
+    "comment" : "tuna recruitment rate",
+    "equation" : "0.01",
+    "unit" : "1/Year"
+  }, {
+    "name" : "delay time",
+    "comment" : "delay time",
+    "equation" : "2",
+    "unit" : "Year"
+  }, {
+    "name" : "tuna growth rate",
+    "comment" : "tuna growth rate",
+    "equation" : "0.04",
+    "unit" : "1/Year"
+  }, {
+    "name" : "tuna catch",
+    "comment" : "tuna catch",
+    "equation" : "Tuna_Biomass*fraction_tuna_catch",
+    "unit" : "ton/Year"
+  }, {
+    "name" : "total number of tuna ships",
+    "comment" : "total number of tuna ships",
+    "equation" : "illegal_tuna_ships+Official_Number_of_Tuna_Ships",
+    "unit" : "Ship"
+  }, {
+    "name" : "ratio of biomass to unfished biomass",
+    "comment" : "ratio of biomass to unfished biomass",
+    "equation" : "Tuna_Biomass/unfished_biomass_1990",
+    "unit" : "Dmnl"
+  }, {
+    "name" : "proposed change in the number of tuna ships",
+    "comment" : "proposed change in the number of tuna ships",
+    "equation" : "(effect)*Official_Number_of_Tuna_Ships",
+    "unit" : "Ship"
+  } ],
+  "lookupTables" : [ {
+    "name" : "effect_lookup",
+    "xValues" : [ -10.0, -7.5, -5.0, -2.5, 0.0, 2.5, 5.0, 7.5, 10.0, 100.0 ],
+    "yValues" : [ -0.9, -0.5, -0.25, -0.1, 0.0, 0.075, 0.15, 0.21, 0.25, 0.25 ],
+    "interpolation" : "LINEAR"
+  }, {
+    "name" : "change in tuna perception lookup",
+    "comment" : "change in tuna perception lookup",
+    "xValues" : [ 0.0, 0.25, 0.5, 0.75, 1.0 ],
+    "yValues" : [ -10.0, -2.0, 0.0, 1.5, 10.0 ],
+    "interpolation" : "LINEAR",
+    "unit" : "Dmnl"
+  } ],
+  "views" : [ {
+    "name" : "View 1",
+    "elements" : [ {
+      "name" : "Tuna Biomass",
+      "type" : "stock",
+      "x" : 610.0,
+      "y" : 265.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 503.0,
+      "y" : 265.0
+    }, {
+      "name" : "tuna recruitment",
+      "type" : "aux",
+      "x" : 503.0,
+      "y" : 284.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 608.0,
+      "y" : 338.0
+    }, {
+      "name" : "growth existing tuna biomass",
+      "type" : "aux",
+      "x" : 546.0,
+      "y" : 338.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 605.0,
+      "y" : 198.0
+    }, {
+      "name" : "tuna catch",
+      "type" : "aux",
+      "x" : 646.0,
+      "y" : 198.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 723.0,
+      "y" : 265.0
+    }, {
+      "name" : "natural deaths",
+      "type" : "aux",
+      "x" : 723.0,
+      "y" : 284.0
+    }, {
+      "name" : "tuna growth rate",
+      "type" : "aux",
+      "x" : 478.0,
+      "y" : 404.0
+    }, {
+      "name" : "tuna recruitment rate",
+      "type" : "aux",
+      "x" : 421.0,
+      "y" : 206.0
+    }, {
+      "name" : "ratio of biomass to unfished biomass",
+      "type" : "aux",
+      "x" : 725.0,
+      "y" : 382.0
+    }, {
+      "name" : "normal death rate",
+      "type" : "aux",
+      "x" : 810.0,
+      "y" : 335.0
+    }, {
+      "name" : "unfished biomass 1990",
+      "type" : "aux",
+      "x" : 773.0,
+      "y" : 449.0
+    }, {
+      "name" : "fraction tuna catch",
+      "type" : "aux",
+      "x" : 519.0,
+      "y" : 90.0
+    }, {
+      "name" : "total number of tuna ships",
+      "type" : "aux",
+      "x" : 320.0,
+      "y" : 81.0
+    }, {
+      "name" : "average efficiency tuna ships",
+      "type" : "aux",
+      "x" : 404.0,
+      "y" : 139.0
+    }, {
+      "name" : "Official Number of Tuna Ships",
+      "type" : "stock",
+      "x" : 151.0,
+      "y" : 163.0
+    }, {
+      "name" : "illegal tuna ships",
+      "type" : "aux",
+      "x" : 149.0,
+      "y" : 98.0
+    }, {
+      "name" : "change in tuna perception lookup",
+      "type" : "lookup",
+      "x" : 745.0,
+      "y" : 501.0
+    }, {
+      "name" : "most recent perception concerning tuna fishery",
+      "type" : "aux",
+      "x" : 520.0,
+      "y" : 502.0
+    }, {
+      "name" : "perceived state of tuna fishery",
+      "type" : "aux",
+      "x" : 284.0,
+      "y" : 503.0
+    }, {
+      "name" : "delay time",
+      "type" : "aux",
+      "x" : 266.0,
+      "y" : 440.0
+    }, {
+      "name" : "initial state tuna fishery",
+      "type" : "aux",
+      "x" : 378.0,
+      "y" : 440.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 156.0,
+      "y" : 218.0
+    }, {
+      "name" : "net increase official number of tuna ships",
+      "type" : "aux",
+      "x" : 235.0,
+      "y" : 218.0
+    }, {
+      "name" : "proposed change in the number of tuna ships",
+      "type" : "aux",
+      "x" : 134.0,
+      "y" : 335.0
+    }, {
+      "name" : "implementation time delay",
+      "type" : "aux",
+      "x" : 328.0,
+      "y" : 326.0
+    }, {
+      "name" : "effect",
+      "type" : "aux",
+      "x" : 166.0,
+      "y" : 435.0
+    } ],
+    "connectors" : [ {
+      "from" : "tuna recruitment rate",
+      "to" : "_48"
+    }, {
+      "from" : "tuna growth rate",
+      "to" : "growth existing tuna biomass"
+    }, {
+      "from" : "Tuna Biomass",
+      "to" : "growth existing tuna biomass"
+    }, {
+      "from" : "Tuna Biomass",
+      "to" : "_48"
+    }, {
+      "from" : "Tuna Biomass",
+      "to" : "_48"
+    }, {
+      "from" : "Tuna Biomass",
+      "to" : "ratio of biomass to unfished biomass"
+    }, {
+      "from" : "ratio of biomass to unfished biomass",
+      "to" : "natural deaths"
+    }, {
+      "from" : "normal death rate",
+      "to" : "natural deaths"
+    }, {
+      "from" : "unfished biomass 1990",
+      "to" : "ratio of biomass to unfished biomass"
+    }, {
+      "from" : "unfished biomass 1990",
+      "to" : "Tuna Biomass"
+    }, {
+      "from" : "Tuna Biomass",
+      "to" : "tuna catch"
+    }, {
+      "from" : "fraction tuna catch",
+      "to" : "tuna catch"
+    }, {
+      "from" : "illegal tuna ships",
+      "to" : "total number of tuna ships"
+    }, {
+      "from" : "Official Number of Tuna Ships",
+      "to" : "total number of tuna ships"
+    }, {
+      "from" : "total number of tuna ships",
+      "to" : "fraction tuna catch"
+    }, {
+      "from" : "average efficiency tuna ships",
+      "to" : "fraction tuna catch"
+    }, {
+      "from" : "ratio of biomass to unfished biomass",
+      "to" : "most recent perception concerning tuna fishery"
+    }, {
+      "from" : "change in tuna perception lookup",
+      "to" : "most recent perception concerning tuna fishery"
+    }, {
+      "from" : "most recent perception concerning tuna fishery",
+      "to" : "perceived state of tuna fishery"
+    }, {
+      "from" : "delay time",
+      "to" : "perceived state of tuna fishery"
+    }, {
+      "from" : "initial state tuna fishery",
+      "to" : "perceived state of tuna fishery"
+    }, {
+      "from" : "proposed change in the number of tuna ships",
+      "to" : "net increase official number of tuna ships"
+    }, {
+      "from" : "implementation time delay",
+      "to" : "net increase official number of tuna ships"
+    }, {
+      "from" : "perceived state of tuna fishery",
+      "to" : "effect"
+    }, {
+      "from" : "effect",
+      "to" : "proposed change in the number of tuna ships"
+    }, {
+      "from" : "Official Number of Tuna Ships",
+      "to" : "proposed change in the number of tuna ships"
+    } ],
+    "flowRoutes" : [ {
+      "flowName" : "_48",
+      "points" : [ [ 503.0, 265.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 608.0, 338.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 605.0, 198.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 723.0, 265.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 156.0, 218.0 ] ]
+    } ]
+  } ],
+  "defaultSimulation" : {
+    "timeStep" : "Year",
+    "duration" : 300.0,
+    "durationUnit" : "Year",
+    "dt" : 0.125,
+    "initialTime" : 1990.0
+  },
+  "metadata" : {
+    "author" : "Dr. Erik Pruyt",
+    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license" : "CC-BY-NC-SA-4.0",
+    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/14_12"
+  }
+}

--- a/courant-app/src/main/resources/models/ecology/ecological-overshoot.json
+++ b/courant-app/src/main/resources/models/ecology/ecological-overshoot.json
@@ -1,0 +1,297 @@
+{
+  "name" : "0603EcOvershootCollapseBasedOnEZ416Bossel",
+  "stocks" : [ {
+    "name" : "renewable resources",
+    "comment" : "renewable resources",
+    "initialValue" : 7000000.0,
+    "unit" : "resource"
+  }, {
+    "name" : "population",
+    "comment" : "population",
+    "initialValue" : 100000.0,
+    "unit" : "consumer"
+  } ],
+  "flows" : [ {
+    "name" : "renewable resources inflow 1",
+    "equation" : "regeneration",
+    "timeUnit" : "Year",
+    "sink" : "renewable resources"
+  }, {
+    "name" : "renewable resources outflow 2",
+    "equation" : "resource_use",
+    "timeUnit" : "Year",
+    "source" : "renewable resources"
+  }, {
+    "name" : "population inflow 1",
+    "equation" : "births",
+    "timeUnit" : "Year",
+    "sink" : "population"
+  }, {
+    "name" : "population outflow 2",
+    "equation" : "deaths",
+    "timeUnit" : "Year",
+    "source" : "population"
+  } ],
+  "variables" : [ {
+    "name" : "deaths",
+    "comment" : "deaths",
+    "equation" : "population/resource_availability_dependent_lifetime",
+    "unit" : "consumer/Year"
+  }, {
+    "name" : "resource availability dependent lifetime",
+    "comment" : "MAX(MIN(normal lifetime*per capita renewable resource availability,100),20)",
+    "equation" : "MAX(15,MIN(100,normal_lifetime*per_capita_renewable_resource_availability))",
+    "unit" : ""
+  }, {
+    "name" : "rapid resource depletion time",
+    "comment" : "rapid resource depletion time",
+    "equation" : "1",
+    "unit" : "Year"
+  }, {
+    "name" : "resource use",
+    "comment" : "IF THEN ELSE(renewable resources/rapid resource depletion time < renewable  resource consumption per capita*population, renewable resources/rapid  resource depletion time, renewable resource consumption per  capita*population)",
+    "equation" : "MIN(renewable_resources/rapid_resource_depletion_time, renewable_resource_consumption_per_capita *population)",
+    "unit" : "resource/Year"
+  }, {
+    "name" : "INITIAL RESOURCES",
+    "comment" : "INITIAL RESOURCES",
+    "equation" : "7000000",
+    "unit" : "resource"
+  }, {
+    "name" : "INITIAL CONSUMERS",
+    "comment" : "INITIAL CONSUMERS",
+    "equation" : "100000",
+    "unit" : "consumer"
+  }, {
+    "name" : "regeneration",
+    "comment" : "regeneration",
+    "equation" : "regeneration_rate*renewable_resources*(renewable_resources/carrying_capacity)*(1-renewable_resources /carrying_capacity)+minimum_regeneration_rate*carrying_capacity",
+    "unit" : "resource/Year"
+  }, {
+    "name" : "regeneration rate",
+    "comment" : "regeneration rate",
+    "equation" : "1.2",
+    "unit" : "1/Year"
+  }, {
+    "name" : "normal birth rate",
+    "comment" : "normal birth rate",
+    "equation" : "0.0035",
+    "unit" : "1/Year"
+  }, {
+    "name" : "minimum regeneration rate",
+    "comment" : "minimum regeneration rate",
+    "equation" : "0.01",
+    "unit" : "1/Year"
+  }, {
+    "name" : "carrying capacity",
+    "comment" : "carrying capacity",
+    "equation" : "7500000",
+    "unit" : "resource"
+  }, {
+    "name" : "per capita renewable resource availability",
+    "comment" : "per capita renewable resource availability",
+    "equation" : "renewable_resources/population",
+    "unit" : "resource/consumer"
+  }, {
+    "name" : "renewable resource consumption per capita",
+    "comment" : "renewable resource consumption per capita",
+    "equation" : "1",
+    "unit" : "resource/(consumer*Year)"
+  }, {
+    "name" : "normal lifetime",
+    "comment" : "normal lifetime",
+    "equation" : "25",
+    "unit" : "1/Year"
+  }, {
+    "name" : "births",
+    "comment" : "births",
+    "equation" : "normal_birth_rate*population*per_capita_renewable_resource_availability",
+    "unit" : "consumer/Year"
+  } ],
+  "views" : [ {
+    "name" : "View 1",
+    "elements" : [ {
+      "name" : "renewable resources",
+      "type" : "stock",
+      "x" : 268.0,
+      "y" : 250.0
+    }, {
+      "name" : "population",
+      "type" : "stock",
+      "x" : 552.0,
+      "y" : 251.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 167.0,
+      "y" : 251.0
+    }, {
+      "name" : "regeneration",
+      "type" : "aux",
+      "x" : 167.0,
+      "y" : 267.0
+    }, {
+      "name" : "regeneration rate",
+      "type" : "aux",
+      "x" : 95.0,
+      "y" : 313.0
+    }, {
+      "name" : "carrying capacity",
+      "type" : "aux",
+      "x" : 174.0,
+      "y" : 172.0
+    }, {
+      "name" : "renewable resource consumption per capita",
+      "type" : "aux",
+      "x" : 319.0,
+      "y" : 420.0
+    }, {
+      "name" : "normal birth rate",
+      "type" : "aux",
+      "x" : 462.0,
+      "y" : 328.0
+    }, {
+      "name" : "normal lifetime",
+      "type" : "aux",
+      "x" : 740.0,
+      "y" : 344.0
+    }, {
+      "name" : "minimum regeneration rate",
+      "type" : "aux",
+      "x" : 163.0,
+      "y" : 358.0
+    }, {
+      "name" : "INITIAL RESOURCES",
+      "type" : "aux",
+      "x" : 268.0,
+      "y" : 214.0
+    }, {
+      "name" : "INITIAL CONSUMERS",
+      "type" : "aux",
+      "x" : 552.0,
+      "y" : 216.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 363.0,
+      "y" : 250.0
+    }, {
+      "name" : "resource use",
+      "type" : "aux",
+      "x" : 363.0,
+      "y" : 266.0
+    }, {
+      "name" : "per capita renewable resource availability",
+      "type" : "aux",
+      "x" : 410.0,
+      "y" : 167.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 468.0,
+      "y" : 250.0
+    }, {
+      "name" : "births",
+      "type" : "aux",
+      "x" : 468.0,
+      "y" : 266.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 630.0,
+      "y" : 251.0
+    }, {
+      "name" : "deaths",
+      "type" : "aux",
+      "x" : 630.0,
+      "y" : 267.0
+    }, {
+      "name" : "rapid resource depletion time",
+      "type" : "aux",
+      "x" : 252.0,
+      "y" : 330.0
+    }, {
+      "name" : "resource availability dependent lifetime",
+      "type" : "aux",
+      "x" : 675.0,
+      "y" : 192.0
+    } ],
+    "connectors" : [ {
+      "from" : "population",
+      "to" : "resource use"
+    }, {
+      "from" : "renewable resource consumption per capita",
+      "to" : "resource use"
+    }, {
+      "from" : "renewable resources",
+      "to" : "resource use"
+    }, {
+      "from" : "renewable resources",
+      "to" : "per capita renewable resource availability"
+    }, {
+      "from" : "population",
+      "to" : "per capita renewable resource availability"
+    }, {
+      "from" : "population",
+      "to" : "deaths"
+    }, {
+      "from" : "per capita renewable resource availability",
+      "to" : "births"
+    }, {
+      "from" : "normal birth rate",
+      "to" : "births"
+    }, {
+      "from" : "regeneration rate",
+      "to" : "regeneration"
+    }, {
+      "from" : "renewable resources",
+      "to" : "regeneration"
+    }, {
+      "from" : "carrying capacity",
+      "to" : "regeneration"
+    }, {
+      "from" : "minimum regeneration rate",
+      "to" : "regeneration"
+    }, {
+      "from" : "population",
+      "to" : "births"
+    }, {
+      "from" : "INITIAL RESOURCES",
+      "to" : "renewable resources"
+    }, {
+      "from" : "INITIAL CONSUMERS",
+      "to" : "population"
+    }, {
+      "from" : "rapid resource depletion time",
+      "to" : "resource use"
+    }, {
+      "from" : "resource availability dependent lifetime",
+      "to" : "deaths"
+    } ],
+    "flowRoutes" : [ {
+      "flowName" : "_48",
+      "points" : [ [ 167.0, 251.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 363.0, 250.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 468.0, 250.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 630.0, 251.0 ] ]
+    } ]
+  } ],
+  "defaultSimulation" : {
+    "timeStep" : "Year",
+    "duration" : 500.0,
+    "durationUnit" : "Year",
+    "dt" : 0.02
+  },
+  "metadata" : {
+    "author" : "Dr. Erik Pruyt",
+    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license" : "CC-BY-NC-SA-4.0",
+    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/06_03"
+  }
+}

--- a/courant-app/src/main/resources/models/ecology/kaibab-deer.json
+++ b/courant-app/src/main/resources/models/ecology/kaibab-deer.json
@@ -1,0 +1,170 @@
+{
+  "name" : "1804_Kaibab1",
+  "stocks" : [ {
+    "name" : "Deer Population",
+    "comment" : "Initial amount of deers is 5,000 and remains constant.",
+    "initialValue" : 5000.0,
+    "unit" : "Deer"
+  } ],
+  "flows" : [ {
+    "name" : "Deer Population inflow 1",
+    "equation" : "Deer_Net_Growth_Rate",
+    "timeUnit" : "Year",
+    "sink" : "Deer Population"
+  }, {
+    "name" : "Deer Population outflow 2",
+    "equation" : "Deer_Predation_Rate",
+    "timeUnit" : "Year",
+    "source" : "Deer Population"
+  } ],
+  "variables" : [ {
+    "name" : "Deer Killed per Predator",
+    "comment" : "When density is equal to 0, the deer killed are 0. Point (0.0). When the  Deer Density is equal to the Initial Deer Density each predator hunts 2  deer each year. Point (1,2).",
+    "equation" : "LOOKUP(Deer_Killed_per_Predator_lookup, Deer_Density/Initial_Deer_Density)",
+    "unit" : "Deer/(year*lion)"
+  }, {
+    "name" : "Deer Predation Rate",
+    "comment" : "Deer Predation Rate",
+    "equation" : "Deer_Killed_per_Predator*Predator_Population",
+    "unit" : "Deer/year"
+  }, {
+    "name" : "Initial Deer Density",
+    "comment" : "1,000,000 acres / 5,000 deer",
+    "equation" : "200",
+    "unit" : "acre/Deer"
+  }, {
+    "name" : "Growth Rate Factor",
+    "comment" : "Here we work with the net growth rate of the deer population. This means  birth minus deceases. If every female had a fawn, the rate will be 0.50%  But there are female too old and too young to have fawns, so we reduce  this amount to the 0.30%. Now we need to consider the life expectancy, may  be 10 years. This is - 0.10% due to deceases. So we assume the Net Growth  Rate Factor equal to 0.2",
+    "equation" : "0.2",
+    "unit" : "1/year"
+  }, {
+    "name" : "Area",
+    "comment" : "Area",
+    "equation" : "1000000",
+    "unit" : "acre"
+  }, {
+    "name" : "Deer Density",
+    "comment" : "This is the amount of acres per deer",
+    "equation" : "Area/Deer_Population",
+    "unit" : "acre/Deer"
+  }, {
+    "name" : "Deer Net Growth Rate",
+    "comment" : "Deer Net Growth Rate",
+    "equation" : "Deer_Population*Growth_Rate_Factor",
+    "unit" : "Deer/year"
+  }, {
+    "name" : "Predator Population",
+    "comment" : "We assume that Net Growth Rate was 1000 deer, so Deer Predation Rate must  be also 1000 deer. In Table 1 we define that with a density of 0.005  deer/acre are killed 2 deer/predator, so we have  1000 (deer) /2  (deer/predator) = 500 predators",
+    "equation" : "500",
+    "unit" : "lion"
+  } ],
+  "lookupTables" : [ {
+    "name" : "Deer_Killed_per_Predator_lookup",
+    "xValues" : [ 0.0, 1.0, 2.0, 4.0, 5.0 ],
+    "yValues" : [ 0.0, 2.0, 4.0, 6.0, 6.0 ],
+    "interpolation" : "LINEAR"
+  } ],
+  "views" : [ {
+    "name" : "View 1",
+    "elements" : [ {
+      "name" : "Deer Population",
+      "type" : "stock",
+      "x" : 287.0,
+      "y" : 97.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 132.0,
+      "y" : 92.0
+    }, {
+      "name" : "Deer Net Growth Rate",
+      "type" : "aux",
+      "x" : 132.0,
+      "y" : 111.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 410.0,
+      "y" : 94.0
+    }, {
+      "name" : "Deer Predation Rate",
+      "type" : "aux",
+      "x" : 410.0,
+      "y" : 113.0
+    }, {
+      "name" : "Growth Rate Factor",
+      "type" : "aux",
+      "x" : 86.0,
+      "y" : 228.0
+    }, {
+      "name" : "Deer Density",
+      "type" : "aux",
+      "x" : 299.0,
+      "y" : 198.0
+    }, {
+      "name" : "Predator Population",
+      "type" : "aux",
+      "x" : 535.0,
+      "y" : 150.0
+    }, {
+      "name" : "Area",
+      "type" : "aux",
+      "x" : 246.0,
+      "y" : 256.0
+    }, {
+      "name" : "Deer Killed per Predator",
+      "type" : "aux",
+      "x" : 440.0,
+      "y" : 195.0
+    }, {
+      "name" : "Initial Deer Density",
+      "type" : "aux",
+      "x" : 557.0,
+      "y" : 244.0
+    } ],
+    "connectors" : [ {
+      "from" : "Deer Population",
+      "to" : "Deer Net Growth Rate"
+    }, {
+      "from" : "Deer Population",
+      "to" : "Deer Density"
+    }, {
+      "from" : "Predator Population",
+      "to" : "Deer Predation Rate"
+    }, {
+      "from" : "Area",
+      "to" : "Deer Density"
+    }, {
+      "from" : "Growth Rate Factor",
+      "to" : "Deer Net Growth Rate"
+    }, {
+      "from" : "Deer Density",
+      "to" : "Deer Killed per Predator"
+    }, {
+      "from" : "Deer Killed per Predator",
+      "to" : "Deer Predation Rate"
+    }, {
+      "from" : "Initial Deer Density",
+      "to" : "Deer Killed per Predator"
+    } ],
+    "flowRoutes" : [ {
+      "flowName" : "_48",
+      "points" : [ [ 132.0, 92.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 410.0, 94.0 ] ]
+    } ]
+  } ],
+  "defaultSimulation" : {
+    "timeStep" : "Year",
+    "duration" : 50.0,
+    "durationUnit" : "Year",
+    "initialTime" : 1900.0
+  },
+  "metadata" : {
+    "author" : "Dr. Erik Pruyt",
+    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license" : "CC-BY-NC-SA-4.0",
+    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/18_04"
+  }
+}

--- a/courant-app/src/main/resources/models/ecology/muskrat-plague.json
+++ b/courant-app/src/main/resources/models/ecology/muskrat-plague.json
@@ -1,0 +1,164 @@
+{
+  "name" : "0602Muskrats1",
+  "stocks" : [ {
+    "name" : "Muskrat population",
+    "comment" : "Muskrat population",
+    "initialValue" : 100.0,
+    "unit" : "Muskrats"
+  } ],
+  "flows" : [ {
+    "name" : "Muskrat population inflow 1",
+    "equation" : "New_Muskrats",
+    "timeUnit" : "Year",
+    "sink" : "Muskrat population"
+  }, {
+    "name" : "Muskrat population outflow 2",
+    "equation" : "Muskrats_caught",
+    "timeUnit" : "Year",
+    "source" : "Muskrat population"
+  } ],
+  "variables" : [ {
+    "name" : "Muskrats caught",
+    "comment" : "Muskrats caught",
+    "equation" : "Muskrats_caught_per_trap*Traps_per_license* Number_of_licenses",
+    "unit" : "Muskrats/Year"
+  }, {
+    "name" : "Initial number of muskrats",
+    "comment" : "Initial number of muskrats",
+    "equation" : "100",
+    "unit" : "Muskrats"
+  }, {
+    "name" : "Number of licenses",
+    "comment" : "10",
+    "equation" : "10",
+    "unit" : "licenses/Year"
+  }, {
+    "name" : "Muskrats caught per trap",
+    "comment" : "Muskrats caught per trap",
+    "equation" : "Muskrat_population * Proportionality_factor",
+    "unit" : "Muskrats/traps"
+  }, {
+    "name" : "New muskrats rate",
+    "comment" : "New muskrats rate",
+    "equation" : "20",
+    "unit" : "1/Year"
+  }, {
+    "name" : "New Muskrats",
+    "comment" : "New Muskrats",
+    "equation" : "New_muskrats_rate*Muskrat_population",
+    "unit" : "Muskrats/Year"
+  }, {
+    "name" : "Proportionality factor",
+    "comment" : "Proportionality factor",
+    "equation" : "0.195",
+    "unit" : "1/traps"
+  }, {
+    "name" : "Traps per license",
+    "comment" : "Traps per license",
+    "equation" : "10",
+    "unit" : "traps/licenses"
+  } ],
+  "views" : [ {
+    "name" : "View 1",
+    "elements" : [ {
+      "name" : "Muskrat population",
+      "type" : "stock",
+      "x" : 222.0,
+      "y" : 142.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 111.0,
+      "y" : 144.0
+    }, {
+      "name" : "New Muskrats",
+      "type" : "aux",
+      "x" : 111.0,
+      "y" : 163.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 335.0,
+      "y" : 141.0
+    }, {
+      "name" : "Muskrats caught",
+      "type" : "aux",
+      "x" : 335.0,
+      "y" : 160.0
+    }, {
+      "name" : "New muskrats rate",
+      "type" : "aux",
+      "x" : 80.0,
+      "y" : 91.0
+    }, {
+      "name" : "Traps per license",
+      "type" : "aux",
+      "x" : 373.0,
+      "y" : 250.0
+    }, {
+      "name" : "Number of licenses",
+      "type" : "aux",
+      "x" : 416.0,
+      "y" : 205.0
+    }, {
+      "name" : "Muskrats caught per trap",
+      "type" : "aux",
+      "x" : 283.0,
+      "y" : 220.0
+    }, {
+      "name" : "Proportionality factor",
+      "type" : "aux",
+      "x" : 159.0,
+      "y" : 258.0
+    }, {
+      "name" : "Initial number of muskrats",
+      "type" : "aux",
+      "x" : 133.0,
+      "y" : 206.0
+    } ],
+    "connectors" : [ {
+      "from" : "Muskrat population",
+      "to" : "_48"
+    }, {
+      "from" : "New muskrats rate",
+      "to" : "_48"
+    }, {
+      "from" : "Muskrat population",
+      "to" : "Muskrats caught per trap"
+    }, {
+      "from" : "Proportionality factor",
+      "to" : "Muskrats caught per trap"
+    }, {
+      "from" : "Muskrats caught per trap",
+      "to" : "Muskrats caught"
+    }, {
+      "from" : "Number of licenses",
+      "to" : "Muskrats caught"
+    }, {
+      "from" : "Traps per license",
+      "to" : "Muskrats caught"
+    }, {
+      "from" : "Initial number of muskrats",
+      "to" : "Muskrat population"
+    } ],
+    "flowRoutes" : [ {
+      "flowName" : "_48",
+      "points" : [ [ 111.0, 144.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 335.0, 141.0 ] ]
+    } ]
+  } ],
+  "defaultSimulation" : {
+    "timeStep" : "Year",
+    "duration" : 10.0,
+    "durationUnit" : "Year",
+    "dt" : 0.0625
+  },
+  "metadata" : {
+    "author" : "Dr. Erik Pruyt",
+    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license" : "CC-BY-NC-SA-4.0",
+    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/06_02"
+  }
+}

--- a/courant-app/src/main/resources/models/introductory/cocaine-flow.json
+++ b/courant-app/src/main/resources/models/introductory/cocaine-flow.json
@@ -1,0 +1,119 @@
+{
+  "name" : "0601Cocaine_model",
+  "stocks" : [ {
+    "name" : "Cocaine",
+    "comment" : "Cocaine",
+    "initialValue" : 20000.0,
+    "unit" : "kg"
+  } ],
+  "flows" : [ {
+    "name" : "Cocaine inflow 1",
+    "equation" : "imports",
+    "timeUnit" : "Month",
+    "sink" : "Cocaine"
+  }, {
+    "name" : "Cocaine outflow 2",
+    "equation" : "confiscation",
+    "timeUnit" : "Month",
+    "source" : "Cocaine"
+  }, {
+    "name" : "Cocaine outflow 3",
+    "equation" : "use",
+    "timeUnit" : "Month",
+    "source" : "Cocaine"
+  } ],
+  "variables" : [ {
+    "name" : "confiscation",
+    "comment" : "confiscation",
+    "equation" : "Cocaine*confiscation_rate",
+    "unit" : "kg/Month"
+  }, {
+    "name" : "confiscation rate",
+    "comment" : "confiscation rate",
+    "equation" : "0.1",
+    "unit" : "1/Month"
+  }, {
+    "name" : "imports",
+    "comment" : "imports",
+    "equation" : "4000",
+    "unit" : "kg/Month"
+  }, {
+    "name" : "use",
+    "comment" : "use",
+    "equation" : "3000",
+    "unit" : "kg/Month"
+  } ],
+  "views" : [ {
+    "name" : "View 1",
+    "elements" : [ {
+      "name" : "Cocaine",
+      "type" : "stock",
+      "x" : 302.0,
+      "y" : 171.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 199.0,
+      "y" : 171.0
+    }, {
+      "name" : "imports",
+      "type" : "aux",
+      "x" : 199.0,
+      "y" : 190.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 303.0,
+      "y" : 246.0
+    }, {
+      "name" : "use",
+      "type" : "aux",
+      "x" : 323.0,
+      "y" : 246.0
+    }, {
+      "name" : "_48",
+      "type" : "flow",
+      "x" : 423.0,
+      "y" : 173.0
+    }, {
+      "name" : "confiscation",
+      "type" : "aux",
+      "x" : 423.0,
+      "y" : 192.0
+    }, {
+      "name" : "confiscation rate",
+      "type" : "aux",
+      "x" : 478.0,
+      "y" : 255.0
+    } ],
+    "connectors" : [ {
+      "from" : "confiscation rate",
+      "to" : "confiscation"
+    }, {
+      "from" : "Cocaine",
+      "to" : "_48"
+    } ],
+    "flowRoutes" : [ {
+      "flowName" : "_48",
+      "points" : [ [ 199.0, 171.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 303.0, 246.0 ] ]
+    }, {
+      "flowName" : "_48",
+      "points" : [ [ 423.0, 173.0 ] ]
+    } ]
+  } ],
+  "defaultSimulation" : {
+    "timeStep" : "Month",
+    "duration" : 24.0,
+    "durationUnit" : "Month",
+    "dt" : 0.0625
+  },
+  "metadata" : {
+    "author" : "Dr. Erik Pruyt",
+    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license" : "CC-BY-NC-SA-4.0",
+    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/06_01"
+  }
+}

--- a/courant-tools/src/main/resources/manifests/tudelft-pruyt-samples.json
+++ b/courant-tools/src/main/resources/manifests/tudelft-pruyt-samples.json
@@ -2,7 +2,8 @@
   {
     "url": "https://simulation.tudelft.nl/SD/model_files_nested/06_01/0601Cocaine_model.mdl",
     "className": "CocaineFlowDemo",
-    "category": null,
+    "id": "cocaine-flow",
+    "category": "introductory",
     "comment": "Simple drug flow model: a single cocaine stock with constant import and use rates, and a confiscation rate proportional to the stock. Demonstrates basic stock-and-flow structure with a balancing feedback loop.",
     "metadata": {
       "author": "Dr. Erik Pruyt",
@@ -14,7 +15,8 @@
   {
     "url": "https://simulation.tudelft.nl/SD/model_files_nested/06_02/0602Muskrats1.mdl",
     "className": "MuskratPlagueDemo",
-    "category": null,
+    "id": "muskrat-plague",
+    "category": "ecology",
     "comment": "Muskrat population dynamics with trapping. A single population stock grows at a fixed per-capita rate and is reduced by trapping, where catch depends on population size, trap count, and licensing. Illustrates negative feedback through harvest pressure.",
     "metadata": {
       "author": "Dr. Erik Pruyt",
@@ -26,7 +28,8 @@
   {
     "url": "https://simulation.tudelft.nl/SD/model_files_nested/18_04/1804_Kaibab1.mdl",
     "className": "KaibabDeerDemo",
-    "category": null,
+    "id": "kaibab-deer",
+    "category": "ecology",
     "comment": "Deer population on the Kaibab Plateau (1900-1950). Models deer population growth limited by predation from a fixed predator population, using a lookup table to relate deer density to predator kill rate. Classic ecology case study.",
     "metadata": {
       "author": "Dr. Erik Pruyt",
@@ -38,7 +41,8 @@
   {
     "url": "https://simulation.tudelft.nl/SD/model_files_nested/14_12/1412_OverfishingOfNBFTunaEN.mdl",
     "className": "BluefinTunaOverfishingDemo",
-    "category": null,
+    "id": "bluefin-tuna-overfishing",
+    "category": "ecology",
     "comment": "Two-stock model of Northern Bluefin Tuna overfishing. Tuna biomass grows via recruitment and natural growth, depleted by catch. Fishing fleet size adjusts based on perceived tuna availability, creating a reinforcing overshoot-and-collapse dynamic.",
     "metadata": {
       "author": "Dr. Erik Pruyt",
@@ -50,7 +54,8 @@
   {
     "url": "https://simulation.tudelft.nl/SD/model_files_nested/06_03/0603EcOvershootCollapseBasedOnEZ416Bossel.mdl",
     "className": "EcologicalOvershootDemo",
-    "category": null,
+    "id": "ecological-overshoot",
+    "category": "ecology",
     "comment": "Ecological overshoot and collapse model based on Bossel. A consumer population grows by consuming a renewable resource; resource depletion reduces population lifetime, creating classic overshoot-and-collapse dynamics.",
     "metadata": {
       "author": "Dr. Erik Pruyt",


### PR DESCRIPTION
## Summary
- Ran `BatchImportCli --json-only --overwrite` against the TU Delft Pruyt manifest
- All 5 models regenerated successfully with latest parser/compiler improvements
- Updated manifest with `id` and `category` fields for each model
- Added all 5 models to `catalog.json` with element counts and tags

New example models:
- **cocaine-flow** (introductory) — simple stock-and-flow with balancing feedback
- **muskrat-plague** (ecology) — population dynamics with trapping
- **kaibab-deer** (ecology) — deer population with predation lookup
- **bluefin-tuna-overfishing** (ecology) — two-stock overshoot and collapse
- **ecological-overshoot** (ecology) — consumer-resource depletion dynamics

Closes #1123

## Test plan
- [x] All 5 models imported successfully (BatchImportCli summary: 5/5 succeeded)
- [x] Full test suite passes
- [x] SpotBugs clean