### PR TITLE
Loop-aware CLD layout and edge routing (#1195)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
@@ -4,6 +4,8 @@ import systems.courant.sd.model.def.ElementPlacement;
 import systems.courant.sd.model.def.ElementType;
 import systems.courant.sd.model.def.ViewDef;
 
+import systems.courant.sd.model.graph.CldLoopInfo;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -41,6 +43,7 @@ public class CanvasState {
     private final Object drawOrderLock = new Object();
     private List<String> drawOrderCache;
     private String viewName = DEFAULT_VIEW_NAME;
+    private CldLoopInfo cldLoopInfo;
 
     /**
      * Loads element positions and types from a ViewDef, clearing any previous state.
@@ -50,6 +53,7 @@ public class CanvasState {
         types.clear();
         sizes.clear();
         selection.clear();
+        cldLoopInfo = null;
         viewName = view.name();
 
         synchronized (drawOrderLock) {
@@ -231,6 +235,20 @@ public class CanvasState {
      */
     public Set<String> getSelection() {
         return Collections.unmodifiableSet(selection);
+    }
+
+    /**
+     * Returns the CLD loop membership info, or null if not set.
+     */
+    public CldLoopInfo getCldLoopInfo() {
+        return cldLoopInfo;
+    }
+
+    /**
+     * Sets the CLD loop membership info for loop-aware edge routing.
+     */
+    public void setCldLoopInfo(CldLoopInfo loopInfo) {
+        this.cldLoopInfo = loopInfo;
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CausalLinkGeometry.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CausalLinkGeometry.java
@@ -2,10 +2,15 @@ package systems.courant.sd.app.canvas;
 
 import systems.courant.sd.model.def.CausalLinkDef;
 import systems.courant.sd.model.def.CldVariableDef;
+import systems.courant.sd.model.def.ElementType;
+import systems.courant.sd.model.graph.CldLoopInfo;
 
 import javafx.scene.canvas.GraphicsContext;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Geometry utilities for curved causal links using quadratic Bézier curves.
@@ -229,7 +234,7 @@ public final class CausalLinkGeometry {
         double px = -ny;
         double py = nx;
 
-        double r = SELF_LOOP_RADIUS * 1.5;
+        double r = 1.5 * Math.max(halfW, halfH);
         double spread = Math.max(halfW, halfH) * 0.5;
 
         double startX = cx + px * spread;
@@ -270,6 +275,232 @@ public final class CausalLinkGeometry {
             return null;
         }
         return new double[]{sumX / count, sumY / count};
+    }
+
+    /**
+     * Pre-computed loop context for edge routing. Holds the loop membership
+     * info, per-loop centroids, and the global centroid so that each edge
+     * can be routed using the appropriate reference point.
+     */
+    public record LoopContext(
+            CldLoopInfo loopInfo,
+            Map<Integer, double[]> loopCentroids,
+            double globalCentroidX,
+            double globalCentroidY
+    ) {
+        /**
+         * Returns the centroid to use for an edge between the two named nodes.
+         * Same-loop edges use the loop centroid; cross-loop, shared-node, or
+         * non-loop edges use the global centroid.
+         */
+        public double[] centroidFor(String fromName, String toName) {
+            if (loopInfo != null && !loopInfo.isEmpty()) {
+                if (!loopInfo.isSharedNode(fromName) && !loopInfo.isSharedNode(toName)) {
+                    int common = loopInfo.commonLoopIndex(fromName, toName);
+                    if (common >= 0) {
+                        double[] lc = loopCentroids.get(common);
+                        if (lc != null) {
+                            return lc;
+                        }
+                    }
+                }
+            }
+            return new double[]{globalCentroidX, globalCentroidY};
+        }
+
+        /**
+         * Returns the bulge factor (k) for an edge between the two named nodes.
+         * Same-loop: 0.6, cross-loop: 0.25, default: 0.35.
+         */
+        public double bulgeFactorFor(String fromName, String toName) {
+            if (loopInfo == null || loopInfo.isEmpty()) {
+                return 0.35;
+            }
+            if (loopInfo.isSharedNode(fromName) || loopInfo.isSharedNode(toName)) {
+                return 0.25;
+            }
+            if (loopInfo.commonLoopIndex(fromName, toName) >= 0) {
+                return 0.6;
+            }
+            if (!loopInfo.loopsOf(fromName).isEmpty()
+                    && !loopInfo.loopsOf(toName).isEmpty()) {
+                return 0.25;
+            }
+            return 0.35;
+        }
+
+        /**
+         * Returns the centroid to use for a self-loop on the named node.
+         */
+        public double[] selfLoopCentroid(String name) {
+            if (loopInfo != null && !loopInfo.isEmpty()) {
+                Set<Integer> loops = loopInfo.loopsOf(name);
+                if (!loops.isEmpty()) {
+                    int idx = loops.iterator().next();
+                    double[] lc = loopCentroids.get(idx);
+                    if (lc != null) {
+                        return lc;
+                    }
+                }
+            }
+            return new double[]{globalCentroidX, globalCentroidY};
+        }
+    }
+
+    /**
+     * Creates a LoopContext from the canvas state and CLD variable list.
+     */
+    public static LoopContext loopContext(CanvasState state,
+                                          List<CldVariableDef> cldVariables) {
+        CldLoopInfo loopInfo = state.getCldLoopInfo();
+        double[] gc = graphCentroid(state, cldVariables);
+        double gx = gc != null ? gc[0] : Double.NaN;
+        double gy = gc != null ? gc[1] : Double.NaN;
+        Map<Integer, double[]> loopCentroids = computeLoopCentroids(loopInfo, state);
+        return new LoopContext(loopInfo, loopCentroids, gx, gy);
+    }
+
+    /**
+     * Creates a LoopContext from canvas state alone, computing the global
+     * centroid from CLD_VARIABLE elements on the canvas.
+     */
+    public static LoopContext loopContext(CanvasState state) {
+        CldLoopInfo loopInfo = state.getCldLoopInfo();
+        double sx = 0, sy = 0;
+        int count = 0;
+        for (String name : state.getDrawOrder()) {
+            if (state.getType(name).orElse(null) == ElementType.CLD_VARIABLE) {
+                double x = state.getX(name);
+                double y = state.getY(name);
+                if (!Double.isNaN(x) && !Double.isNaN(y)) {
+                    sx += x;
+                    sy += y;
+                    count++;
+                }
+            }
+        }
+        double gx = count > 0 ? sx / count : Double.NaN;
+        double gy = count > 0 ? sy / count : Double.NaN;
+        Map<Integer, double[]> loopCentroids = computeLoopCentroids(loopInfo, state);
+        return new LoopContext(loopInfo, loopCentroids, gx, gy);
+    }
+
+    private static Map<Integer, double[]> computeLoopCentroids(CldLoopInfo loopInfo,
+                                                                CanvasState state) {
+        Map<Integer, double[]> result = new LinkedHashMap<>();
+        if (loopInfo == null || loopInfo.isEmpty()) {
+            return result;
+        }
+        for (int i = 0; i < loopInfo.loops().size(); i++) {
+            double lsx = 0, lsy = 0;
+            int lcnt = 0;
+            for (String node : loopInfo.loops().get(i)) {
+                double x = state.getX(node);
+                double y = state.getY(node);
+                if (!Double.isNaN(x) && !Double.isNaN(y)) {
+                    lsx += x;
+                    lsy += y;
+                    lcnt++;
+                }
+            }
+            if (lcnt > 0) {
+                result.put(i, new double[]{lsx / lcnt, lsy / lcnt});
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Loop-aware control point. Uses per-loop centroids for intra-loop edges
+     * (k=0.6) and the global centroid for cross-loop edges (k=0.25).
+     */
+    public static ControlPoint controlPoint(double fromX, double fromY,
+                                             double toX, double toY,
+                                             String fromName, String toName,
+                                             List<CausalLinkDef> allLinks,
+                                             LoopContext loopCtx) {
+        if (loopCtx == null || Double.isNaN(loopCtx.globalCentroidX())) {
+            return controlPoint(fromX, fromY, toX, toY, fromName, toName, allLinks);
+        }
+
+        if (fromName.equals(toName)) {
+            return new ControlPoint(fromX, fromY - SELF_LOOP_RADIUS * 2);
+        }
+
+        double midX = (fromX + toX) / 2;
+        double midY = (fromY + toY) / 2;
+
+        double dx = toX - fromX;
+        double dy = toY - fromY;
+        double chordLen = Math.sqrt(dx * dx + dy * dy);
+
+        if (chordLen < 1) {
+            return new ControlPoint(midX, midY);
+        }
+
+        boolean canonical = fromName.compareTo(toName) < 0;
+        double cdx = canonical ? dx : -dx;
+        double cdy = canonical ? dy : -dy;
+        double perpX = -cdy / chordLen;
+        double perpY = cdx / chordLen;
+
+        double[] centroid = loopCtx.centroidFor(fromName, toName);
+        double k = loopCtx.bulgeFactorFor(fromName, toName);
+
+        double outDx = midX - centroid[0];
+        double outDy = midY - centroid[1];
+        double outDist = Math.sqrt(outDx * outDx + outDy * outDy);
+
+        double finalDirX;
+        double finalDirY;
+
+        if (outDist < 1) {
+            finalDirX = perpX;
+            finalDirY = perpY;
+        } else {
+            double outNx = outDx / outDist;
+            double outNy = outDy / outDist;
+
+            double dot = outNx * perpX + outNy * perpY;
+            if (dot < 0) {
+                perpX = -perpX;
+                perpY = -perpY;
+                dot = -dot;
+            }
+
+            double w = Math.min(1, dot);
+            finalDirX = perpX * (1 - w) + outNx * w;
+            finalDirY = perpY * (1 - w) + outNy * w;
+            double finalLen = Math.sqrt(finalDirX * finalDirX + finalDirY * finalDirY);
+            if (finalLen > 0.001) {
+                finalDirX /= finalLen;
+                finalDirY /= finalLen;
+            }
+        }
+
+        double bulge = k * chordLen;
+        bulge = Math.min(bulge, 120);
+
+        int direction = curveDirection(fromName, toName, allLinks);
+
+        return new ControlPoint(
+                midX + finalDirX * bulge * direction,
+                midY + finalDirY * bulge * direction
+        );
+    }
+
+    /**
+     * Loop-aware self-loop geometry. Uses the loop-specific centroid for
+     * radial direction and 1.5 × node radius for offset distance.
+     */
+    public static double[] selfLoopPoints(double cx, double cy,
+                                           double halfW, double halfH,
+                                           LoopContext loopCtx, String nodeName) {
+        if (loopCtx == null) {
+            return selfLoopPoints(cx, cy, halfW, halfH);
+        }
+        double[] centroid = loopCtx.selfLoopCentroid(nodeName);
+        return selfLoopPoints(cx, cy, halfW, halfH, centroid[0], centroid[1]);
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ExportBounds.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ExportBounds.java
@@ -83,10 +83,8 @@ final class ExportBounds {
 
         // Include causal link polarity label positions
         List<CausalLinkDef> allLinks = editor.getCausalLinks();
-        double[] centroid = CausalLinkGeometry.graphCentroid(
+        CausalLinkGeometry.LoopContext loopCtx = CausalLinkGeometry.loopContext(
                 canvasState, editor.getCldVariables());
-        double gx = centroid != null ? centroid[0] : Double.NaN;
-        double gy = centroid != null ? centroid[1] : Double.NaN;
         for (CausalLinkDef link : allLinks) {
             String fromName = link.from();
             String toName = link.to();
@@ -101,7 +99,7 @@ final class ExportBounds {
                 // Self-loop: label at cubic midpoint with y offset
                 double halfW = LayoutMetrics.effectiveWidth(canvasState, fromName) / 2;
                 double halfH = LayoutMetrics.effectiveHeight(canvasState, fromName) / 2;
-                double[] loopPts = CausalLinkGeometry.selfLoopPoints(fromX, fromY, halfW, halfH, gx, gy);
+                double[] loopPts = CausalLinkGeometry.selfLoopPoints(fromX, fromY, halfW, halfH, loopCtx, fromName);
                 double[] midPt = CausalLinkGeometry.evaluateCubic(
                         loopPts[0], loopPts[1], loopPts[2], loopPts[3],
                         loopPts[4], loopPts[5], loopPts[6], loopPts[7], 0.5);
@@ -125,7 +123,7 @@ final class ExportBounds {
             }
 
             CausalLinkGeometry.ControlPoint cp = CausalLinkGeometry.controlPoint(
-                    fromX, fromY, toX, toY, fromName, toName, allLinks, gx, gy);
+                    fromX, fromY, toX, toY, fromName, toName, allLinks, loopCtx);
             double[] labelPt = CausalLinkGeometry.evaluate(
                     fromX, fromY, cp.x(), cp.y(), toX, toY, POLARITY_LABEL_T);
             double[] labelTan = CausalLinkGeometry.tangent(

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/HitTester.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/HitTester.java
@@ -204,8 +204,8 @@ public final class HitTester {
     public static ConnectionId hitTestCausalLink(CanvasState state,
                                                   List<CausalLinkDef> causalLinks,
                                                   double worldX, double worldY) {
-        return hitTestCausalLink(state, causalLinks, worldX, worldY, false,
-                Double.NaN, Double.NaN);
+        CausalLinkGeometry.LoopContext loopCtx = CausalLinkGeometry.loopContext(state);
+        return hitTestCausalLink(state, causalLinks, worldX, worldY, false, loopCtx);
     }
 
     /**
@@ -217,8 +217,8 @@ public final class HitTester {
                                                   List<CausalLinkDef> causalLinks,
                                                   double worldX, double worldY,
                                                   boolean hideVariables) {
-        return hitTestCausalLink(state, causalLinks, worldX, worldY, hideVariables,
-                Double.NaN, Double.NaN);
+        CausalLinkGeometry.LoopContext loopCtx = CausalLinkGeometry.loopContext(state);
+        return hitTestCausalLink(state, causalLinks, worldX, worldY, hideVariables, loopCtx);
     }
 
     /**
@@ -231,6 +231,19 @@ public final class HitTester {
                                                   double worldX, double worldY,
                                                   boolean hideVariables,
                                                   double centroidX, double centroidY) {
+        CausalLinkGeometry.LoopContext loopCtx = CausalLinkGeometry.loopContext(state);
+        return hitTestCausalLink(state, causalLinks, worldX, worldY, hideVariables, loopCtx);
+    }
+
+    /**
+     * Returns the ConnectionId of the causal link at the given world coordinates,
+     * or null if no causal link is hit. Uses loop-aware curve geometry.
+     */
+    public static ConnectionId hitTestCausalLink(CanvasState state,
+                                                  List<CausalLinkDef> causalLinks,
+                                                  double worldX, double worldY,
+                                                  boolean hideVariables,
+                                                  CausalLinkGeometry.LoopContext loopCtx) {
         for (int i = causalLinks.size() - 1; i >= 0; i--) {
             CausalLinkDef link = causalLinks.get(i);
             String fromName = link.from();
@@ -255,7 +268,7 @@ public final class HitTester {
                 double halfW = LayoutMetrics.effectiveWidth(state, fromName) / 2;
                 double halfH = LayoutMetrics.effectiveHeight(state, fromName) / 2;
                 double[] lp = CausalLinkGeometry.selfLoopPoints(
-                        fromX, fromY, halfW, halfH, centroidX, centroidY);
+                        fromX, fromY, halfW, halfH, loopCtx, fromName);
                 dist = CausalLinkGeometry.pointToCubicDistance(worldX, worldY,
                         lp[0], lp[1], lp[2], lp[3], lp[4], lp[5], lp[6], lp[7]);
             } else {
@@ -263,8 +276,7 @@ public final class HitTester {
                 double toY = state.getY(toName);
 
                 CausalLinkGeometry.ControlPoint cp = CausalLinkGeometry.controlPoint(
-                        fromX, fromY, toX, toY, fromName, toName, causalLinks,
-                        centroidX, centroidY);
+                        fromX, fromY, toX, toY, fromName, toName, causalLinks, loopCtx);
 
                 FlowGeometry.Point2D clippedFrom = FlowGeometry.clipToElement(
                         state, fromName, cp.x(), cp.y());

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelCanvas.java
@@ -4,6 +4,7 @@ import systems.courant.sd.model.def.ConnectorRoute;
 import systems.courant.sd.model.def.ElementType;
 import systems.courant.sd.model.def.ValidationIssue;
 import systems.courant.sd.model.def.ViewDef;
+import systems.courant.sd.model.graph.CldLoopInfo;
 
 import javafx.application.Platform;
 import javafx.scene.canvas.Canvas;
@@ -153,6 +154,8 @@ public class ModelCanvas extends Canvas {
     public void setModel(ModelEditor editor, ViewDef view) {
         this.editor = editor;
         canvasState.loadFrom(view);
+        canvasState.setCldLoopInfo(
+                CldLoopInfo.compute(editor.getCldVariables(), editor.getCausalLinks()));
         this.connectors = editor.generateConnectors();
         invalidateAnalysis();
         redraw();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
@@ -542,10 +542,8 @@ public final class SvgExporter {
 
     private static void writeCausalLinks(PrintWriter w, CanvasState state, ModelEditor editor) {
         List<CausalLinkDef> allLinks = editor.getCausalLinks();
-        double[] centroid = CausalLinkGeometry.graphCentroid(
+        CausalLinkGeometry.LoopContext loopCtx = CausalLinkGeometry.loopContext(
                 state, editor.getCldVariables());
-        double gx = centroid != null ? centroid[0] : Double.NaN;
-        double gy = centroid != null ? centroid[1] : Double.NaN;
 
         for (CausalLinkDef link : allLinks) {
             if (!state.hasElement(link.from()) || !state.hasElement(link.to())) {
@@ -559,7 +557,7 @@ public final class SvgExporter {
             if (link.from().equals(link.to())) {
                 double halfW = LayoutMetrics.effectiveWidth(state, link.from()) / 2;
                 double halfH = LayoutMetrics.effectiveHeight(state, link.from()) / 2;
-                double[] lp = CausalLinkGeometry.selfLoopPoints(fromX, fromY, halfW, halfH, gx, gy);
+                double[] lp = CausalLinkGeometry.selfLoopPoints(fromX, fromY, halfW, halfH, loopCtx, link.from());
 
                 boolean isUnknown = link.polarity() == CausalLinkDef.Polarity.UNKNOWN;
                 Color selfLinkColor = isUnknown ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
@@ -589,7 +587,7 @@ public final class SvgExporter {
             double toY = state.getY(link.to());
 
             CausalLinkGeometry.ControlPoint cp = CausalLinkGeometry.controlPoint(
-                    fromX, fromY, toX, toY, link.from(), link.to(), allLinks, gx, gy);
+                    fromX, fromY, toX, toY, link.from(), link.to(), allLinks, loopCtx);
 
             FlowGeometry.Point2D cf = FlowGeometry.clipToElement(state, link.from(), cp.x(), cp.y());
             FlowGeometry.Point2D ct = FlowGeometry.clipToElement(state, link.to(), cp.x(), cp.y());

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CausalLinkPass.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CausalLinkPass.java
@@ -31,10 +31,8 @@ final class CausalLinkPass implements RenderPass {
         String hoveredElement = ctx.hoveredElement();
         CausalTraceAnalysis traceAnalysis = ctx.traceAnalysis();
         List<CausalLinkDef> allLinks = editor.getCausalLinks();
-        double[] centroid = CausalLinkGeometry.graphCentroid(
+        CausalLinkGeometry.LoopContext loopCtx = CausalLinkGeometry.loopContext(
                 canvasState, editor.getCldVariables());
-        double gx = centroid != null ? centroid[0] : Double.NaN;
-        double gy = centroid != null ? centroid[1] : Double.NaN;
 
         for (CausalLinkDef link : allLinks) {
             String fromName = link.from();
@@ -62,7 +60,7 @@ final class CausalLinkPass implements RenderPass {
             if (fromName.equals(toName)) {
                 double halfW = LayoutMetrics.effectiveWidth(canvasState, fromName) / 2;
                 double halfH = LayoutMetrics.effectiveHeight(canvasState, fromName) / 2;
-                double[] loopPts = CausalLinkGeometry.selfLoopPoints(fromX, fromY, halfW, halfH, gx, gy);
+                double[] loopPts = CausalLinkGeometry.selfLoopPoints(fromX, fromY, halfW, halfH, loopCtx, fromName);
                 ConnectionRenderer.drawCausalLinkSelfLoop(gc, loopPts, link.polarity());
                 if (dim) {
                     gc.restore();
@@ -75,7 +73,7 @@ final class CausalLinkPass implements RenderPass {
 
             // Compute control point for the curve
             CausalLinkGeometry.ControlPoint cp = CausalLinkGeometry.controlPoint(
-                    fromX, fromY, toX, toY, fromName, toName, allLinks, gx, gy);
+                    fromX, fromY, toX, toY, fromName, toName, allLinks, loopCtx);
 
             // Clip endpoints to element borders, aiming at the control point
             // for a more natural exit angle from the element

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/InteractionOverlayPass.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/InteractionOverlayPass.java
@@ -54,7 +54,7 @@ final class InteractionOverlayPass implements RenderPass {
     public void render(GraphicsContext gc, CanvasRenderer.RenderContext ctx) {
         List<ConnectorRoute> connectors = ctx.connectors();
         List<CausalLinkDef> allCausalLinks = ctx.editor().getCausalLinks();
-        double[] centroid = CausalLinkGeometry.graphCentroid(
+        CausalLinkGeometry.LoopContext loopCtx = CausalLinkGeometry.loopContext(
                 canvasState, ctx.editor().getCldVariables());
         boolean hideAux = ctx.hideVariables();
 
@@ -128,11 +128,11 @@ final class InteractionOverlayPass implements RenderPass {
         ConnectionId selectedConnection = ctx.selectedConnection();
         ConnectionId hoveredConnection = ctx.hoveredConnection();
         if (selectedConnection != null) {
-            drawConnectionHighlight(gc, connectors, allCausalLinks, selectedConnection, false, centroid);
+            drawConnectionHighlight(gc, connectors, allCausalLinks, selectedConnection, false, loopCtx);
         }
         if (hoveredConnection != null
                 && !hoveredConnection.equals(selectedConnection)) {
-            drawConnectionHighlight(gc, connectors, allCausalLinks, hoveredConnection, true, centroid);
+            drawConnectionHighlight(gc, connectors, allCausalLinks, hoveredConnection, true, loopCtx);
         }
 
         // Hover indicator (above loops, below selection)
@@ -329,28 +329,26 @@ final class InteractionOverlayPass implements RenderPass {
     private void drawConnectionHighlight(GraphicsContext gc, List<ConnectorRoute> connectors,
                                          List<CausalLinkDef> allLinks,
                                          ConnectionId connectionId, boolean isHover,
-                                         double[] centroid) {
-        double gx = centroid != null ? centroid[0] : Double.NaN;
-        double gy = centroid != null ? centroid[1] : Double.NaN;
+                                         CausalLinkGeometry.LoopContext loopCtx) {
         for (ConnectorRoute route : connectors) {
             if (route.from().equals(connectionId.from())
                     && route.to().equals(connectionId.to())) {
                 drawClippedHighlight(gc, connectionId.from(), connectionId.to(),
-                        isHover, false, allLinks, gx, gy);
+                        isHover, false, allLinks, loopCtx);
                 return;
             }
         }
         if (canvasState.hasElement(connectionId.from())
                 && canvasState.hasElement(connectionId.to())) {
             drawClippedHighlight(gc, connectionId.from(), connectionId.to(),
-                    isHover, true, allLinks, gx, gy);
+                    isHover, true, allLinks, loopCtx);
         }
     }
 
     private void drawClippedHighlight(GraphicsContext gc, String fromName, String toName,
                                       boolean isHover, boolean isCausalLink,
                                       List<CausalLinkDef> allLinks,
-                                      double gx, double gy) {
+                                      CausalLinkGeometry.LoopContext loopCtx) {
         if (!canvasState.hasElement(fromName) || !canvasState.hasElement(toName)) {
             return;
         }
@@ -377,7 +375,7 @@ final class InteractionOverlayPass implements RenderPass {
             }
 
             CausalLinkGeometry.ControlPoint cp = CausalLinkGeometry.controlPoint(
-                    fromX, fromY, toX, toY, fromName, toName, allLinks, gx, gy);
+                    fromX, fromY, toX, toY, fromName, toName, allLinks, loopCtx);
 
             FlowGeometry.Point2D clippedFrom = FlowGeometry.clipToElement(
                     canvasState, fromName, cp.x(), cp.y());

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/LoopHighlightPass.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/LoopHighlightPass.java
@@ -104,10 +104,8 @@ final class LoopHighlightPass implements RenderPass {
 
         // Highlight causal link edges (curved)
         List<CausalLinkDef> allLinks = editor.getCausalLinks();
-        double[] centroid = CausalLinkGeometry.graphCentroid(
+        CausalLinkGeometry.LoopContext loopCtx = CausalLinkGeometry.loopContext(
                 canvasState, editor.getCldVariables());
-        double gx = centroid != null ? centroid[0] : Double.NaN;
-        double gy = centroid != null ? centroid[1] : Double.NaN;
         for (CausalLinkDef link : allLinks) {
             String fromName = link.from();
             String toName = link.to();
@@ -130,7 +128,7 @@ final class LoopHighlightPass implements RenderPass {
                 double halfW = LayoutMetrics.effectiveWidth(canvasState, fromName) / 2;
                 double halfH = LayoutMetrics.effectiveHeight(canvasState, fromName) / 2;
                 double[] loopPts = CausalLinkGeometry.selfLoopPoints(
-                        fromX, fromY, halfW, halfH, gx, gy);
+                        fromX, fromY, halfW, halfH, loopCtx, fromName);
                 FeedbackLoopRenderer.drawLoopEdgeCubic(gc, loopPts);
                 continue;
             }
@@ -139,7 +137,7 @@ final class LoopHighlightPass implements RenderPass {
             double toY = canvasState.getY(toName);
 
             CausalLinkGeometry.ControlPoint cp = CausalLinkGeometry.controlPoint(
-                    fromX, fromY, toX, toY, fromName, toName, allLinks, gx, gy);
+                    fromX, fromY, toX, toY, fromName, toName, allLinks, loopCtx);
 
             FlowGeometry.Point2D clippedFrom = FlowGeometry.clipToElement(
                     canvasState, fromName, cp.x(), cp.y());
@@ -238,10 +236,8 @@ final class LoopHighlightPass implements RenderPass {
 
         // Highlight causal link edges in the trace (curved)
         List<CausalLinkDef> allLinks = editor.getCausalLinks();
-        double[] centroid = CausalLinkGeometry.graphCentroid(
+        CausalLinkGeometry.LoopContext traceLoopCtx = CausalLinkGeometry.loopContext(
                 canvasState, editor.getCldVariables());
-        double gx = centroid != null ? centroid[0] : Double.NaN;
-        double gy = centroid != null ? centroid[1] : Double.NaN;
         for (CausalLinkDef link : allLinks) {
             String fromName = link.from();
             String toName = link.to();
@@ -275,7 +271,7 @@ final class LoopHighlightPass implements RenderPass {
             double toY = canvasState.getY(toName);
 
             CausalLinkGeometry.ControlPoint cp = CausalLinkGeometry.controlPoint(
-                    fromX, fromY, toX, toY, fromName, toName, allLinks, gx, gy);
+                    fromX, fromY, toX, toY, fromName, toName, allLinks, traceLoopCtx);
 
             FlowGeometry.Point2D clippedFrom = FlowGeometry.clipToElement(
                     canvasState, fromName, cp.x(), cp.y());

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/CausalLinkGeometryTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/CausalLinkGeometryTest.java
@@ -5,11 +5,14 @@ import systems.courant.sd.model.def.CldVariableDef;
 import systems.courant.sd.model.def.ElementPlacement;
 import systems.courant.sd.model.def.ElementType;
 import systems.courant.sd.model.def.ViewDef;
+import systems.courant.sd.model.graph.CldLoopInfo;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -100,6 +103,122 @@ class CausalLinkGeometryTest {
             double cp2Y = lp[5]; // cp2Y
             assertThat(cp1Y).isLessThan(100);
             assertThat(cp2Y).isLessThan(100);
+        }
+    }
+
+    @Nested
+    class LoopAwareControlPoint {
+
+        @Test
+        void shouldUseLargerBulgeForSameLoopEdge() {
+            // A → B → A (same loop), k=0.6
+            List<CausalLinkDef> links = List.of(
+                    new CausalLinkDef("A", "B"),
+                    new CausalLinkDef("B", "A"));
+            CldLoopInfo loopInfo = CldLoopInfo.compute(
+                    List.of(new CldVariableDef("A"), new CldVariableDef("B")), links);
+
+            Map<Integer, double[]> loopCentroids = Map.of(0, new double[]{100, 0});
+            CausalLinkGeometry.LoopContext loopCtx = new CausalLinkGeometry.LoopContext(
+                    loopInfo, loopCentroids, 100, 0);
+
+            CausalLinkGeometry.ControlPoint cpLoop = CausalLinkGeometry.controlPoint(
+                    0, 0, 200, 0, "A", "B", links, loopCtx);
+
+            // Compare with old centroid-aware method (k=0.35)
+            CausalLinkGeometry.ControlPoint cpOld = CausalLinkGeometry.controlPoint(
+                    0, 0, 200, 0, "A", "B", links, 100, 0);
+
+            // Same-loop curve (k=0.6) should have larger offset than default (k=0.35)
+            double loopOffset = Math.abs(cpLoop.y());
+            double oldOffset = Math.abs(cpOld.y());
+            assertThat(loopOffset).isGreaterThan(oldOffset);
+        }
+
+        @Test
+        void shouldUseSmallerBulgeForCrossLoopEdge() {
+            // Loop1: A → B → A, Loop2: C → D → C, cross-edge: A → C
+            List<CausalLinkDef> links = List.of(
+                    new CausalLinkDef("A", "B"),
+                    new CausalLinkDef("B", "A"),
+                    new CausalLinkDef("C", "D"),
+                    new CausalLinkDef("D", "C"),
+                    new CausalLinkDef("A", "C"));
+            List<CldVariableDef> vars = List.of(
+                    new CldVariableDef("A"),
+                    new CldVariableDef("B"),
+                    new CldVariableDef("C"),
+                    new CldVariableDef("D"));
+            CldLoopInfo loopInfo = CldLoopInfo.compute(vars, links);
+            assertThat(loopInfo.inSameLoop("A", "C")).isFalse();
+
+            CausalLinkGeometry.LoopContext loopCtx = new CausalLinkGeometry.LoopContext(
+                    loopInfo, Map.of(), 100, 100);
+
+            // Cross-loop edges should use k=0.25 (gentle curve)
+            assertThat(loopCtx.bulgeFactorFor("A", "C")).isEqualTo(0.25);
+        }
+
+        @Test
+        void shouldUseSameLoopBulgeWhenAllInOneSCC() {
+            // A→B→A and B→C→B merge into one SCC {A,B,C}
+            // All intra-SCC edges get k=0.6
+            List<CausalLinkDef> links = List.of(
+                    new CausalLinkDef("A", "B"),
+                    new CausalLinkDef("B", "A"),
+                    new CausalLinkDef("B", "C"),
+                    new CausalLinkDef("C", "B"));
+            List<CldVariableDef> vars = List.of(
+                    new CldVariableDef("A"),
+                    new CldVariableDef("B"),
+                    new CldVariableDef("C"));
+            CldLoopInfo loopInfo = CldLoopInfo.compute(vars, links);
+
+            Map<Integer, double[]> loopCentroids = Map.of(0, new double[]{100, 100});
+            CausalLinkGeometry.LoopContext loopCtx = new CausalLinkGeometry.LoopContext(
+                    loopInfo, loopCentroids, 100, 100);
+
+            // All in same SCC → k=0.6
+            assertThat(loopCtx.bulgeFactorFor("A", "B")).isEqualTo(0.6);
+            assertThat(loopCtx.bulgeFactorFor("B", "C")).isEqualTo(0.6);
+        }
+
+        @Test
+        void shouldFallBackWhenLoopContextIsNull() {
+            List<CausalLinkDef> links = List.of(new CausalLinkDef("A", "B"));
+
+            CausalLinkGeometry.ControlPoint cp1 = CausalLinkGeometry.controlPoint(
+                    0, 0, 100, 0, "A", "B", links);
+            CausalLinkGeometry.ControlPoint cp2 = CausalLinkGeometry.controlPoint(
+                    0, 0, 100, 0, "A", "B", links, (CausalLinkGeometry.LoopContext) null);
+
+            assertThat(cp2.x()).isEqualTo(cp1.x());
+            assertThat(cp2.y()).isEqualTo(cp1.y());
+        }
+    }
+
+    @Nested
+    class LoopContextComputation {
+
+        @Test
+        void shouldComputeLoopContextFromCanvasState() {
+            CanvasState state = new CanvasState();
+            state.loadFrom(new ViewDef("test", List.of(
+                    new ElementPlacement("A", ElementType.CLD_VARIABLE, 0, 0),
+                    new ElementPlacement("B", ElementType.CLD_VARIABLE, 200, 0),
+                    new ElementPlacement("C", ElementType.CLD_VARIABLE, 100, 200)
+            ), List.of(), List.of()));
+            state.setCldLoopInfo(CldLoopInfo.compute(
+                    List.of(new CldVariableDef("A"), new CldVariableDef("B"),
+                            new CldVariableDef("C")),
+                    List.of(new CausalLinkDef("A", "B"),
+                            new CausalLinkDef("B", "C"),
+                            new CausalLinkDef("C", "A"))));
+
+            CausalLinkGeometry.LoopContext ctx = CausalLinkGeometry.loopContext(state);
+
+            assertThat(ctx.globalCentroidX()).isCloseTo(100, org.assertj.core.data.Offset.offset(1.0));
+            assertThat(ctx.loopCentroids()).isNotEmpty();
         }
     }
 

--- a/courant-engine/src/main/java/systems/courant/sd/model/graph/CldLayout.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/graph/CldLayout.java
@@ -10,7 +10,6 @@ import systems.courant.sd.model.def.ViewDef;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -21,8 +20,9 @@ import java.util.Set;
  * CLD-specific layout algorithm. Detects whether the causal link graph
  * is cyclic or a DAG and applies the appropriate placement strategy:
  * <ul>
- *   <li><b>Cyclic</b>: Seeds nodes on an ellipse and runs force-directed
- *       relaxation so feedback loops form natural circular shapes.</li>
+ *   <li><b>Cyclic</b>: Uses SCC detection for loop-aware placement, seeding
+ *       each loop's nodes on a local ellipse and running force-directed
+ *       relaxation with loop cohesion.</li>
  *   <li><b>DAG</b>: Longest-path rank assignment with evenly spaced
  *       nodes per rank (layered left-to-right).</li>
  * </ul>
@@ -41,6 +41,9 @@ public final class CldLayout {
 
     /** Centripetal pull toward center (prevents drift). */
     private static final double K_CENTER = 0.002;
+
+    /** Loop cohesion constant — gently pulls loop members toward their loop centroid. */
+    private static final double K_LOOP_COHESION = 0.005;
 
     /** Number of force-directed iterations. */
     private static final int ITERATIONS = 75;
@@ -93,13 +96,12 @@ public final class CldLayout {
             return new ViewDef("Main", placements, List.of(), List.of());
         }
 
-        // Detect cycles
-        List<Set<String>> sccs = TarjanSCC.findNonTrivial(nodes, adj);
-        boolean hasCycle = !sccs.isEmpty();
+        // Detect cycles and compute loop info
+        CldLoopInfo loopInfo = CldLoopInfo.fromAdjacency(nodes, adj);
 
         Map<String, double[]> positions;
-        if (hasCycle) {
-            positions = forceDirectedLayout(nodes, adj);
+        if (!loopInfo.isEmpty()) {
+            positions = loopAwareLayout(nodes, adj, loopInfo);
         } else {
             positions = dagLayout(nodes, adj);
         }
@@ -122,30 +124,146 @@ public final class CldLayout {
     }
 
     /**
-     * Force-directed layout for cyclic graphs. Seeds nodes on an ellipse,
-     * then iteratively applies repulsion, attraction, and centripetal forces.
+     * Force-directed layout for cyclic graphs. Uses SCC detection for
+     * loop-aware node placement.
      */
     static Map<String, double[]> forceDirectedLayout(Set<String> nodes,
                                                       Map<String, Set<String>> adj) {
-        int n = nodes.size();
-        double radius = Math.max(200, n * 40);
-        Map<String, double[]> positions = new LinkedHashMap<>();
+        CldLoopInfo loopInfo = CldLoopInfo.fromAdjacency(nodes, adj);
+        return loopAwareLayout(nodes, adj, loopInfo);
+    }
 
-        // Seed on ellipse
-        int i = 0;
-        for (String node : nodes) {
-            double angle = 2 * Math.PI * i / n;
-            positions.put(node, new double[]{
-                    CENTER_X + radius * Math.cos(angle),
-                    CENTER_Y + radius * 0.7 * Math.sin(angle)
-            });
-            i++;
+    /**
+     * Loop-aware layout: seeds nodes per-SCC on local ellipses, places shared
+     * nodes at midpoints between loop centers, then runs force-directed
+     * relaxation with loop cohesion.
+     */
+    private static Map<String, double[]> loopAwareLayout(Set<String> nodes,
+                                                          Map<String, Set<String>> adj,
+                                                          CldLoopInfo loopInfo) {
+        int n = nodes.size();
+        Map<String, double[]> positions = new LinkedHashMap<>();
+        List<Set<String>> loops = loopInfo.loops();
+        int numLoops = loops.size();
+
+        if (numLoops == 0) {
+            // No loops — single ellipse seeding (existing behavior)
+            double radius = Math.max(200, n * 40);
+            int i = 0;
+            for (String node : nodes) {
+                double angle = 2 * Math.PI * i / n;
+                positions.put(node, new double[]{
+                        CENTER_X + radius * Math.cos(angle),
+                        CENTER_Y + radius * 0.7 * Math.sin(angle)
+                });
+                i++;
+            }
+        } else {
+            // Position loop centers on a ring (single loop stays at canvas center)
+            double loopRingRadius = numLoops == 1 ? 0 : Math.max(200, numLoops * 80);
+            double[][] loopCenters = new double[numLoops][];
+            for (int li = 0; li < numLoops; li++) {
+                double angle = 2 * Math.PI * li / numLoops;
+                loopCenters[li] = new double[]{
+                        CENTER_X + loopRingRadius * Math.cos(angle),
+                        CENTER_Y + loopRingRadius * 0.7 * Math.sin(angle)
+                };
+            }
+
+            // Place non-shared nodes on local ellipses around their loop center
+            Set<String> placed = new LinkedHashSet<>();
+            for (int li = 0; li < numLoops; li++) {
+                List<String> loopNodeList = new ArrayList<>();
+                for (String node : loops.get(li)) {
+                    if (!loopInfo.isSharedNode(node)) {
+                        loopNodeList.add(node);
+                    }
+                }
+                double localRadius = Math.max(150, loopNodeList.size() * 50);
+                for (int j = 0; j < loopNodeList.size(); j++) {
+                    String node = loopNodeList.get(j);
+                    double angle = 2 * Math.PI * j / Math.max(loopNodeList.size(), 1);
+                    positions.put(node, new double[]{
+                            loopCenters[li][0] + localRadius * Math.cos(angle),
+                            loopCenters[li][1] + localRadius * 0.7 * Math.sin(angle)
+                    });
+                    placed.add(node);
+                }
+            }
+
+            // Place shared nodes at midpoint of their loop centers
+            for (Map.Entry<String, Set<Integer>> entry : loopInfo.nodeToLoops().entrySet()) {
+                String node = entry.getKey();
+                Set<Integer> indices = entry.getValue();
+                if (indices.size() > 1 && !placed.contains(node)) {
+                    double mx = 0, my = 0;
+                    for (int li : indices) {
+                        mx += loopCenters[li][0];
+                        my += loopCenters[li][1];
+                    }
+                    positions.put(node, new double[]{mx / indices.size(), my / indices.size()});
+                    placed.add(node);
+                }
+            }
+
+            // Place non-loop nodes near connected placed nodes, or on an outer ring
+            int nonLoopIdx = 0;
+            for (String node : nodes) {
+                if (placed.contains(node)) {
+                    continue;
+                }
+                double nx = CENTER_X;
+                double ny = CENTER_Y;
+                boolean foundNeighbor = false;
+                for (String neighbor : adj.getOrDefault(node, Set.of())) {
+                    double[] np = positions.get(neighbor);
+                    if (np != null) {
+                        double offsetAngle = 2 * Math.PI * nonLoopIdx / Math.max(n, 1);
+                        nx = np[0] + 100 * Math.cos(offsetAngle);
+                        ny = np[1] + 100 * Math.sin(offsetAngle);
+                        foundNeighbor = true;
+                        break;
+                    }
+                }
+                if (!foundNeighbor) {
+                    double outerRadius = Math.max(200, n * 40) * 1.5;
+                    int nonLoopCount = n - placed.size();
+                    double angle = 2 * Math.PI * nonLoopIdx / Math.max(nonLoopCount, 1);
+                    nx = CENTER_X + outerRadius * Math.cos(angle);
+                    ny = CENTER_Y + outerRadius * 0.7 * Math.sin(angle);
+                }
+                positions.put(node, new double[]{nx, ny});
+                placed.add(node);
+                nonLoopIdx++;
+            }
         }
 
+        // Force-directed relaxation with loop cohesion
         List<String> nodeList = new ArrayList<>(nodes);
         Map<String, double[]> displacements = new HashMap<>();
 
         for (int iter = 0; iter < ITERATIONS; iter++) {
+            // Compute current loop centroids for cohesion force
+            double[][] loopCentroids = null;
+            if (numLoops > 0) {
+                loopCentroids = new double[numLoops][];
+                for (int li = 0; li < numLoops; li++) {
+                    double sx = 0, sy = 0;
+                    int cnt = 0;
+                    for (String node : loops.get(li)) {
+                        double[] p = positions.get(node);
+                        if (p != null) {
+                            sx += p[0];
+                            sy += p[1];
+                            cnt++;
+                        }
+                    }
+                    loopCentroids[li] = cnt > 0
+                            ? new double[]{sx / cnt, sy / cnt}
+                            : new double[]{CENTER_X, CENTER_Y};
+                }
+            }
+
             // Reset displacements
             for (String node : nodeList) {
                 displacements.put(node, new double[]{0, 0});
@@ -212,6 +330,23 @@ public final class CldLayout {
                 double dy = CENTER_Y - p[1];
                 displacements.get(node)[0] += K_CENTER * dx;
                 displacements.get(node)[1] += K_CENTER * dy;
+            }
+
+            // Loop cohesion: pull loop members toward their loop centroid
+            if (loopCentroids != null) {
+                for (int li = 0; li < numLoops; li++) {
+                    double[] gc = loopCentroids[li];
+                    for (String node : loops.get(li)) {
+                        double[] p = positions.get(node);
+                        if (p == null) {
+                            continue;
+                        }
+                        double dx = gc[0] - p[0];
+                        double dy = gc[1] - p[1];
+                        displacements.get(node)[0] += K_LOOP_COHESION * dx;
+                        displacements.get(node)[1] += K_LOOP_COHESION * dy;
+                    }
+                }
             }
 
             // Apply displacements with damping and max displacement cap

--- a/courant-engine/src/main/java/systems/courant/sd/model/graph/CldLoopInfo.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/graph/CldLoopInfo.java
@@ -1,0 +1,110 @@
+package systems.courant.sd.model.graph;
+
+import systems.courant.sd.model.def.CausalLinkDef;
+import systems.courant.sd.model.def.CldVariableDef;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Loop membership data for CLD graphs. Identifies which nodes belong to
+ * which strongly connected components (loops) so that layout and edge
+ * routing can treat intra-loop and cross-loop edges differently.
+ *
+ * @param loops       non-trivial SCCs (size &ge; 2), each a set of node names
+ * @param nodeToLoops mapping from node name to the indices into {@code loops}
+ */
+public record CldLoopInfo(
+        List<Set<String>> loops,
+        Map<String, Set<Integer>> nodeToLoops
+) {
+
+    /** Empty instance for graphs with no feedback loops. */
+    public static final CldLoopInfo EMPTY = new CldLoopInfo(List.of(), Map.of());
+
+    /**
+     * Computes loop info from CLD variable and causal link definitions.
+     */
+    public static CldLoopInfo compute(List<CldVariableDef> vars, List<CausalLinkDef> links) {
+        if (vars.isEmpty()) {
+            return EMPTY;
+        }
+        Set<String> nodes = new LinkedHashSet<>();
+        Map<String, Set<String>> adj = new LinkedHashMap<>();
+        for (CldVariableDef v : vars) {
+            nodes.add(v.name());
+            adj.putIfAbsent(v.name(), new LinkedHashSet<>());
+        }
+        for (CausalLinkDef link : links) {
+            adj.computeIfAbsent(link.from(), k -> new LinkedHashSet<>()).add(link.to());
+        }
+        return fromAdjacency(nodes, adj);
+    }
+
+    /**
+     * Computes loop info from a pre-built adjacency graph.
+     */
+    static CldLoopInfo fromAdjacency(Set<String> nodes, Map<String, Set<String>> adj) {
+        List<Set<String>> sccs = TarjanSCC.findNonTrivial(nodes, adj);
+        if (sccs.isEmpty()) {
+            return EMPTY;
+        }
+        Map<String, Set<Integer>> ntl = new LinkedHashMap<>();
+        for (int i = 0; i < sccs.size(); i++) {
+            for (String node : sccs.get(i)) {
+                ntl.computeIfAbsent(node, k -> new LinkedHashSet<>()).add(i);
+            }
+        }
+        return new CldLoopInfo(List.copyOf(sccs), Collections.unmodifiableMap(ntl));
+    }
+
+    /**
+     * Returns true if both nodes share at least one common loop.
+     */
+    public boolean inSameLoop(String a, String b) {
+        return commonLoopIndex(a, b) >= 0;
+    }
+
+    /**
+     * Returns the index of a common loop, or -1 if the nodes share no loop.
+     */
+    public int commonLoopIndex(String a, String b) {
+        Set<Integer> la = nodeToLoops.get(a);
+        Set<Integer> lb = nodeToLoops.get(b);
+        if (la == null || lb == null) {
+            return -1;
+        }
+        for (int idx : la) {
+            if (lb.contains(idx)) {
+                return idx;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Returns true if the node belongs to more than one loop.
+     */
+    public boolean isSharedNode(String name) {
+        Set<Integer> set = nodeToLoops.get(name);
+        return set != null && set.size() > 1;
+    }
+
+    /**
+     * Returns the set of loop indices the node belongs to, or empty set.
+     */
+    public Set<Integer> loopsOf(String name) {
+        return nodeToLoops.getOrDefault(name, Set.of());
+    }
+
+    /**
+     * Returns true if there are no feedback loops.
+     */
+    public boolean isEmpty() {
+        return loops.isEmpty();
+    }
+}

--- a/courant-engine/src/test/java/systems/courant/sd/model/graph/CldLayoutTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/graph/CldLayoutTest.java
@@ -197,4 +197,91 @@ class CldLayoutTest {
             assertThat(positions).containsKeys("A", "B", "C");
         }
     }
+
+    @Nested
+    class LoopAwareLayout {
+        @Test
+        void shouldPlaceNodesFromMultipleSCCsNearDifferentCentroids() {
+            // Loop1: A → B → A, Loop2: C → D → C, cross-link: A → C
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("test")
+                    .cldVariable(new CldVariableDef("A"))
+                    .cldVariable(new CldVariableDef("B"))
+                    .cldVariable(new CldVariableDef("C"))
+                    .cldVariable(new CldVariableDef("D"))
+                    .causalLink(new CausalLinkDef("A", "B"))
+                    .causalLink(new CausalLinkDef("B", "A"))
+                    .causalLink(new CausalLinkDef("C", "D"))
+                    .causalLink(new CausalLinkDef("D", "C"))
+                    .causalLink(new CausalLinkDef("A", "C"))
+                    .build();
+
+            ViewDef view = CldLayout.layout(def);
+
+            assertThat(view.elements()).hasSize(4);
+
+            // Nodes in loop1 (A, B) should be closer to each other than to loop2 (C, D)
+            Map<String, double[]> positions = new LinkedHashMap<>();
+            for (ElementPlacement ep : view.elements()) {
+                positions.put(ep.name(), new double[]{ep.x(), ep.y()});
+            }
+
+            double distAB = dist(positions.get("A"), positions.get("B"));
+            double distCD = dist(positions.get("C"), positions.get("D"));
+            double distAC = dist(positions.get("A"), positions.get("C"));
+
+            // Intra-loop distances should be less than cross-loop distance
+            assertThat(distAB).isLessThan(distAC);
+            assertThat(distCD).isLessThan(distAC);
+        }
+
+        @Test
+        void shouldPlaceSharedNodeBetweenLoopCenters() {
+            // Loop1: A → B → A, Loop2: B → C → B
+            // B is shared between both loops
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("test")
+                    .cldVariable(new CldVariableDef("A"))
+                    .cldVariable(new CldVariableDef("B"))
+                    .cldVariable(new CldVariableDef("C"))
+                    .causalLink(new CausalLinkDef("A", "B"))
+                    .causalLink(new CausalLinkDef("B", "A"))
+                    .causalLink(new CausalLinkDef("B", "C"))
+                    .causalLink(new CausalLinkDef("C", "B"))
+                    .build();
+
+            ViewDef view = CldLayout.layout(def);
+
+            assertThat(view.elements()).hasSize(3);
+        }
+
+        @Test
+        void shouldHandleSingletonNodesOutsideLoops() {
+            // Loop: A → B → A, singleton: X (with link A → X)
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("test")
+                    .cldVariable(new CldVariableDef("A"))
+                    .cldVariable(new CldVariableDef("B"))
+                    .cldVariable(new CldVariableDef("X"))
+                    .causalLink(new CausalLinkDef("A", "B"))
+                    .causalLink(new CausalLinkDef("B", "A"))
+                    .causalLink(new CausalLinkDef("A", "X"))
+                    .build();
+
+            ViewDef view = CldLayout.layout(def);
+
+            assertThat(view.elements()).hasSize(3);
+            Set<String> names = new HashSet<>();
+            for (ElementPlacement ep : view.elements()) {
+                names.add(ep.name());
+            }
+            assertThat(names).containsExactlyInAnyOrder("A", "B", "X");
+        }
+
+        private double dist(double[] a, double[] b) {
+            double dx = a[0] - b[0];
+            double dy = a[1] - b[1];
+            return Math.sqrt(dx * dx + dy * dy);
+        }
+    }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/model/graph/CldLoopInfoTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/graph/CldLoopInfoTest.java
@@ -1,0 +1,180 @@
+package systems.courant.sd.model.graph;
+
+import systems.courant.sd.model.def.CausalLinkDef;
+import systems.courant.sd.model.def.CldVariableDef;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CldLoopInfoTest {
+
+    @Test
+    void shouldReturnEmptyForNoVariables() {
+        CldLoopInfo info = CldLoopInfo.compute(List.of(), List.of());
+        assertThat(info.isEmpty()).isTrue();
+        assertThat(info).isSameAs(CldLoopInfo.EMPTY);
+    }
+
+    @Test
+    void shouldReturnEmptyForDag() {
+        // A → B → C (no cycles)
+        List<CldVariableDef> vars = List.of(
+                new CldVariableDef("A"),
+                new CldVariableDef("B"),
+                new CldVariableDef("C"));
+        List<CausalLinkDef> links = List.of(
+                new CausalLinkDef("A", "B"),
+                new CausalLinkDef("B", "C"));
+
+        CldLoopInfo info = CldLoopInfo.compute(vars, links);
+        assertThat(info.isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldDetectSingleLoop() {
+        // A → B → C → A
+        List<CldVariableDef> vars = List.of(
+                new CldVariableDef("A"),
+                new CldVariableDef("B"),
+                new CldVariableDef("C"));
+        List<CausalLinkDef> links = List.of(
+                new CausalLinkDef("A", "B"),
+                new CausalLinkDef("B", "C"),
+                new CausalLinkDef("C", "A"));
+
+        CldLoopInfo info = CldLoopInfo.compute(vars, links);
+        assertThat(info.isEmpty()).isFalse();
+        assertThat(info.loops()).hasSize(1);
+        assertThat(info.loops().getFirst()).containsExactlyInAnyOrder("A", "B", "C");
+    }
+
+    @Nested
+    class InSameLoop {
+        @Test
+        void shouldReturnTrueForNodesInSameLoop() {
+            List<CldVariableDef> vars = List.of(
+                    new CldVariableDef("A"),
+                    new CldVariableDef("B"),
+                    new CldVariableDef("C"));
+            List<CausalLinkDef> links = List.of(
+                    new CausalLinkDef("A", "B"),
+                    new CausalLinkDef("B", "C"),
+                    new CausalLinkDef("C", "A"));
+
+            CldLoopInfo info = CldLoopInfo.compute(vars, links);
+            assertThat(info.inSameLoop("A", "B")).isTrue();
+            assertThat(info.inSameLoop("B", "C")).isTrue();
+            assertThat(info.inSameLoop("A", "C")).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalseForNodesInDifferentLoops() {
+            // Loop1: A → B → A, Loop2: C → D → C
+            List<CldVariableDef> vars = List.of(
+                    new CldVariableDef("A"),
+                    new CldVariableDef("B"),
+                    new CldVariableDef("C"),
+                    new CldVariableDef("D"));
+            List<CausalLinkDef> links = List.of(
+                    new CausalLinkDef("A", "B"),
+                    new CausalLinkDef("B", "A"),
+                    new CausalLinkDef("C", "D"),
+                    new CausalLinkDef("D", "C"));
+
+            CldLoopInfo info = CldLoopInfo.compute(vars, links);
+            assertThat(info.inSameLoop("A", "C")).isFalse();
+            assertThat(info.inSameLoop("B", "D")).isFalse();
+        }
+
+        @Test
+        void shouldReturnFalseForNodeNotInAnyLoop() {
+            List<CldVariableDef> vars = List.of(
+                    new CldVariableDef("A"),
+                    new CldVariableDef("B"),
+                    new CldVariableDef("X"));
+            List<CausalLinkDef> links = List.of(
+                    new CausalLinkDef("A", "B"),
+                    new CausalLinkDef("B", "A"),
+                    new CausalLinkDef("A", "X"));
+
+            CldLoopInfo info = CldLoopInfo.compute(vars, links);
+            assertThat(info.inSameLoop("A", "X")).isFalse();
+        }
+    }
+
+    @Nested
+    class SharedNode {
+        @Test
+        void shouldNotBeSharedWhenAllInOneSCC() {
+            // A → B → A and B → C → B merges into one SCC {A, B, C}
+            List<CldVariableDef> vars = List.of(
+                    new CldVariableDef("A"),
+                    new CldVariableDef("B"),
+                    new CldVariableDef("C"));
+            List<CausalLinkDef> links = List.of(
+                    new CausalLinkDef("A", "B"),
+                    new CausalLinkDef("B", "A"),
+                    new CausalLinkDef("B", "C"),
+                    new CausalLinkDef("C", "B"));
+
+            CldLoopInfo info = CldLoopInfo.compute(vars, links);
+            // SCCs are disjoint — all three form one SCC
+            assertThat(info.loops()).hasSize(1);
+            assertThat(info.isSharedNode("A")).isFalse();
+            assertThat(info.isSharedNode("B")).isFalse();
+            assertThat(info.isSharedNode("C")).isFalse();
+        }
+
+        @Test
+        void shouldReturnFalseForNodeNotInAnyLoop() {
+            CldLoopInfo info = CldLoopInfo.EMPTY;
+            assertThat(info.isSharedNode("X")).isFalse();
+        }
+    }
+
+    @Nested
+    class LoopsOf {
+        @Test
+        void shouldReturnEmptyForNonLoopNode() {
+            CldLoopInfo info = CldLoopInfo.EMPTY;
+            assertThat(info.loopsOf("X")).isEmpty();
+        }
+
+        @Test
+        void shouldReturnSingleLoopIndex() {
+            List<CldVariableDef> vars = List.of(
+                    new CldVariableDef("A"),
+                    new CldVariableDef("B"));
+            List<CausalLinkDef> links = List.of(
+                    new CausalLinkDef("A", "B"),
+                    new CausalLinkDef("B", "A"));
+
+            CldLoopInfo info = CldLoopInfo.compute(vars, links);
+            assertThat(info.loopsOf("A")).hasSize(1);
+        }
+
+        @Test
+        void shouldReturnOneLoopForNodeInMergedSCC() {
+            // A→B→A and B→C→B merge into one SCC
+            List<CldVariableDef> vars = List.of(
+                    new CldVariableDef("A"),
+                    new CldVariableDef("B"),
+                    new CldVariableDef("C"));
+            List<CausalLinkDef> links = List.of(
+                    new CausalLinkDef("A", "B"),
+                    new CausalLinkDef("B", "A"),
+                    new CausalLinkDef("B", "C"),
+                    new CausalLinkDef("C", "B"));
+
+            CldLoopInfo info = CldLoopInfo.compute(vars, links);
+            // All three are in one SCC
+            assertThat(info.loopsOf("B")).hasSize(1);
+            assertThat(info.loopsOf("A")).hasSize(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `CldLoopInfo` record using Tarjan SCC detection to identify feedback loops in CLD graphs
- Rewrite `CldLayout` to seed each SCC's nodes on per-loop ellipses with loop cohesion force during relaxation
- Add `LoopContext` to `CausalLinkGeometry` for loop-aware Bézier control point computation (k=0.6 intra-loop, k=0.25 cross-loop)
- Update all 7 consumer call sites (renderers, hit-tester, exporters) to use the new API
- Self-loops now offset radially outward from loop centroid by 1.5× node radius

Closes #1195

## Test plan

- [x] All existing tests pass (2361+)
- [x] SpotBugs clean
- [x] New `CldLoopInfoTest`: SCC detection, inSameLoop, isSharedNode, loopsOf queries
- [x] New `CldLayoutTest.LoopAwareLayout`: multi-SCC clustering, shared nodes, singleton nodes
- [x] New `CausalLinkGeometryTest.LoopAwareControlPoint`: bulge factors, cross-loop edges, fallback behavior
- [ ] Visual verification with existing CLD models (bankrun, cocaine, rem-aggregated)