### PR TITLE
Fix edge routing instability and clear CLD view positions (#1195)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CausalLinkGeometry.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CausalLinkGeometry.java
@@ -234,7 +234,7 @@ public final class CausalLinkGeometry {
         double px = -ny;
         double py = nx;
 
-        double r = 1.5 * Math.max(halfW, halfH);
+        double r = SELF_LOOP_RADIUS * 1.5;
         double spread = Math.max(halfW, halfH) * 0.5;
 
         double startX = cx + px * spread;
@@ -290,27 +290,16 @@ public final class CausalLinkGeometry {
     ) {
         /**
          * Returns the centroid to use for an edge between the two named nodes.
-         * Same-loop edges use the loop centroid; cross-loop, shared-node, or
-         * non-loop edges use the global centroid.
+         * Always uses the global centroid for consistency — using per-loop
+         * centroids causes visual instability when only some nodes are in loops.
          */
         public double[] centroidFor(String fromName, String toName) {
-            if (loopInfo != null && !loopInfo.isEmpty()) {
-                if (!loopInfo.isSharedNode(fromName) && !loopInfo.isSharedNode(toName)) {
-                    int common = loopInfo.commonLoopIndex(fromName, toName);
-                    if (common >= 0) {
-                        double[] lc = loopCentroids.get(common);
-                        if (lc != null) {
-                            return lc;
-                        }
-                    }
-                }
-            }
             return new double[]{globalCentroidX, globalCentroidY};
         }
 
         /**
          * Returns the bulge factor (k) for an edge between the two named nodes.
-         * Same-loop: 0.6, cross-loop: 0.25, default: 0.35.
+         * Same-loop: 0.45, cross-loop: 0.25, default: 0.35.
          */
         public double bulgeFactorFor(String fromName, String toName) {
             if (loopInfo == null || loopInfo.isEmpty()) {
@@ -320,7 +309,7 @@ public final class CausalLinkGeometry {
                 return 0.25;
             }
             if (loopInfo.commonLoopIndex(fromName, toName) >= 0) {
-                return 0.6;
+                return 0.45;
             }
             if (!loopInfo.loopsOf(fromName).isEmpty()
                     && !loopInfo.loopsOf(toName).isEmpty()) {
@@ -331,18 +320,9 @@ public final class CausalLinkGeometry {
 
         /**
          * Returns the centroid to use for a self-loop on the named node.
+         * Uses global centroid for consistency with regular edges.
          */
         public double[] selfLoopCentroid(String name) {
-            if (loopInfo != null && !loopInfo.isEmpty()) {
-                Set<Integer> loops = loopInfo.loopsOf(name);
-                if (!loops.isEmpty()) {
-                    int idx = loops.iterator().next();
-                    double[] lc = loopCentroids.get(idx);
-                    if (lc != null) {
-                        return lc;
-                    }
-                }
-            }
             return new double[]{globalCentroidX, globalCentroidY};
         }
     }

--- a/courant-app/src/main/resources/models/causal-loop/bpr0.json
+++ b/courant-app/src/main/resources/models/causal-loop/bpr0.json
@@ -1,144 +1,132 @@
 {
-  "name" : "BPR0",
-  "cldVariables" : [ {
-    "name" : "Activate Service",
-    "comment" : "Activate Service"
-  }, {
-    "name" : "dedicated facilities",
-    "comment" : "dedicated facilities"
-  }, {
-    "name" : "Dispatch Service Technician",
-    "comment" : "Dispatch Service Technician"
-  }, {
-    "name" : "Process Order",
-    "comment" : "Process Order"
-  }, {
-    "name" : "Set Program Switch",
-    "comment" : "Set Program Switch"
-  }, {
-    "name" : "Take Order",
-    "comment" : "Take Order"
-  }, {
-    "name" : "Test",
-    "comment" : "Test"
-  } ],
-  "causalLinks" : [ {
-    "from" : "Set Program Switch",
-    "to" : "Test",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "dedicated facilities",
-    "to" : "Set Program Switch",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "Process Order",
-    "to" : "dedicated facilities",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "Take Order",
-    "to" : "Process Order",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "dedicated facilities",
-    "to" : "Dispatch Service Technician",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "Dispatch Service Technician",
-    "to" : "Activate Service",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "Test",
-    "to" : "Dispatch Service Technician",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "Test",
-    "to" : "Activate Service",
-    "polarity" : "UNKNOWN"
-  } ],
-  "comments" : [ {
-    "name" : "Comment 1",
-    "text" : "Business Process ReEngineering Model 0"
-  } ],
-  "views" : [ {
-    "name" : "1",
-    "elements" : [ {
-      "name" : "Activate Service",
-      "type" : "cld_variable",
-      "x" : 842.0,
-      "y" : 417.0
-    }, {
-      "name" : "Test",
-      "type" : "cld_variable",
-      "x" : 788.0,
-      "y" : 311.0
-    }, {
-      "name" : "Set Program Switch",
-      "type" : "cld_variable",
-      "x" : 659.0,
-      "y" : 235.0
-    }, {
-      "name" : "dedicated facilities",
-      "type" : "cld_variable",
-      "x" : 395.0,
-      "y" : 207.0
-    }, {
-      "name" : "Process Order",
-      "type" : "cld_variable",
-      "x" : 282.0,
-      "y" : 151.0
-    }, {
-      "name" : "Take Order",
-      "type" : "cld_variable",
-      "x" : 199.0,
-      "y" : 98.0
-    }, {
-      "name" : "Dispatch Service Technician",
-      "type" : "cld_variable",
-      "x" : 508.0,
-      "y" : 342.0
-    }, {
-      "name" : "Comment 1",
-      "type" : "comment",
-      "x" : 504.0,
-      "y" : 46.0,
-      "width" : 224.0,
-      "height" : 74.0
-    } ],
-    "connectors" : [ {
-      "from" : "Set Program Switch",
-      "to" : "Test"
-    }, {
-      "from" : "dedicated facilities",
-      "to" : "Set Program Switch"
-    }, {
-      "from" : "Process Order",
-      "to" : "dedicated facilities"
-    }, {
-      "from" : "Take Order",
-      "to" : "Process Order"
-    }, {
-      "from" : "dedicated facilities",
-      "to" : "Dispatch Service Technician"
-    }, {
-      "from" : "Dispatch Service Technician",
-      "to" : "Activate Service"
-    }, {
-      "from" : "Test",
-      "to" : "Dispatch Service Technician"
-    }, {
-      "from" : "Test",
-      "to" : "Activate Service"
-    } ]
-  } ],
-  "defaultSimulation" : {
-    "timeStep" : "Month",
-    "duration" : 100.0,
-    "durationUnit" : "Month"
+  "name": "BPR0",
+  "cldVariables": [
+    {
+      "name": "Activate Service",
+      "comment": "Activate Service"
+    },
+    {
+      "name": "dedicated facilities",
+      "comment": "dedicated facilities"
+    },
+    {
+      "name": "Dispatch Service Technician",
+      "comment": "Dispatch Service Technician"
+    },
+    {
+      "name": "Process Order",
+      "comment": "Process Order"
+    },
+    {
+      "name": "Set Program Switch",
+      "comment": "Set Program Switch"
+    },
+    {
+      "name": "Take Order",
+      "comment": "Take Order"
+    },
+    {
+      "name": "Test",
+      "comment": "Test"
+    }
+  ],
+  "causalLinks": [
+    {
+      "from": "Set Program Switch",
+      "to": "Test",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "dedicated facilities",
+      "to": "Set Program Switch",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "Process Order",
+      "to": "dedicated facilities",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "Take Order",
+      "to": "Process Order",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "dedicated facilities",
+      "to": "Dispatch Service Technician",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "Dispatch Service Technician",
+      "to": "Activate Service",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "Test",
+      "to": "Dispatch Service Technician",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "Test",
+      "to": "Activate Service",
+      "polarity": "UNKNOWN"
+    }
+  ],
+  "comments": [
+    {
+      "name": "Comment 1",
+      "text": "Business Process ReEngineering Model 0"
+    }
+  ],
+  "views": [
+    {
+      "name": "1",
+      "elements": [],
+      "connectors": [
+        {
+          "from": "Set Program Switch",
+          "to": "Test"
+        },
+        {
+          "from": "dedicated facilities",
+          "to": "Set Program Switch"
+        },
+        {
+          "from": "Process Order",
+          "to": "dedicated facilities"
+        },
+        {
+          "from": "Take Order",
+          "to": "Process Order"
+        },
+        {
+          "from": "dedicated facilities",
+          "to": "Dispatch Service Technician"
+        },
+        {
+          "from": "Dispatch Service Technician",
+          "to": "Activate Service"
+        },
+        {
+          "from": "Test",
+          "to": "Dispatch Service Technician"
+        },
+        {
+          "from": "Test",
+          "to": "Activate Service"
+        }
+      ]
+    }
+  ],
+  "defaultSimulation": {
+    "timeStep": "Month",
+    "duration": 100.0,
+    "durationUnit": "Month"
   },
-  "metadata" : {
-    "author" : "Ventana Systems, Inc.",
-    "source" : "Vensim Sample Models — Business Process Reengineering",
-    "license" : "Proprietary — bundled with Vensim distribution",
-    "url" : "https://vensim.com/documentation/"
+  "metadata": {
+    "author": "Ventana Systems, Inc.",
+    "source": "Vensim Sample Models \u00e2\u20ac\u201d Business Process Reengineering",
+    "license": "Proprietary \u00e2\u20ac\u201d bundled with Vensim distribution",
+    "url": "https://vensim.com/documentation/"
   }
 }

--- a/courant-app/src/main/resources/models/causal-loop/cld-bankrun.json
+++ b/courant-app/src/main/resources/models/causal-loop/cld-bankrun.json
@@ -1,247 +1,231 @@
 {
-  "name" : "0211CLDbankrun",
-  "cldVariables" : [ {
-    "name" : "depositors and lenders fear of bank failure",
-    "comment" : "depositors' and lenders' fear of bank failure"
-  }, {
-    "name" : "exogenous net worth loss",
-    "comment" : "exogenous net worth loss"
-  }, {
-    "name" : "fixed asset loss",
-    "comment" : "fixed asset loss"
-  }, {
-    "name" : "liquid asset loss",
-    "comment" : "liquid asset loss"
-  }, {
-    "name" : "liquid deposito and loan loss",
-    "comment" : "liquid deposito and loan loss"
-  }, {
-    "name" : "net worth loss",
-    "comment" : "net worth loss"
-  }, {
-    "name" : "relative share price loss",
-    "comment" : "relative share price loss"
-  }, {
-    "name" : "fear of bank failure",
-    "comment" : "fear of bank failure"
-  }, {
-    "name" : "liquid bank reserves",
-    "comment" : "liquid bank reserves"
-  }, {
-    "name" : "perceived solvency of the bank",
-    "comment" : "perceived solvency of the bank"
-  }, {
-    "name" : "solvency of the bank",
-    "comment" : "solvency of the bank"
-  }, {
-    "name" : "tendency to withdraw personal savings",
-    "comment" : "tendency to withdraw personal savings"
-  }, {
-    "name" : "weak or uncertain economic conditions",
-    "comment" : "weak or uncertain economic conditions"
-  } ],
-  "causalLinks" : [ {
-    "from" : "fear of bank failure",
-    "to" : "tendency to withdraw personal savings",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "tendency to withdraw personal savings",
-    "to" : "perceived solvency of the bank",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "perceived solvency of the bank",
-    "to" : "fear of bank failure",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "tendency to withdraw personal savings",
-    "to" : "liquid bank reserves",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "liquid bank reserves",
-    "to" : "solvency of the bank",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "solvency of the bank",
-    "to" : "perceived solvency of the bank",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "weak or uncertain economic conditions",
-    "to" : "perceived solvency of the bank",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "weak or uncertain economic conditions",
-    "to" : "fear of bank failure",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "exogenous net worth loss",
-    "to" : "net worth loss",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "net worth loss",
-    "to" : "relative share price loss",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "relative share price loss",
-    "to" : "depositors and lenders fear of bank failure",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "depositors and lenders fear of bank failure",
-    "to" : "liquid deposito and loan loss",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "liquid deposito and loan loss",
-    "to" : "fixed asset loss",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "fixed asset loss",
-    "to" : "net worth loss",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "liquid deposito and loan loss",
-    "to" : "liquid asset loss",
-    "polarity" : "POSITIVE"
-  } ],
-  "views" : [ {
-    "name" : "View 1",
-    "elements" : [ {
-      "name" : "perceived solvency of the bank",
-      "type" : "cld_variable",
-      "x" : 239.0,
-      "y" : 119.0
-    }, {
-      "name" : "fear of bank failure",
-      "type" : "cld_variable",
-      "x" : 354.0,
-      "y" : 209.0
-    }, {
-      "name" : "tendency to withdraw personal savings",
-      "type" : "cld_variable",
-      "x" : 220.0,
-      "y" : 293.0
-    }, {
-      "name" : "liquid bank reserves",
-      "type" : "cld_variable",
-      "x" : 76.0,
-      "y" : 252.0
-    }, {
-      "name" : "solvency of the bank",
-      "type" : "cld_variable",
-      "x" : 73.0,
-      "y" : 163.0
-    }, {
-      "name" : "weak or uncertain economic conditions",
-      "type" : "cld_variable",
-      "x" : 391.0,
-      "y" : 113.0
-    }, {
-      "name" : "relative share price loss",
-      "type" : "cld_variable",
-      "x" : 723.0,
-      "y" : 97.0
-    }, {
-      "name" : "net worth loss",
-      "type" : "cld_variable",
-      "x" : 631.0,
-      "y" : 138.0
-    }, {
-      "name" : "depositors and lenders fear of bank failure",
-      "type" : "cld_variable",
-      "x" : 816.0,
-      "y" : 183.0
-    }, {
-      "name" : "liquid deposito and loan loss",
-      "type" : "cld_variable",
-      "x" : 719.0,
-      "y" : 273.0
-    }, {
-      "name" : "liquid asset loss",
-      "type" : "cld_variable",
-      "x" : 555.0,
-      "y" : 253.0
-    }, {
-      "name" : "fixed asset loss",
-      "type" : "cld_variable",
-      "x" : 627.0,
-      "y" : 220.0
-    }, {
-      "name" : "exogenous net worth loss",
-      "type" : "cld_variable",
-      "x" : 540.0,
-      "y" : 192.0
-    } ],
-    "connectors" : [ {
-      "from" : "fear of bank failure",
-      "to" : "tendency to withdraw personal savings",
-      "polarity" : "+"
-    }, {
-      "from" : "tendency to withdraw personal savings",
-      "to" : "perceived solvency of the bank",
-      "polarity" : "-"
-    }, {
-      "from" : "perceived solvency of the bank",
-      "to" : "fear of bank failure",
-      "polarity" : "-"
-    }, {
-      "from" : "tendency to withdraw personal savings",
-      "to" : "liquid bank reserves",
-      "polarity" : "-"
-    }, {
-      "from" : "liquid bank reserves",
-      "to" : "solvency of the bank",
-      "polarity" : "+"
-    }, {
-      "from" : "solvency of the bank",
-      "to" : "perceived solvency of the bank",
-      "polarity" : "+"
-    }, {
-      "from" : "weak or uncertain economic conditions",
-      "to" : "perceived solvency of the bank",
-      "polarity" : "-"
-    }, {
-      "from" : "weak or uncertain economic conditions",
-      "to" : "fear of bank failure",
-      "polarity" : "+"
-    }, {
-      "from" : "exogenous net worth loss",
-      "to" : "net worth loss",
-      "polarity" : "+"
-    }, {
-      "from" : "net worth loss",
-      "to" : "relative share price loss",
-      "polarity" : "+"
-    }, {
-      "from" : "relative share price loss",
-      "to" : "depositors and lenders fear of bank failure",
-      "polarity" : "+"
-    }, {
-      "from" : "depositors and lenders fear of bank failure",
-      "to" : "liquid deposito and loan loss",
-      "polarity" : "+"
-    }, {
-      "from" : "liquid deposito and loan loss",
-      "to" : "fixed asset loss",
-      "polarity" : "+"
-    }, {
-      "from" : "fixed asset loss",
-      "to" : "net worth loss",
-      "polarity" : "+"
-    }, {
-      "from" : "liquid deposito and loan loss",
-      "to" : "liquid asset loss",
-      "polarity" : "+"
-    } ]
-  }, {
-    "name" : "View 2"
-  } ],
-  "defaultSimulation" : {
-    "timeStep" : "Month",
-    "duration" : 100.0,
-    "durationUnit" : "Month"
+  "name": "0211CLDbankrun",
+  "cldVariables": [
+    {
+      "name": "depositors and lenders fear of bank failure",
+      "comment": "depositors' and lenders' fear of bank failure"
+    },
+    {
+      "name": "exogenous net worth loss",
+      "comment": "exogenous net worth loss"
+    },
+    {
+      "name": "fixed asset loss",
+      "comment": "fixed asset loss"
+    },
+    {
+      "name": "liquid asset loss",
+      "comment": "liquid asset loss"
+    },
+    {
+      "name": "liquid deposito and loan loss",
+      "comment": "liquid deposito and loan loss"
+    },
+    {
+      "name": "net worth loss",
+      "comment": "net worth loss"
+    },
+    {
+      "name": "relative share price loss",
+      "comment": "relative share price loss"
+    },
+    {
+      "name": "fear of bank failure",
+      "comment": "fear of bank failure"
+    },
+    {
+      "name": "liquid bank reserves",
+      "comment": "liquid bank reserves"
+    },
+    {
+      "name": "perceived solvency of the bank",
+      "comment": "perceived solvency of the bank"
+    },
+    {
+      "name": "solvency of the bank",
+      "comment": "solvency of the bank"
+    },
+    {
+      "name": "tendency to withdraw personal savings",
+      "comment": "tendency to withdraw personal savings"
+    },
+    {
+      "name": "weak or uncertain economic conditions",
+      "comment": "weak or uncertain economic conditions"
+    }
+  ],
+  "causalLinks": [
+    {
+      "from": "fear of bank failure",
+      "to": "tendency to withdraw personal savings",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "tendency to withdraw personal savings",
+      "to": "perceived solvency of the bank",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "perceived solvency of the bank",
+      "to": "fear of bank failure",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "tendency to withdraw personal savings",
+      "to": "liquid bank reserves",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "liquid bank reserves",
+      "to": "solvency of the bank",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "solvency of the bank",
+      "to": "perceived solvency of the bank",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "weak or uncertain economic conditions",
+      "to": "perceived solvency of the bank",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "weak or uncertain economic conditions",
+      "to": "fear of bank failure",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "exogenous net worth loss",
+      "to": "net worth loss",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "net worth loss",
+      "to": "relative share price loss",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "relative share price loss",
+      "to": "depositors and lenders fear of bank failure",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "depositors and lenders fear of bank failure",
+      "to": "liquid deposito and loan loss",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "liquid deposito and loan loss",
+      "to": "fixed asset loss",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "fixed asset loss",
+      "to": "net worth loss",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "liquid deposito and loan loss",
+      "to": "liquid asset loss",
+      "polarity": "POSITIVE"
+    }
+  ],
+  "views": [
+    {
+      "name": "View 1",
+      "elements": [],
+      "connectors": [
+        {
+          "from": "fear of bank failure",
+          "to": "tendency to withdraw personal savings",
+          "polarity": "+"
+        },
+        {
+          "from": "tendency to withdraw personal savings",
+          "to": "perceived solvency of the bank",
+          "polarity": "-"
+        },
+        {
+          "from": "perceived solvency of the bank",
+          "to": "fear of bank failure",
+          "polarity": "-"
+        },
+        {
+          "from": "tendency to withdraw personal savings",
+          "to": "liquid bank reserves",
+          "polarity": "-"
+        },
+        {
+          "from": "liquid bank reserves",
+          "to": "solvency of the bank",
+          "polarity": "+"
+        },
+        {
+          "from": "solvency of the bank",
+          "to": "perceived solvency of the bank",
+          "polarity": "+"
+        },
+        {
+          "from": "weak or uncertain economic conditions",
+          "to": "perceived solvency of the bank",
+          "polarity": "-"
+        },
+        {
+          "from": "weak or uncertain economic conditions",
+          "to": "fear of bank failure",
+          "polarity": "+"
+        },
+        {
+          "from": "exogenous net worth loss",
+          "to": "net worth loss",
+          "polarity": "+"
+        },
+        {
+          "from": "net worth loss",
+          "to": "relative share price loss",
+          "polarity": "+"
+        },
+        {
+          "from": "relative share price loss",
+          "to": "depositors and lenders fear of bank failure",
+          "polarity": "+"
+        },
+        {
+          "from": "depositors and lenders fear of bank failure",
+          "to": "liquid deposito and loan loss",
+          "polarity": "+"
+        },
+        {
+          "from": "liquid deposito and loan loss",
+          "to": "fixed asset loss",
+          "polarity": "+"
+        },
+        {
+          "from": "fixed asset loss",
+          "to": "net worth loss",
+          "polarity": "+"
+        },
+        {
+          "from": "liquid deposito and loan loss",
+          "to": "liquid asset loss",
+          "polarity": "+"
+        }
+      ]
+    },
+    {
+      "name": "View 2"
+    }
+  ],
+  "defaultSimulation": {
+    "timeStep": "Month",
+    "duration": 100.0,
+    "durationUnit": "Month"
   },
-  "metadata" : {
-    "author" : "Dr. Erik Pruyt",
-    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
-    "license" : "CC-BY-NC-SA-4.0",
-    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/02_11"
+  "metadata": {
+    "author": "Dr. Erik Pruyt",
+    "source": "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license": "CC-BY-NC-SA-4.0",
+    "url": "https://simulation.tudelft.nl/SD/model_files_nested/02_11"
   }
 }

--- a/courant-app/src/main/resources/models/causal-loop/cocaine-cld.json
+++ b/courant-app/src/main/resources/models/causal-loop/cocaine-cld.json
@@ -1,101 +1,96 @@
 {
-  "name" : "0601Cocaine_CLD",
-  "cldVariables" : [ {
-    "name" : "Cocaine",
-    "comment" : "Cocaine"
-  }, {
-    "name" : "confiscation",
-    "comment" : "confiscation"
-  }, {
-    "name" : "confiscation rate",
-    "comment" : "confiscation rate"
-  }, {
-    "name" : "imports",
-    "comment" : "imports"
-  }, {
-    "name" : "use",
-    "comment" : "use"
-  } ],
-  "causalLinks" : [ {
-    "from" : "imports",
-    "to" : "Cocaine",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "use",
-    "to" : "Cocaine",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "Cocaine",
-    "to" : "confiscation",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "confiscation",
-    "to" : "Cocaine",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "confiscation rate",
-    "to" : "confiscation",
-    "polarity" : "POSITIVE"
-  } ],
-  "views" : [ {
-    "name" : "View 1",
-    "elements" : [ {
-      "name" : "Cocaine",
-      "type" : "cld_variable",
-      "x" : 307.0,
-      "y" : 204.0
-    }, {
-      "name" : "imports",
-      "type" : "cld_variable",
-      "x" : 147.0,
-      "y" : 204.0
-    }, {
-      "name" : "confiscation",
-      "type" : "cld_variable",
-      "x" : 512.0,
-      "y" : 202.0
-    }, {
-      "name" : "use",
-      "type" : "cld_variable",
-      "x" : 306.0,
-      "y" : 311.0
-    }, {
-      "name" : "confiscation rate",
-      "type" : "cld_variable",
-      "x" : 570.0,
-      "y" : 298.0
-    } ],
-    "connectors" : [ {
-      "from" : "imports",
-      "to" : "Cocaine",
-      "polarity" : "+"
-    }, {
-      "from" : "use",
-      "to" : "Cocaine",
-      "polarity" : "-"
-    }, {
-      "from" : "Cocaine",
-      "to" : "confiscation",
-      "polarity" : "+"
-    }, {
-      "from" : "confiscation",
-      "to" : "Cocaine",
-      "polarity" : "-"
-    }, {
-      "from" : "confiscation rate",
-      "to" : "confiscation",
-      "polarity" : "+"
-    } ]
-  } ],
-  "defaultSimulation" : {
-    "timeStep" : "Month",
-    "duration" : 100.0,
-    "durationUnit" : "Month"
+  "name": "0601Cocaine_CLD",
+  "cldVariables": [
+    {
+      "name": "Cocaine",
+      "comment": "Cocaine"
+    },
+    {
+      "name": "confiscation",
+      "comment": "confiscation"
+    },
+    {
+      "name": "confiscation rate",
+      "comment": "confiscation rate"
+    },
+    {
+      "name": "imports",
+      "comment": "imports"
+    },
+    {
+      "name": "use",
+      "comment": "use"
+    }
+  ],
+  "causalLinks": [
+    {
+      "from": "imports",
+      "to": "Cocaine",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "use",
+      "to": "Cocaine",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "Cocaine",
+      "to": "confiscation",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "confiscation",
+      "to": "Cocaine",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "confiscation rate",
+      "to": "confiscation",
+      "polarity": "POSITIVE"
+    }
+  ],
+  "views": [
+    {
+      "name": "View 1",
+      "elements": [],
+      "connectors": [
+        {
+          "from": "imports",
+          "to": "Cocaine",
+          "polarity": "+"
+        },
+        {
+          "from": "use",
+          "to": "Cocaine",
+          "polarity": "-"
+        },
+        {
+          "from": "Cocaine",
+          "to": "confiscation",
+          "polarity": "+"
+        },
+        {
+          "from": "confiscation",
+          "to": "Cocaine",
+          "polarity": "-"
+        },
+        {
+          "from": "confiscation rate",
+          "to": "confiscation",
+          "polarity": "+"
+        }
+      ]
+    }
+  ],
+  "defaultSimulation": {
+    "timeStep": "Month",
+    "duration": 100.0,
+    "durationUnit": "Month"
   },
-  "metadata" : {
-    "author" : "Dr. Erik Pruyt",
-    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
-    "license" : "CC-BY-NC-SA-4.0",
-    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/06_01"
+  "metadata": {
+    "author": "Dr. Erik Pruyt",
+    "source": "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license": "CC-BY-NC-SA-4.0",
+    "url": "https://simulation.tudelft.nl/SD/model_files_nested/06_01"
   }
 }

--- a/courant-app/src/main/resources/models/causal-loop/competition-faculty.json
+++ b/courant-app/src/main/resources/models/causal-loop/competition-faculty.json
@@ -1,165 +1,158 @@
 {
-  "name" : "0201CompetitionFaculty",
-  "cldVariables" : [ {
-    "name" : "budget section A",
-    "comment" : "budget section A"
-  }, {
-    "name" : "budget section B",
-    "comment" : "budget section B"
-  }, {
-    "name" : "fraction of total budget to section A",
-    "comment" : "fraction of total budget to section A"
-  }, {
-    "name" : "scientific papers section A",
-    "comment" : "scientific papers section A"
-  }, {
-    "name" : "scientific papers section B",
-    "comment" : "scientific papers section B"
-  }, {
-    "name" : "scientific personnel section A",
-    "comment" : "scientific personnel section A"
-  }, {
-    "name" : "scientific personnel section B",
-    "comment" : "scientific personnel section B"
-  }, {
-    "name" : "total TPM budget",
-    "comment" : "total TPM budget"
-  } ],
-  "causalLinks" : [ {
-    "from" : "scientific papers section A",
-    "to" : "fraction of total budget to section A",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "scientific papers section B",
-    "to" : "fraction of total budget to section A",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "scientific personnel section A",
-    "to" : "scientific papers section A",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "scientific personnel section B",
-    "to" : "scientific papers section B",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "fraction of total budget to section A",
-    "to" : "budget section B",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "fraction of total budget to section A",
-    "to" : "budget section A",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "budget section A",
-    "to" : "scientific personnel section A",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "total TPM budget",
-    "to" : "budget section A",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "total TPM budget",
-    "to" : "budget section B",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "budget section B",
-    "to" : "scientific personnel section B",
-    "polarity" : "POSITIVE"
-  } ],
-  "views" : [ {
-    "name" : "View 1",
-    "elements" : [ {
-      "name" : "scientific papers section A",
-      "type" : "cld_variable",
-      "x" : 253.0,
-      "y" : 207.0
-    }, {
-      "name" : "scientific papers section B",
-      "type" : "cld_variable",
-      "x" : 446.0,
-      "y" : 206.0
-    }, {
-      "name" : "fraction of total budget to section A",
-      "type" : "cld_variable",
-      "x" : 350.0,
-      "y" : 294.0
-    }, {
-      "name" : "scientific personnel section A",
-      "type" : "cld_variable",
-      "x" : 159.0,
-      "y" : 283.0
-    }, {
-      "name" : "scientific personnel section B",
-      "type" : "cld_variable",
-      "x" : 546.0,
-      "y" : 287.0
-    }, {
-      "name" : "budget section A",
-      "type" : "cld_variable",
-      "x" : 258.0,
-      "y" : 372.0
-    }, {
-      "name" : "budget section B",
-      "type" : "cld_variable",
-      "x" : 451.0,
-      "y" : 374.0
-    }, {
-      "name" : "total TPM budget",
-      "type" : "cld_variable",
-      "x" : 361.0,
-      "y" : 424.0
-    } ],
-    "connectors" : [ {
-      "from" : "scientific papers section A",
-      "to" : "fraction of total budget to section A",
-      "polarity" : "+"
-    }, {
-      "from" : "scientific papers section B",
-      "to" : "fraction of total budget to section A",
-      "polarity" : "-"
-    }, {
-      "from" : "scientific personnel section A",
-      "to" : "scientific papers section A",
-      "polarity" : "+"
-    }, {
-      "from" : "scientific personnel section B",
-      "to" : "scientific papers section B",
-      "polarity" : "+"
-    }, {
-      "from" : "fraction of total budget to section A",
-      "to" : "budget section B",
-      "polarity" : "-"
-    }, {
-      "from" : "fraction of total budget to section A",
-      "to" : "budget section A",
-      "polarity" : "+"
-    }, {
-      "from" : "budget section A",
-      "to" : "scientific personnel section A",
-      "polarity" : "+"
-    }, {
-      "from" : "total TPM budget",
-      "to" : "budget section A",
-      "polarity" : "+"
-    }, {
-      "from" : "total TPM budget",
-      "to" : "budget section B",
-      "polarity" : "+"
-    }, {
-      "from" : "budget section B",
-      "to" : "scientific personnel section B",
-      "polarity" : "+"
-    } ]
-  } ],
-  "defaultSimulation" : {
-    "timeStep" : "Month",
-    "duration" : 100.0,
-    "durationUnit" : "Month"
+  "name": "0201CompetitionFaculty",
+  "cldVariables": [
+    {
+      "name": "budget section A",
+      "comment": "budget section A"
+    },
+    {
+      "name": "budget section B",
+      "comment": "budget section B"
+    },
+    {
+      "name": "fraction of total budget to section A",
+      "comment": "fraction of total budget to section A"
+    },
+    {
+      "name": "scientific papers section A",
+      "comment": "scientific papers section A"
+    },
+    {
+      "name": "scientific papers section B",
+      "comment": "scientific papers section B"
+    },
+    {
+      "name": "scientific personnel section A",
+      "comment": "scientific personnel section A"
+    },
+    {
+      "name": "scientific personnel section B",
+      "comment": "scientific personnel section B"
+    },
+    {
+      "name": "total TPM budget",
+      "comment": "total TPM budget"
+    }
+  ],
+  "causalLinks": [
+    {
+      "from": "scientific papers section A",
+      "to": "fraction of total budget to section A",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "scientific papers section B",
+      "to": "fraction of total budget to section A",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "scientific personnel section A",
+      "to": "scientific papers section A",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "scientific personnel section B",
+      "to": "scientific papers section B",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "fraction of total budget to section A",
+      "to": "budget section B",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "fraction of total budget to section A",
+      "to": "budget section A",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "budget section A",
+      "to": "scientific personnel section A",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "total TPM budget",
+      "to": "budget section A",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "total TPM budget",
+      "to": "budget section B",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "budget section B",
+      "to": "scientific personnel section B",
+      "polarity": "POSITIVE"
+    }
+  ],
+  "views": [
+    {
+      "name": "View 1",
+      "elements": [],
+      "connectors": [
+        {
+          "from": "scientific papers section A",
+          "to": "fraction of total budget to section A",
+          "polarity": "+"
+        },
+        {
+          "from": "scientific papers section B",
+          "to": "fraction of total budget to section A",
+          "polarity": "-"
+        },
+        {
+          "from": "scientific personnel section A",
+          "to": "scientific papers section A",
+          "polarity": "+"
+        },
+        {
+          "from": "scientific personnel section B",
+          "to": "scientific papers section B",
+          "polarity": "+"
+        },
+        {
+          "from": "fraction of total budget to section A",
+          "to": "budget section B",
+          "polarity": "-"
+        },
+        {
+          "from": "fraction of total budget to section A",
+          "to": "budget section A",
+          "polarity": "+"
+        },
+        {
+          "from": "budget section A",
+          "to": "scientific personnel section A",
+          "polarity": "+"
+        },
+        {
+          "from": "total TPM budget",
+          "to": "budget section A",
+          "polarity": "+"
+        },
+        {
+          "from": "total TPM budget",
+          "to": "budget section B",
+          "polarity": "+"
+        },
+        {
+          "from": "budget section B",
+          "to": "scientific personnel section B",
+          "polarity": "+"
+        }
+      ]
+    }
+  ],
+  "defaultSimulation": {
+    "timeStep": "Month",
+    "duration": 100.0,
+    "durationUnit": "Month"
   },
-  "metadata" : {
-    "author" : "Dr. Erik Pruyt",
-    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
-    "license" : "CC-BY-NC-SA-4.0",
-    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/02_01"
+  "metadata": {
+    "author": "Dr. Erik Pruyt",
+    "source": "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license": "CC-BY-NC-SA-4.0",
+    "url": "https://simulation.tudelft.nl/SD/model_files_nested/02_01"
   }
 }

--- a/courant-app/src/main/resources/models/causal-loop/conflict-middle-east.json
+++ b/courant-app/src/main/resources/models/causal-loop/conflict-middle-east.json
@@ -1,392 +1,345 @@
 {
-  "name" : "0210ConflictInMiddleEast",
-  "cldVariables" : [ {
-    "name" : "successful suicide attacks",
-    "comment" : "\"'successful' suicide attacks\""
-  }, {
-    "name" : "autonomy Palestinians",
-    "comment" : "autonomy Palestinians"
-  }, {
-    "name" : "preparedness to dialogue",
-    "comment" : "preparedness to dialogue"
-  }, {
-    "name" : "willingness suicide attacks",
-    "comment" : "willingness suicide attacks"
-  }, {
-    "name" : "security by shielding wall",
-    "comment" : "\"security by shielding (wall)\""
-  }, {
-    "name" : "degree of equality in negotiations",
-    "comment" : "degree of equality in negotiations"
-  }, {
-    "name" : "living conditions Palestinians",
-    "comment" : "living conditions Palestinians"
-  }, {
-    "name" : "mijn visie op europees beleid",
-    "comment" : "mijn visie op europees beleid"
-  }, {
-    "name" : "restrictions on Palestinians",
-    "comment" : "restrictions on Palestinians"
-  }, {
-    "name" : "reprisal Isi on Paln",
-    "comment" : "reprisal Isi on Paln"
-  }, {
-    "name" : "trust Isi in Paln",
-    "comment" : "trust Isi in Paln"
-  }, {
-    "name" : "trust Paln in Isi",
-    "comment" : "trust Paln in Isi"
-  }, {
-    "name" : "progress peace process",
-    "comment" : "progress peace process"
-  }, {
-    "name" : "chance of success of peace process",
-    "comment" : "chance of success of peace process"
-  } ],
-  "causalLinks" : [ {
-    "from" : "trust Isi in Paln",
-    "to" : "restrictions on Palestinians",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "restrictions on Palestinians",
-    "to" : "living conditions Palestinians",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "successful suicide attacks",
-    "to" : "trust Isi in Paln",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "successful suicide attacks",
-    "to" : "reprisal Isi on Paln",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "reprisal Isi on Paln",
-    "to" : "living conditions Palestinians",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "trust Isi in Paln",
-    "to" : "security by shielding wall",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "security by shielding wall",
-    "to" : "successful suicide attacks",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "security by shielding wall",
-    "to" : "living conditions Palestinians",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "living conditions Palestinians",
-    "to" : "willingness suicide attacks",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "willingness suicide attacks",
-    "to" : "successful suicide attacks",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "living conditions Palestinians",
-    "to" : "preparedness to dialogue",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "trust Paln in Isi",
-    "to" : "preparedness to dialogue",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "trust Isi in Paln",
-    "to" : "preparedness to dialogue",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "preparedness to dialogue",
-    "to" : "progress peace process",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "reprisal Isi on Paln",
-    "to" : "trust Paln in Isi",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "living conditions Palestinians",
-    "to" : "degree of equality in negotiations",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "degree of equality in negotiations",
-    "to" : "chance of success of peace process",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "chance of success of peace process",
-    "to" : "progress peace process",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "progress peace process",
-    "to" : "autonomy Palestinians",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "autonomy Palestinians",
-    "to" : "living conditions Palestinians",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "autonomy Palestinians",
-    "to" : "successful suicide attacks",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "progress peace process",
-    "to" : "trust Paln in Isi",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "progress peace process",
-    "to" : "trust Isi in Paln",
-    "polarity" : "UNKNOWN"
-  } ],
-  "comments" : [ {
-    "name" : "Comment 1",
-    "text" : "-"
-  }, {
-    "name" : "Comment 2",
-    "text" : "+"
-  }, {
-    "name" : "Comment 3",
-    "text" : "+"
-  }, {
-    "name" : "Comment 4",
-    "text" : "+"
-  }, {
-    "name" : "Comment 5",
-    "text" : "+"
-  }, {
-    "name" : "Comment 6",
-    "text" : "+"
-  }, {
-    "name" : "Comment 7",
-    "text" : "+"
-  }, {
-    "name" : "Comment 8",
-    "text" : "+"
-  } ],
-  "views" : [ {
-    "name" : "View 1",
-    "elements" : [ {
-      "name" : "trust Isi in Paln",
-      "type" : "cld_variable",
-      "x" : 405.0,
-      "y" : 470.0
-    }, {
-      "name" : "trust Paln in Isi",
-      "type" : "cld_variable",
-      "x" : 444.0,
-      "y" : 59.0
-    }, {
-      "name" : "successful suicide attacks",
-      "type" : "cld_variable",
-      "x" : 290.0,
-      "y" : 410.0
-    }, {
-      "name" : "living conditions Palestinians",
-      "type" : "cld_variable",
-      "x" : 431.0,
-      "y" : 276.0
-    }, {
-      "name" : "restrictions on Palestinians",
-      "type" : "cld_variable",
-      "x" : 531.0,
-      "y" : 369.0
-    }, {
-      "name" : "reprisal Isi on Paln",
-      "type" : "cld_variable",
-      "x" : 225.0,
-      "y" : 218.0
-    }, {
-      "name" : "security by shielding wall",
-      "type" : "cld_variable",
-      "x" : 431.0,
-      "y" : 370.0
-    }, {
-      "name" : "willingness suicide attacks",
-      "type" : "cld_variable",
-      "x" : 286.0,
-      "y" : 313.0
-    }, {
-      "name" : "progress peace process",
-      "type" : "cld_variable",
-      "x" : 581.0,
-      "y" : 156.0
-    }, {
-      "name" : "preparedness to dialogue",
-      "type" : "cld_variable",
-      "x" : 651.0,
-      "y" : 312.0
-    }, {
-      "name" : "Comment 1",
-      "type" : "comment",
-      "x" : 373.0,
-      "y" : 406.0,
-      "width" : 32.0,
-      "height" : 32.0
-    }, {
-      "name" : "Comment 2",
-      "type" : "comment",
-      "x" : 482.0,
-      "y" : 416.0,
-      "width" : 28.0,
-      "height" : 28.0
-    }, {
-      "name" : "Comment 3",
-      "type" : "comment",
-      "x" : 366.0,
-      "y" : 307.0,
-      "width" : 28.0,
-      "height" : 28.0
-    }, {
-      "name" : "Comment 4",
-      "type" : "comment",
-      "x" : 590.0,
-      "y" : 345.0,
-      "width" : 28.0,
-      "height" : 28.0
-    }, {
-      "name" : "Comment 5",
-      "type" : "comment",
-      "x" : 342.0,
-      "y" : 127.0,
-      "width" : 32.0,
-      "height" : 32.0
-    }, {
-      "name" : "Comment 6",
-      "type" : "comment",
-      "x" : 264.0,
-      "y" : 274.0,
-      "width" : 28.0,
-      "height" : 28.0
-    }, {
-      "name" : "Comment 7",
-      "type" : "comment",
-      "x" : 573.0,
-      "y" : 266.0,
-      "width" : 30.0,
-      "height" : 30.0
-    }, {
-      "name" : "autonomy Palestinians",
-      "type" : "cld_variable",
-      "x" : 533.0,
-      "y" : 221.0
-    }, {
-      "name" : "chance of success of peace process",
-      "type" : "cld_variable",
-      "x" : 488.0,
-      "y" : 109.0
-    }, {
-      "name" : "degree of equality in negotiations",
-      "type" : "cld_variable",
-      "x" : 400.0,
-      "y" : 169.0
-    }, {
-      "name" : "Comment 8",
-      "type" : "comment",
-      "x" : 492.0,
-      "y" : 178.0,
-      "width" : 30.0,
-      "height" : 30.0
-    } ],
-    "connectors" : [ {
-      "from" : "trust Isi in Paln",
-      "to" : "restrictions on Palestinians",
-      "polarity" : "-"
-    }, {
-      "from" : "restrictions on Palestinians",
-      "to" : "living conditions Palestinians",
-      "polarity" : "-"
-    }, {
-      "from" : "successful suicide attacks",
-      "to" : "trust Isi in Paln",
-      "polarity" : "-"
-    }, {
-      "from" : "successful suicide attacks",
-      "to" : "reprisal Isi on Paln",
-      "polarity" : "+"
-    }, {
-      "from" : "reprisal Isi on Paln",
-      "to" : "living conditions Palestinians",
-      "polarity" : "-"
-    }, {
-      "from" : "trust Isi in Paln",
-      "to" : "security by shielding wall",
-      "polarity" : "-"
-    }, {
-      "from" : "security by shielding wall",
-      "to" : "successful suicide attacks",
-      "polarity" : "-"
-    }, {
-      "from" : "security by shielding wall",
-      "to" : "living conditions Palestinians",
-      "polarity" : "-"
-    }, {
-      "from" : "living conditions Palestinians",
-      "to" : "willingness suicide attacks",
-      "polarity" : "-"
-    }, {
-      "from" : "willingness suicide attacks",
-      "to" : "successful suicide attacks",
-      "polarity" : "+"
-    }, {
-      "from" : "living conditions Palestinians",
-      "to" : "preparedness to dialogue",
-      "polarity" : "+"
-    }, {
-      "from" : "trust Paln in Isi",
-      "to" : "preparedness to dialogue",
-      "polarity" : "+"
-    }, {
-      "from" : "trust Isi in Paln",
-      "to" : "preparedness to dialogue",
-      "polarity" : "+"
-    }, {
-      "from" : "preparedness to dialogue",
-      "to" : "progress peace process",
-      "polarity" : "+"
-    }, {
-      "from" : "reprisal Isi on Paln",
-      "to" : "trust Paln in Isi",
-      "polarity" : "-"
-    }, {
-      "from" : "living conditions Palestinians",
-      "to" : "degree of equality in negotiations",
-      "polarity" : "+"
-    }, {
-      "from" : "degree of equality in negotiations",
-      "to" : "chance of success of peace process",
-      "polarity" : "+"
-    }, {
-      "from" : "chance of success of peace process",
-      "to" : "progress peace process",
-      "polarity" : "+"
-    }, {
-      "from" : "progress peace process",
-      "to" : "autonomy Palestinians",
-      "polarity" : "+"
-    }, {
-      "from" : "autonomy Palestinians",
-      "to" : "living conditions Palestinians",
-      "polarity" : "+"
-    }, {
-      "from" : "autonomy Palestinians",
-      "to" : "successful suicide attacks",
-      "polarity" : "+"
-    }, {
-      "from" : "progress peace process",
-      "to" : "trust Paln in Isi"
-    }, {
-      "from" : "progress peace process",
-      "to" : "trust Isi in Paln"
-    } ]
-  } ],
-  "defaultSimulation" : {
-    "timeStep" : "Year",
-    "duration" : 120.0,
-    "durationUnit" : "Year",
-    "initialTime" : 1980.0
+  "name": "0210ConflictInMiddleEast",
+  "cldVariables": [
+    {
+      "name": "successful suicide attacks",
+      "comment": "\"'successful' suicide attacks\""
+    },
+    {
+      "name": "autonomy Palestinians",
+      "comment": "autonomy Palestinians"
+    },
+    {
+      "name": "preparedness to dialogue",
+      "comment": "preparedness to dialogue"
+    },
+    {
+      "name": "willingness suicide attacks",
+      "comment": "willingness suicide attacks"
+    },
+    {
+      "name": "security by shielding wall",
+      "comment": "\"security by shielding (wall)\""
+    },
+    {
+      "name": "degree of equality in negotiations",
+      "comment": "degree of equality in negotiations"
+    },
+    {
+      "name": "living conditions Palestinians",
+      "comment": "living conditions Palestinians"
+    },
+    {
+      "name": "mijn visie op europees beleid",
+      "comment": "mijn visie op europees beleid"
+    },
+    {
+      "name": "restrictions on Palestinians",
+      "comment": "restrictions on Palestinians"
+    },
+    {
+      "name": "reprisal Isi on Paln",
+      "comment": "reprisal Isi on Paln"
+    },
+    {
+      "name": "trust Isi in Paln",
+      "comment": "trust Isi in Paln"
+    },
+    {
+      "name": "trust Paln in Isi",
+      "comment": "trust Paln in Isi"
+    },
+    {
+      "name": "progress peace process",
+      "comment": "progress peace process"
+    },
+    {
+      "name": "chance of success of peace process",
+      "comment": "chance of success of peace process"
+    }
+  ],
+  "causalLinks": [
+    {
+      "from": "trust Isi in Paln",
+      "to": "restrictions on Palestinians",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "restrictions on Palestinians",
+      "to": "living conditions Palestinians",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "successful suicide attacks",
+      "to": "trust Isi in Paln",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "successful suicide attacks",
+      "to": "reprisal Isi on Paln",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "reprisal Isi on Paln",
+      "to": "living conditions Palestinians",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "trust Isi in Paln",
+      "to": "security by shielding wall",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "security by shielding wall",
+      "to": "successful suicide attacks",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "security by shielding wall",
+      "to": "living conditions Palestinians",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "living conditions Palestinians",
+      "to": "willingness suicide attacks",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "willingness suicide attacks",
+      "to": "successful suicide attacks",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "living conditions Palestinians",
+      "to": "preparedness to dialogue",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "trust Paln in Isi",
+      "to": "preparedness to dialogue",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "trust Isi in Paln",
+      "to": "preparedness to dialogue",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "preparedness to dialogue",
+      "to": "progress peace process",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "reprisal Isi on Paln",
+      "to": "trust Paln in Isi",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "living conditions Palestinians",
+      "to": "degree of equality in negotiations",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "degree of equality in negotiations",
+      "to": "chance of success of peace process",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "chance of success of peace process",
+      "to": "progress peace process",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "progress peace process",
+      "to": "autonomy Palestinians",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "autonomy Palestinians",
+      "to": "living conditions Palestinians",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "autonomy Palestinians",
+      "to": "successful suicide attacks",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "progress peace process",
+      "to": "trust Paln in Isi",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "progress peace process",
+      "to": "trust Isi in Paln",
+      "polarity": "UNKNOWN"
+    }
+  ],
+  "comments": [
+    {
+      "name": "Comment 1",
+      "text": "-"
+    },
+    {
+      "name": "Comment 2",
+      "text": "+"
+    },
+    {
+      "name": "Comment 3",
+      "text": "+"
+    },
+    {
+      "name": "Comment 4",
+      "text": "+"
+    },
+    {
+      "name": "Comment 5",
+      "text": "+"
+    },
+    {
+      "name": "Comment 6",
+      "text": "+"
+    },
+    {
+      "name": "Comment 7",
+      "text": "+"
+    },
+    {
+      "name": "Comment 8",
+      "text": "+"
+    }
+  ],
+  "views": [
+    {
+      "name": "View 1",
+      "elements": [],
+      "connectors": [
+        {
+          "from": "trust Isi in Paln",
+          "to": "restrictions on Palestinians",
+          "polarity": "-"
+        },
+        {
+          "from": "restrictions on Palestinians",
+          "to": "living conditions Palestinians",
+          "polarity": "-"
+        },
+        {
+          "from": "successful suicide attacks",
+          "to": "trust Isi in Paln",
+          "polarity": "-"
+        },
+        {
+          "from": "successful suicide attacks",
+          "to": "reprisal Isi on Paln",
+          "polarity": "+"
+        },
+        {
+          "from": "reprisal Isi on Paln",
+          "to": "living conditions Palestinians",
+          "polarity": "-"
+        },
+        {
+          "from": "trust Isi in Paln",
+          "to": "security by shielding wall",
+          "polarity": "-"
+        },
+        {
+          "from": "security by shielding wall",
+          "to": "successful suicide attacks",
+          "polarity": "-"
+        },
+        {
+          "from": "security by shielding wall",
+          "to": "living conditions Palestinians",
+          "polarity": "-"
+        },
+        {
+          "from": "living conditions Palestinians",
+          "to": "willingness suicide attacks",
+          "polarity": "-"
+        },
+        {
+          "from": "willingness suicide attacks",
+          "to": "successful suicide attacks",
+          "polarity": "+"
+        },
+        {
+          "from": "living conditions Palestinians",
+          "to": "preparedness to dialogue",
+          "polarity": "+"
+        },
+        {
+          "from": "trust Paln in Isi",
+          "to": "preparedness to dialogue",
+          "polarity": "+"
+        },
+        {
+          "from": "trust Isi in Paln",
+          "to": "preparedness to dialogue",
+          "polarity": "+"
+        },
+        {
+          "from": "preparedness to dialogue",
+          "to": "progress peace process",
+          "polarity": "+"
+        },
+        {
+          "from": "reprisal Isi on Paln",
+          "to": "trust Paln in Isi",
+          "polarity": "-"
+        },
+        {
+          "from": "living conditions Palestinians",
+          "to": "degree of equality in negotiations",
+          "polarity": "+"
+        },
+        {
+          "from": "degree of equality in negotiations",
+          "to": "chance of success of peace process",
+          "polarity": "+"
+        },
+        {
+          "from": "chance of success of peace process",
+          "to": "progress peace process",
+          "polarity": "+"
+        },
+        {
+          "from": "progress peace process",
+          "to": "autonomy Palestinians",
+          "polarity": "+"
+        },
+        {
+          "from": "autonomy Palestinians",
+          "to": "living conditions Palestinians",
+          "polarity": "+"
+        },
+        {
+          "from": "autonomy Palestinians",
+          "to": "successful suicide attacks",
+          "polarity": "+"
+        },
+        {
+          "from": "progress peace process",
+          "to": "trust Paln in Isi"
+        },
+        {
+          "from": "progress peace process",
+          "to": "trust Isi in Paln"
+        }
+      ]
+    }
+  ],
+  "defaultSimulation": {
+    "timeStep": "Year",
+    "duration": 120.0,
+    "durationUnit": "Year",
+    "initialTime": 1980.0
   },
-  "metadata" : {
-    "author" : "Dr. Erik Pruyt",
-    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
-    "license" : "CC-BY-NC-SA-4.0",
-    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/02_10"
+  "metadata": {
+    "author": "Dr. Erik Pruyt",
+    "source": "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license": "CC-BY-NC-SA-4.0",
+    "url": "https://simulation.tudelft.nl/SD/model_files_nested/02_10"
   }
 }

--- a/courant-app/src/main/resources/models/causal-loop/munro-lane.json
+++ b/courant-app/src/main/resources/models/causal-loop/munro-lane.json
@@ -1,189 +1,166 @@
 {
-  "name" : "0204MunroLane",
-  "cldVariables" : [ {
-    "name" : "average caseload",
-    "comment" : "average caseload"
-  }, {
-    "name" : "prescription of practice",
-    "comment" : "prescription of practice"
-  }, {
-    "name" : "quality of outcomes for CYPs",
-    "comment" : "quality of outcomes for CYPs"
-  }, {
-    "name" : "quality of social worker relationship with CYP and family",
-    "comment" : "quality of social worker relationship with CYP and family"
-  }, {
-    "name" : "scope for dealing with variety of CYP needs with professional expertise",
-    "comment" : "scope for dealing with variety of CYP needs with professional expertise"
-  }, {
-    "name" : "sense of satisfaction selfesteem and personal responsibility",
-    "comment" : "\"sense of satisfaction, self-esteem and personal responsibility\""
-  }, {
-    "name" : "staff absence or sickness rate",
-    "comment" : "staff absence or sickness rate"
-  }, {
-    "name" : "staff turnover rate",
-    "comment" : "staff turnover rate"
-  }, {
-    "name" : "time spent working with CYPs and families",
-    "comment" : "time spent working with CYPs and families"
-  }, {
-    "name" : "variety of needs of CYPs",
-    "comment" : "variety of needs of CYPs"
-  } ],
-  "causalLinks" : [ {
-    "from" : "variety of needs of CYPs",
-    "to" : "quality of outcomes for CYPs",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "prescription of practice",
-    "to" : "scope for dealing with variety of CYP needs with professional expertise",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "scope for dealing with variety of CYP needs with professional expertise",
-    "to" : "quality of outcomes for CYPs",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "staff absence or sickness rate",
-    "to" : "average caseload",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "average caseload",
-    "to" : "time spent working with CYPs and families",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "time spent working with CYPs and families",
-    "to" : "quality of social worker relationship with CYP and family",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "quality of social worker relationship with CYP and family",
-    "to" : "quality of outcomes for CYPs",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "staff turnover rate",
-    "to" : "average caseload",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "prescription of practice",
-    "to" : "time spent working with CYPs and families",
-    "polarity" : "NEGATIVE"
-  } ],
-  "comments" : [ {
-    "name" : "Comment 1",
-    "text" : "1"
-  }, {
-    "name" : "Comment 2",
-    "text" : "2"
-  } ],
-  "views" : [ {
-    "name" : "View 1",
-    "elements" : [ {
-      "name" : "prescription of practice",
-      "type" : "cld_variable",
-      "x" : 555.0,
-      "y" : 203.0
-    }, {
-      "name" : "scope for dealing with variety of CYP needs with professional expertise",
-      "type" : "cld_variable",
-      "x" : 232.0,
-      "y" : 415.0
-    }, {
-      "name" : "quality of outcomes for CYPs",
-      "type" : "cld_variable",
-      "x" : 437.0,
-      "y" : 420.0
-    }, {
-      "name" : "staff absence or sickness rate",
-      "type" : "cld_variable",
-      "x" : 660.0,
-      "y" : 569.0
-    }, {
-      "name" : "staff turnover rate",
-      "type" : "cld_variable",
-      "x" : 637.0,
-      "y" : 649.0
-    }, {
-      "name" : "average caseload",
-      "type" : "cld_variable",
-      "x" : 805.0,
-      "y" : 506.0
-    }, {
-      "name" : "time spent working with CYPs and families",
-      "type" : "cld_variable",
-      "x" : 811.0,
-      "y" : 412.0
-    }, {
-      "name" : "quality of social worker relationship with CYP and family",
-      "type" : "cld_variable",
-      "x" : 617.0,
-      "y" : 319.0
-    }, {
-      "name" : "variety of needs of CYPs",
-      "type" : "cld_variable",
-      "x" : 436.0,
-      "y" : 328.0
-    }, {
-      "name" : "Comment 1",
-      "type" : "comment",
-      "x" : 618.0,
-      "y" : 433.0,
-      "width" : 10.0,
-      "height" : 14.0
-    }, {
-      "name" : "Comment 2",
-      "type" : "comment",
-      "x" : 659.0,
-      "y" : 600.0,
-      "width" : 10.0,
-      "height" : 14.0
-    } ],
-    "connectors" : [ {
-      "from" : "variety of needs of CYPs",
-      "to" : "quality of outcomes for CYPs",
-      "polarity" : "-"
-    }, {
-      "from" : "prescription of practice",
-      "to" : "scope for dealing with variety of CYP needs with professional expertise",
-      "polarity" : "-"
-    }, {
-      "from" : "scope for dealing with variety of CYP needs with professional expertise",
-      "to" : "quality of outcomes for CYPs",
-      "polarity" : "+"
-    }, {
-      "from" : "staff absence or sickness rate",
-      "to" : "average caseload",
-      "polarity" : "+"
-    }, {
-      "from" : "average caseload",
-      "to" : "time spent working with CYPs and families",
-      "polarity" : "-"
-    }, {
-      "from" : "time spent working with CYPs and families",
-      "to" : "quality of social worker relationship with CYP and family",
-      "polarity" : "+"
-    }, {
-      "from" : "quality of social worker relationship with CYP and family",
-      "to" : "quality of outcomes for CYPs",
-      "polarity" : "+"
-    }, {
-      "from" : "staff turnover rate",
-      "to" : "average caseload",
-      "polarity" : "+"
-    }, {
-      "from" : "prescription of practice",
-      "to" : "time spent working with CYPs and families",
-      "polarity" : "-"
-    } ]
-  } ],
-  "defaultSimulation" : {
-    "timeStep" : "Month",
-    "duration" : 100.0,
-    "durationUnit" : "Month"
+  "name": "0204MunroLane",
+  "cldVariables": [
+    {
+      "name": "average caseload",
+      "comment": "average caseload"
+    },
+    {
+      "name": "prescription of practice",
+      "comment": "prescription of practice"
+    },
+    {
+      "name": "quality of outcomes for CYPs",
+      "comment": "quality of outcomes for CYPs"
+    },
+    {
+      "name": "quality of social worker relationship with CYP and family",
+      "comment": "quality of social worker relationship with CYP and family"
+    },
+    {
+      "name": "scope for dealing with variety of CYP needs with professional expertise",
+      "comment": "scope for dealing with variety of CYP needs with professional expertise"
+    },
+    {
+      "name": "sense of satisfaction selfesteem and personal responsibility",
+      "comment": "\"sense of satisfaction, self-esteem and personal responsibility\""
+    },
+    {
+      "name": "staff absence or sickness rate",
+      "comment": "staff absence or sickness rate"
+    },
+    {
+      "name": "staff turnover rate",
+      "comment": "staff turnover rate"
+    },
+    {
+      "name": "time spent working with CYPs and families",
+      "comment": "time spent working with CYPs and families"
+    },
+    {
+      "name": "variety of needs of CYPs",
+      "comment": "variety of needs of CYPs"
+    }
+  ],
+  "causalLinks": [
+    {
+      "from": "variety of needs of CYPs",
+      "to": "quality of outcomes for CYPs",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "prescription of practice",
+      "to": "scope for dealing with variety of CYP needs with professional expertise",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "scope for dealing with variety of CYP needs with professional expertise",
+      "to": "quality of outcomes for CYPs",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "staff absence or sickness rate",
+      "to": "average caseload",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "average caseload",
+      "to": "time spent working with CYPs and families",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "time spent working with CYPs and families",
+      "to": "quality of social worker relationship with CYP and family",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "quality of social worker relationship with CYP and family",
+      "to": "quality of outcomes for CYPs",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "staff turnover rate",
+      "to": "average caseload",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "prescription of practice",
+      "to": "time spent working with CYPs and families",
+      "polarity": "NEGATIVE"
+    }
+  ],
+  "comments": [
+    {
+      "name": "Comment 1",
+      "text": "1"
+    },
+    {
+      "name": "Comment 2",
+      "text": "2"
+    }
+  ],
+  "views": [
+    {
+      "name": "View 1",
+      "elements": [],
+      "connectors": [
+        {
+          "from": "variety of needs of CYPs",
+          "to": "quality of outcomes for CYPs",
+          "polarity": "-"
+        },
+        {
+          "from": "prescription of practice",
+          "to": "scope for dealing with variety of CYP needs with professional expertise",
+          "polarity": "-"
+        },
+        {
+          "from": "scope for dealing with variety of CYP needs with professional expertise",
+          "to": "quality of outcomes for CYPs",
+          "polarity": "+"
+        },
+        {
+          "from": "staff absence or sickness rate",
+          "to": "average caseload",
+          "polarity": "+"
+        },
+        {
+          "from": "average caseload",
+          "to": "time spent working with CYPs and families",
+          "polarity": "-"
+        },
+        {
+          "from": "time spent working with CYPs and families",
+          "to": "quality of social worker relationship with CYP and family",
+          "polarity": "+"
+        },
+        {
+          "from": "quality of social worker relationship with CYP and family",
+          "to": "quality of outcomes for CYPs",
+          "polarity": "+"
+        },
+        {
+          "from": "staff turnover rate",
+          "to": "average caseload",
+          "polarity": "+"
+        },
+        {
+          "from": "prescription of practice",
+          "to": "time spent working with CYPs and families",
+          "polarity": "-"
+        }
+      ]
+    }
+  ],
+  "defaultSimulation": {
+    "timeStep": "Month",
+    "duration": 100.0,
+    "durationUnit": "Month"
   },
-  "metadata" : {
-    "author" : "Dr. Erik Pruyt",
-    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
-    "license" : "CC-BY-NC-SA-4.0",
-    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/02_04"
+  "metadata": {
+    "author": "Dr. Erik Pruyt",
+    "source": "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license": "CC-BY-NC-SA-4.0",
+    "url": "https://simulation.tudelft.nl/SD/model_files_nested/02_04"
   }
 }

--- a/courant-app/src/main/resources/models/causal-loop/random-vs-randomized.json
+++ b/courant-app/src/main/resources/models/causal-loop/random-vs-randomized.json
@@ -1,113 +1,100 @@
 {
-  "name" : "1009_RANDOMvsRANDOMIZED",
-  "cldVariables" : [ {
-    "name" : "difference between random variables",
-    "comment" : "difference between random variables"
-  }, {
-    "name" : "difference between randomly sampled variables",
-    "comment" : "difference between randomly sampled variables"
-  }, {
-    "name" : "random variable 1",
-    "comment" : "random variable 1"
-  }, {
-    "name" : "random variable 2",
-    "comment" : "random variable 2"
-  }, {
-    "name" : "randomly sampled variable 1",
-    "comment" : "randomly sampled variable 1"
-  }, {
-    "name" : "randomly sampled variable 2",
-    "comment" : "randomly sampled variable 2"
-  }, {
-    "name" : "seed",
-    "comment" : "seed"
-  } ],
-  "causalLinks" : [ {
-    "from" : "random variable 1",
-    "to" : "difference between random variables",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "random variable 2",
-    "to" : "difference between random variables",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "randomly sampled variable 1",
-    "to" : "difference between randomly sampled variables",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "randomly sampled variable 2",
-    "to" : "difference between randomly sampled variables",
-    "polarity" : "UNKNOWN"
-  }, {
-    "from" : "seed",
-    "to" : "random variable 1",
-    "polarity" : "UNKNOWN"
-  } ],
-  "views" : [ {
-    "name" : "View 1",
-    "elements" : [ {
-      "name" : "random variable 1",
-      "type" : "cld_variable",
-      "x" : 216.0,
-      "y" : 190.0
-    }, {
-      "name" : "random variable 2",
-      "type" : "cld_variable",
-      "x" : 398.0,
-      "y" : 189.0
-    }, {
-      "name" : "difference between random variables",
-      "type" : "cld_variable",
-      "x" : 307.0,
-      "y" : 123.0
-    }, {
-      "name" : "randomly sampled variable 1",
-      "type" : "cld_variable",
-      "x" : 215.0,
-      "y" : 261.0
-    }, {
-      "name" : "randomly sampled variable 2",
-      "type" : "cld_variable",
-      "x" : 397.0,
-      "y" : 264.0
-    }, {
-      "name" : "difference between randomly sampled variables",
-      "type" : "cld_variable",
-      "x" : 316.0,
-      "y" : 336.0
-    }, {
-      "name" : "seed",
-      "type" : "cld_variable",
-      "x" : 312.0,
-      "y" : 225.0
-    } ],
-    "connectors" : [ {
-      "from" : "random variable 1",
-      "to" : "difference between random variables"
-    }, {
-      "from" : "random variable 2",
-      "to" : "difference between random variables"
-    }, {
-      "from" : "randomly sampled variable 1",
-      "to" : "difference between randomly sampled variables"
-    }, {
-      "from" : "randomly sampled variable 2",
-      "to" : "difference between randomly sampled variables"
-    }, {
-      "from" : "seed",
-      "to" : "random variable 1"
-    } ]
-  } ],
-  "defaultSimulation" : {
-    "timeStep" : "Month",
-    "duration" : 10.0,
-    "durationUnit" : "Month",
-    "dt" : 0.25
+  "name": "1009_RANDOMvsRANDOMIZED",
+  "cldVariables": [
+    {
+      "name": "difference between random variables",
+      "comment": "difference between random variables"
+    },
+    {
+      "name": "difference between randomly sampled variables",
+      "comment": "difference between randomly sampled variables"
+    },
+    {
+      "name": "random variable 1",
+      "comment": "random variable 1"
+    },
+    {
+      "name": "random variable 2",
+      "comment": "random variable 2"
+    },
+    {
+      "name": "randomly sampled variable 1",
+      "comment": "randomly sampled variable 1"
+    },
+    {
+      "name": "randomly sampled variable 2",
+      "comment": "randomly sampled variable 2"
+    },
+    {
+      "name": "seed",
+      "comment": "seed"
+    }
+  ],
+  "causalLinks": [
+    {
+      "from": "random variable 1",
+      "to": "difference between random variables",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "random variable 2",
+      "to": "difference between random variables",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "randomly sampled variable 1",
+      "to": "difference between randomly sampled variables",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "randomly sampled variable 2",
+      "to": "difference between randomly sampled variables",
+      "polarity": "UNKNOWN"
+    },
+    {
+      "from": "seed",
+      "to": "random variable 1",
+      "polarity": "UNKNOWN"
+    }
+  ],
+  "views": [
+    {
+      "name": "View 1",
+      "elements": [],
+      "connectors": [
+        {
+          "from": "random variable 1",
+          "to": "difference between random variables"
+        },
+        {
+          "from": "random variable 2",
+          "to": "difference between random variables"
+        },
+        {
+          "from": "randomly sampled variable 1",
+          "to": "difference between randomly sampled variables"
+        },
+        {
+          "from": "randomly sampled variable 2",
+          "to": "difference between randomly sampled variables"
+        },
+        {
+          "from": "seed",
+          "to": "random variable 1"
+        }
+      ]
+    }
+  ],
+  "defaultSimulation": {
+    "timeStep": "Month",
+    "duration": 10.0,
+    "durationUnit": "Month",
+    "dt": 0.25
   },
-  "metadata" : {
-    "author" : "Dr. Erik Pruyt",
-    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
-    "license" : "CC-BY-NC-SA-4.0",
-    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/10_09"
+  "metadata": {
+    "author": "Dr. Erik Pruyt",
+    "source": "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license": "CC-BY-NC-SA-4.0",
+    "url": "https://simulation.tudelft.nl/SD/model_files_nested/10_09"
   }
 }

--- a/courant-app/src/main/resources/models/causal-loop/rem-aggregated-cld.json
+++ b/courant-app/src/main/resources/models/causal-loop/rem-aggregated-cld.json
@@ -1,93 +1,86 @@
 {
-  "name" : "0203REMaggregatedCLDen1",
-  "cldVariables" : [ {
-    "name" : "average lifetime of goods containing REM",
-    "comment" : "average lifetime of goods containing REM"
-  }, {
-    "name" : "demand for REM in goods",
-    "comment" : "demand for REM in goods"
-  }, {
-    "name" : "loss of REM in goods",
-    "comment" : "loss of REM in goods"
-  }, {
-    "name" : "processing of REM",
-    "comment" : "processing of REM"
-  }, {
-    "name" : "use of REM in production of goods",
-    "comment" : "use of REM in production of goods"
-  } ],
-  "causalLinks" : [ {
-    "from" : "average lifetime of goods containing REM",
-    "to" : "loss of REM in goods",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "demand for REM in goods",
-    "to" : "use of REM in production of goods",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "processing of REM",
-    "to" : "use of REM in production of goods",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "use of REM in production of goods",
-    "to" : "loss of REM in goods",
-    "polarity" : "POSITIVE"
-  } ],
-  "views" : [ {
-    "name" : "View 1",
-    "elements" : [ {
-      "name" : "processing of REM",
-      "type" : "cld_variable",
-      "x" : 303.0,
-      "y" : 440.0
-    }, {
-      "name" : "use of REM in production of goods",
-      "type" : "cld_variable",
-      "x" : 305.0,
-      "y" : 306.0
-    }, {
-      "name" : "loss of REM in goods",
-      "type" : "cld_variable",
-      "x" : 305.0,
-      "y" : 186.0
-    }, {
-      "name" : "average lifetime of goods containing REM",
-      "type" : "cld_variable",
-      "x" : 304.0,
-      "y" : 115.0
-    }, {
-      "name" : "demand for REM in goods",
-      "type" : "cld_variable",
-      "x" : 225.0,
-      "y" : 271.0
-    } ],
-    "connectors" : [ {
-      "from" : "average lifetime of goods containing REM",
-      "to" : "loss of REM in goods",
-      "polarity" : "-"
-    }, {
-      "from" : "demand for REM in goods",
-      "to" : "use of REM in production of goods",
-      "polarity" : "+"
-    }, {
-      "from" : "processing of REM",
-      "to" : "use of REM in production of goods",
-      "polarity" : "+"
-    }, {
-      "from" : "use of REM in production of goods",
-      "to" : "loss of REM in goods",
-      "polarity" : "+"
-    } ]
-  } ],
-  "defaultSimulation" : {
-    "timeStep" : "Month",
-    "duration" : 100.0,
-    "durationUnit" : "Month"
+  "name": "0203REMaggregatedCLDen1",
+  "cldVariables": [
+    {
+      "name": "average lifetime of goods containing REM",
+      "comment": "average lifetime of goods containing REM"
+    },
+    {
+      "name": "demand for REM in goods",
+      "comment": "demand for REM in goods"
+    },
+    {
+      "name": "loss of REM in goods",
+      "comment": "loss of REM in goods"
+    },
+    {
+      "name": "processing of REM",
+      "comment": "processing of REM"
+    },
+    {
+      "name": "use of REM in production of goods",
+      "comment": "use of REM in production of goods"
+    }
+  ],
+  "causalLinks": [
+    {
+      "from": "average lifetime of goods containing REM",
+      "to": "loss of REM in goods",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "demand for REM in goods",
+      "to": "use of REM in production of goods",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "processing of REM",
+      "to": "use of REM in production of goods",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "use of REM in production of goods",
+      "to": "loss of REM in goods",
+      "polarity": "POSITIVE"
+    }
+  ],
+  "views": [
+    {
+      "name": "View 1",
+      "elements": [],
+      "connectors": [
+        {
+          "from": "average lifetime of goods containing REM",
+          "to": "loss of REM in goods",
+          "polarity": "-"
+        },
+        {
+          "from": "demand for REM in goods",
+          "to": "use of REM in production of goods",
+          "polarity": "+"
+        },
+        {
+          "from": "processing of REM",
+          "to": "use of REM in production of goods",
+          "polarity": "+"
+        },
+        {
+          "from": "use of REM in production of goods",
+          "to": "loss of REM in goods",
+          "polarity": "+"
+        }
+      ]
+    }
+  ],
+  "defaultSimulation": {
+    "timeStep": "Month",
+    "duration": 100.0,
+    "durationUnit": "Month"
   },
-  "metadata" : {
-    "author" : "Dr. Erik Pruyt",
-    "source" : "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
-    "license" : "CC-BY-NC-SA-4.0",
-    "url" : "https://simulation.tudelft.nl/SD/model_files_nested/02_03"
+  "metadata": {
+    "author": "Dr. Erik Pruyt",
+    "source": "Pruyt, E., 2013. Small System Dynamics Models for Big Issues: Triple Jump towards Real-World Complexity. TU Delft Library. ISBN 978-94-6186-195-5",
+    "license": "CC-BY-NC-SA-4.0",
+    "url": "https://simulation.tudelft.nl/SD/model_files_nested/02_03"
   }
 }

--- a/courant-app/src/main/resources/models/causal-loop/repair01.json
+++ b/courant-app/src/main/resources/models/causal-loop/repair01.json
@@ -1,117 +1,110 @@
 {
-  "name" : "repair01",
-  "cldVariables" : [ {
-    "name" : "average machine reliability",
-    "comment" : "average machine reliability"
-  }, {
-    "name" : "number of repairs required",
-    "comment" : "number of repairs required"
-  }, {
-    "name" : "routine maintenance work done",
-    "comment" : "routine maintenance work done"
-  }, {
-    "name" : "total maintenance workforce",
-    "comment" : "total maintenance workforce"
-  }, {
-    "name" : "workers available for routine maintenance",
-    "comment" : "workers available for routine maintenance"
-  }, {
-    "name" : "workers performing repairs",
-    "comment" : "workers performing repairs"
-  } ],
-  "causalLinks" : [ {
-    "from" : "workers available for routine maintenance",
-    "to" : "routine maintenance work done",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "routine maintenance work done",
-    "to" : "average machine reliability",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "average machine reliability",
-    "to" : "number of repairs required",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "number of repairs required",
-    "to" : "workers performing repairs",
-    "polarity" : "POSITIVE"
-  }, {
-    "from" : "workers performing repairs",
-    "to" : "workers available for routine maintenance",
-    "polarity" : "NEGATIVE"
-  }, {
-    "from" : "total maintenance workforce",
-    "to" : "workers available for routine maintenance",
-    "polarity" : "POSITIVE"
-  } ],
-  "views" : [ {
-    "name" : "View 1",
-    "elements" : [ {
-      "name" : "average machine reliability",
-      "type" : "cld_variable",
-      "x" : 559.0,
-      "y" : 168.0
-    }, {
-      "name" : "number of repairs required",
-      "type" : "cld_variable",
-      "x" : 688.0,
-      "y" : 304.0
-    }, {
-      "name" : "workers performing repairs",
-      "type" : "cld_variable",
-      "x" : 540.0,
-      "y" : 417.0
-    }, {
-      "name" : "total maintenance workforce",
-      "type" : "cld_variable",
-      "x" : 363.0,
-      "y" : 487.0
-    }, {
-      "name" : "workers available for routine maintenance",
-      "type" : "cld_variable",
-      "x" : 347.0,
-      "y" : 361.0
-    }, {
-      "name" : "routine maintenance work done",
-      "type" : "cld_variable",
-      "x" : 373.0,
-      "y" : 227.0
-    } ],
-    "connectors" : [ {
-      "from" : "workers available for routine maintenance",
-      "to" : "routine maintenance work done",
-      "polarity" : "+"
-    }, {
-      "from" : "routine maintenance work done",
-      "to" : "average machine reliability",
-      "polarity" : "+"
-    }, {
-      "from" : "average machine reliability",
-      "to" : "number of repairs required",
-      "polarity" : "-"
-    }, {
-      "from" : "number of repairs required",
-      "to" : "workers performing repairs",
-      "polarity" : "+"
-    }, {
-      "from" : "workers performing repairs",
-      "to" : "workers available for routine maintenance",
-      "polarity" : "-"
-    }, {
-      "from" : "total maintenance workforce",
-      "to" : "workers available for routine maintenance",
-      "polarity" : "+"
-    } ]
-  } ],
-  "defaultSimulation" : {
-    "timeStep" : "Month",
-    "duration" : 100.0,
-    "durationUnit" : "Month"
+  "name": "repair01",
+  "cldVariables": [
+    {
+      "name": "average machine reliability",
+      "comment": "average machine reliability"
+    },
+    {
+      "name": "number of repairs required",
+      "comment": "number of repairs required"
+    },
+    {
+      "name": "routine maintenance work done",
+      "comment": "routine maintenance work done"
+    },
+    {
+      "name": "total maintenance workforce",
+      "comment": "total maintenance workforce"
+    },
+    {
+      "name": "workers available for routine maintenance",
+      "comment": "workers available for routine maintenance"
+    },
+    {
+      "name": "workers performing repairs",
+      "comment": "workers performing repairs"
+    }
+  ],
+  "causalLinks": [
+    {
+      "from": "workers available for routine maintenance",
+      "to": "routine maintenance work done",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "routine maintenance work done",
+      "to": "average machine reliability",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "average machine reliability",
+      "to": "number of repairs required",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "number of repairs required",
+      "to": "workers performing repairs",
+      "polarity": "POSITIVE"
+    },
+    {
+      "from": "workers performing repairs",
+      "to": "workers available for routine maintenance",
+      "polarity": "NEGATIVE"
+    },
+    {
+      "from": "total maintenance workforce",
+      "to": "workers available for routine maintenance",
+      "polarity": "POSITIVE"
+    }
+  ],
+  "views": [
+    {
+      "name": "View 1",
+      "elements": [],
+      "connectors": [
+        {
+          "from": "workers available for routine maintenance",
+          "to": "routine maintenance work done",
+          "polarity": "+"
+        },
+        {
+          "from": "routine maintenance work done",
+          "to": "average machine reliability",
+          "polarity": "+"
+        },
+        {
+          "from": "average machine reliability",
+          "to": "number of repairs required",
+          "polarity": "-"
+        },
+        {
+          "from": "number of repairs required",
+          "to": "workers performing repairs",
+          "polarity": "+"
+        },
+        {
+          "from": "workers performing repairs",
+          "to": "workers available for routine maintenance",
+          "polarity": "-"
+        },
+        {
+          "from": "total maintenance workforce",
+          "to": "workers available for routine maintenance",
+          "polarity": "+"
+        }
+      ]
+    }
+  ],
+  "defaultSimulation": {
+    "timeStep": "Month",
+    "duration": 100.0,
+    "durationUnit": "Month"
   },
-  "metadata" : {
-    "author" : "Ventana Systems, Inc.",
-    "source" : "Vensim User's Guide, Chapter 20",
-    "license" : "Proprietary — bundled with Vensim distribution",
-    "url" : "https://vensim.com/documentation/"
+  "metadata": {
+    "author": "Ventana Systems, Inc.",
+    "source": "Vensim User's Guide, Chapter 20",
+    "license": "Proprietary \u00e2\u20ac\u201d bundled with Vensim distribution",
+    "url": "https://vensim.com/documentation/"
   }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/CausalLinkGeometryTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/CausalLinkGeometryTest.java
@@ -178,9 +178,9 @@ class CausalLinkGeometryTest {
             CausalLinkGeometry.LoopContext loopCtx = new CausalLinkGeometry.LoopContext(
                     loopInfo, loopCentroids, 100, 100);
 
-            // All in same SCC → k=0.6
-            assertThat(loopCtx.bulgeFactorFor("A", "B")).isEqualTo(0.6);
-            assertThat(loopCtx.bulgeFactorFor("B", "C")).isEqualTo(0.6);
+            // All in same SCC → k=0.45
+            assertThat(loopCtx.bulgeFactorFor("A", "B")).isEqualTo(0.45);
+            assertThat(loopCtx.bulgeFactorFor("B", "C")).isEqualTo(0.45);
         }
 
         @Test


### PR DESCRIPTION
## Summary

- Use global centroid for all edges instead of per-loop centroids — fixes visual instability when only some nodes are in SCCs
- Reduce intra-loop bulge from 0.6 to 0.45 for less aggressive curvature
- Revert self-loop radius to fixed `SELF_LOOP_RADIUS * 1.5` (was dynamic, caused oversized loops)
- Clear embedded Vensim positions from CLD model JSONs so `CldLayout.layout()` computes loop-aware placement

## Test plan

- [x] All tests pass
- [x] SpotBugs clean
- [ ] Visual verification: edges should be consistent when dragging variables