### PR TITLE
Wrap CLD variable labels for better layout fit

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
@@ -66,7 +66,8 @@ public class CanvasState {
                     sizes.put(ep.name(), new Size(ep.width(), ep.height()));
                 } else if (ep.type() == ElementType.CLD_VARIABLE) {
                     double w = LayoutMetrics.cldVarWidthForName(ep.name());
-                    sizes.put(ep.name(), new Size(w, LayoutMetrics.CLD_VAR_HEIGHT));
+                    double h = LayoutMetrics.cldVarHeightForName(ep.name());
+                    sizes.put(ep.name(), new Size(w, h));
                 } else if (ep.type() == ElementType.AUX) {
                     double w = LayoutMetrics.auxWidthForName(ep.name());
                     sizes.put(ep.name(), new Size(w, LayoutMetrics.AUX_HEIGHT));

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/LayoutMetrics.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/LayoutMetrics.java
@@ -9,9 +9,13 @@ import systems.courant.sd.model.def.StockDef;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.graph.ElementSizes;
 
+import systems.courant.sd.app.canvas.renderers.ElementRenderer;
+
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
+
+import java.util.List;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -62,6 +66,8 @@ public final class LayoutMetrics {
     public static final double CLD_VAR_CORNER_RADIUS = 6;
     /** Horizontal padding around text for CLD variable auto-sizing. */
     public static final double CLD_VAR_TEXT_PADDING = 16;
+    /** Maximum auto-width for CLD variables before text wraps to a second line. */
+    public static final double CLD_VAR_MAX_AUTO_WIDTH = 140;
 
     // Causal link
     public static final double CAUSAL_LINK_WIDTH = 1.5;
@@ -272,13 +278,32 @@ public final class LayoutMetrics {
 
     /**
      * Computes the width for a CLD variable based on its text label.
-     * Returns the measured text width plus padding, clamped to the minimum.
+     * Returns the measured text width plus padding, clamped to the minimum
+     * and capped at {@link #CLD_VAR_MAX_AUTO_WIDTH} so long names wrap.
      */
     public static double cldVarWidthForName(String name) {
         Text text = new Text(name);
         text.setFont(AUX_NAME_FONT);
         double textWidth = text.getLayoutBounds().getWidth();
-        return Math.max(minWidthFor(ElementType.CLD_VARIABLE), textWidth + CLD_VAR_TEXT_PADDING);
+        return Math.max(minWidthFor(ElementType.CLD_VARIABLE),
+                Math.min(textWidth + CLD_VAR_TEXT_PADDING, CLD_VAR_MAX_AUTO_WIDTH));
+    }
+
+    /**
+     * Computes the height for a CLD variable, expanding to fit wrapped text lines.
+     * Returns the standard height for short names, or taller for names that wrap.
+     */
+    public static double cldVarHeightForName(String name) {
+        double maxWidth = cldVarWidthForName(name) - CLD_VAR_TEXT_PADDING;
+        Text text = new Text(name);
+        text.setFont(AUX_NAME_FONT);
+        if (text.getLayoutBounds().getWidth() <= maxWidth) {
+            return CLD_VAR_HEIGHT;
+        }
+        List<String> lines = ElementRenderer.wrapText(name, AUX_NAME_FONT, maxWidth);
+        int lineCount = Math.min(lines.size(), 3);
+        double lineHeight = ElementRenderer.measureLineHeight(AUX_NAME_FONT);
+        return Math.max(CLD_VAR_HEIGHT, lineCount * lineHeight + 8);
     }
 
     /**
@@ -336,7 +361,8 @@ public final class LayoutMetrics {
         }
         for (CldVariableDef c : def.cldVariables()) {
             double w = cldVarWidthForName(c.name());
-            overrides.put(c.name(), new ElementSizes(w, CLD_VAR_HEIGHT));
+            double h = cldVarHeightForName(c.name());
+            overrides.put(c.name(), new ElementSizes(w, h));
         }
         return overrides;
     }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/SvgExporter.java
@@ -507,11 +507,9 @@ public final class SvgExporter {
     private static void writeCldVariable(PrintWriter w, String name,
                                           double cx, double cy, double width, double height) {
         // Plain text only -- no rectangle, matching standard CLD notation
-        String label = ElementRenderer.truncate(name, LayoutMetrics.AUX_NAME_FONT, width - 12);
-        w.printf(Locale.US,
-                "  <text x=\"%.2f\" y=\"%.2f\" text-anchor=\"middle\" dominant-baseline=\"central\" " +
-                "font-family=\"sans-serif\" font-size=\"%.0f\" fill=\"%s\">%s</text>%n",
-                cx, cy, LayoutMetrics.AUX_NAME_FONT_SIZE, svgColor(ColorPalette.TEXT), escapeXml(label));
+        // Wrap to multiple lines like canvas rendering
+        writeSvgWrappedName(w, name, LayoutMetrics.AUX_NAME_FONT, LayoutMetrics.AUX_NAME_FONT_SIZE,
+                cx, cy, width, LayoutMetrics.CLD_VAR_TEXT_PADDING);
     }
 
     private static void writeComment(PrintWriter w, String text,

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
@@ -323,6 +323,7 @@ public final class ElementRenderer {
 
     /**
      * Draws a CLD variable as plain text (no rectangle), matching standard CLD notation.
+     * Wraps long names to multiple lines (up to 3) to fit within the element width.
      */
     public static void drawCldVariable(GraphicsContext gc, String name,
                                        double x, double y, double width, double height) {
@@ -330,8 +331,8 @@ public final class ElementRenderer {
         gc.setFont(LayoutMetrics.AUX_NAME_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
-        gc.fillText(truncate(name, LayoutMetrics.AUX_NAME_FONT, width - 12),
-                x + width / 2, y + height / 2);
+        drawWrappedCldName(gc, name, LayoutMetrics.AUX_NAME_FONT,
+                x, y, width, height, LayoutMetrics.CLD_VAR_TEXT_PADDING);
     }
 
     /**
@@ -467,6 +468,34 @@ public final class ElementRenderer {
 
             for (int i = 0; i < lineCount; i++) {
                 String line = truncate(lines.get(i), font, maxWidth);
+                gc.fillText(line, x + width / 2, startY + i * lineHeight);
+            }
+        }
+    }
+
+    /**
+     * Draws a CLD variable name, wrapping to up to 3 lines (vs 2 for AUX elements)
+     * to accommodate the longer names typical in causal loop diagrams.
+     */
+    private static void drawWrappedCldName(GraphicsContext gc, String name, Font font,
+                                            double x, double y, double width, double height,
+                                            double padding) {
+        double maxWidth = width - padding;
+        MEASURE_TEXT.get().setFont(font);
+        MEASURE_TEXT.get().setText(name);
+        if (MEASURE_TEXT.get().getLayoutBounds().getWidth() <= maxWidth) {
+            gc.fillText(name, x + width / 2, y + height / 2);
+        } else {
+            List<String> lines = wrapText(name, font, maxWidth);
+            double lineHeight = measureLineHeight(font);
+            int lineCount = Math.min(lines.size(), 3);
+            double totalHeight = lineCount * lineHeight;
+            double startY = y + (height - totalHeight) / 2 + lineHeight / 2;
+
+            for (int i = 0; i < lineCount; i++) {
+                String line = (i == lineCount - 1 && lines.size() > lineCount)
+                        ? truncate(lines.get(i), font, maxWidth)
+                        : lines.get(i);
                 gc.fillText(line, x + width / 2, startY + i * lineHeight);
             }
         }


### PR DESCRIPTION
## Summary

- CLD variable names now word-wrap to up to 3 lines instead of truncating with ellipsis
- Width capped at 140px (was unbounded), height auto-expands to fit wrapped lines
- Matches Vensim rendering where multi-word names wrap into compact labels
- Applied to both canvas rendering and SVG export

## Test plan

- [x] All tests pass
- [x] SpotBugs clean
- [ ] Visual verification: long CLD variable names should wrap (e.g., "fraction of total budget to section A")