### PR TITLE
Show varied parameters and distributions in Monte Carlo reports

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ResultReportGenerator.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ResultReportGenerator.java
@@ -6,6 +6,7 @@ import systems.courant.sd.model.graph.FeedbackAnalysis;
 import systems.courant.sd.model.graph.LoopDominanceAnalysis;
 import systems.courant.sd.sweep.MonteCarloResult;
 import systems.courant.sd.sweep.OptimizationResult;
+import systems.courant.sd.sweep.ParameterSpec;
 import systems.courant.sd.sweep.RunResult;
 import systems.courant.sd.sweep.SensitivitySummary;
 import systems.courant.sd.sweep.SensitivitySummary.ParameterImpact;
@@ -329,6 +330,11 @@ public final class ResultReportGenerator {
         html.append("<section>\n<h2>Monte Carlo Analysis (")
                 .append(mc.getRunCount()).append(" runs)</h2>\n");
 
+        List<ParameterSpec> specs = mc.getParameterSpecs();
+        if (!specs.isEmpty()) {
+            writeVariedParametersTable(html, specs);
+        }
+
         List<String> allNames = new ArrayList<>(mc.getStockNames());
         allNames.addAll(mc.getVariableNames());
 
@@ -338,6 +344,26 @@ public final class ResultReportGenerator {
         }
 
         html.append("</section>\n\n");
+    }
+
+    static void writeVariedParametersTable(StringBuilder html, List<ParameterSpec> specs) {
+        html.append("<h3>Varied Parameters</h3>\n");
+        html.append("<table class=\"element-table\">\n");
+        html.append("<thead><tr><th>Parameter</th><th>Distribution</th>");
+        html.append("<th>Parameters</th></tr></thead>\n<tbody>\n");
+
+        for (ParameterSpec spec : specs) {
+            html.append("<tr>");
+            html.append("<td class=\"name\">").append(esc(spec.name())).append("</td>");
+            html.append("<td>").append(esc(spec.distributionType())).append("</td>");
+            html.append("<td class=\"code\">").append(esc(spec.param1Label())).append(" = ")
+                    .append(fmt(spec.param1())).append(", ")
+                    .append(esc(spec.param2Label())).append(" = ")
+                    .append(fmt(spec.param2())).append("</td>");
+            html.append("</tr>\n");
+        }
+
+        html.append("</tbody></table>\n");
     }
 
     static void writePercentileTable(StringBuilder html, MonteCarloResult mc, String variableName) {

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ResultReportGeneratorTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ResultReportGeneratorTest.java
@@ -11,6 +11,7 @@ import systems.courant.sd.model.graph.FeedbackAnalysis;
 import systems.courant.sd.model.graph.LoopDominanceAnalysis;
 import systems.courant.sd.sweep.MonteCarloResult;
 import systems.courant.sd.sweep.OptimizationResult;
+import systems.courant.sd.sweep.ParameterSpec;
 import systems.courant.sd.sweep.RunResult;
 import systems.courant.sd.sweep.SensitivitySummary.ParameterImpact;
 import systems.courant.sd.sweep.SweepResult;
@@ -343,6 +344,49 @@ class ResultReportGeneratorTest {
 
             assertThat(html.toString()).contains("<details>");
             assertThat(html.toString()).contains("<summary>");
+        }
+
+        @Test
+        @DisplayName("should contain varied parameters table when specs are present")
+        void shouldContainVariedParametersTable() {
+            MonteCarloResult mc = buildMonteCarloResultWithSpecs();
+            StringBuilder html = new StringBuilder();
+            ResultReportGenerator.writeMonteCarloSection(html, mc);
+            String output = html.toString();
+
+            assertThat(output).contains("Varied Parameters");
+            assertThat(output).contains("drainRate");
+            assertThat(output).contains("Normal");
+            assertThat(output).contains("Mean = 10");
+            assertThat(output).contains("Std Dev = 2");
+        }
+
+        @Test
+        @DisplayName("should handle mixed distribution types in varied parameters table")
+        void shouldHandleMixedDistributions() {
+            List<ParameterSpec> specs = List.of(
+                    new ParameterSpec("rate", "Normal", 8.0, 2.0, "Mean", "Std Dev"),
+                    new ParameterSpec("capacity", "Uniform", 50.0, 150.0, "Min", "Max"));
+            MonteCarloResult mc = new MonteCarloResult(buildRunResults(), specs);
+            StringBuilder html = new StringBuilder();
+            ResultReportGenerator.writeMonteCarloSection(html, mc);
+            String output = html.toString();
+
+            assertThat(output).contains("Normal");
+            assertThat(output).contains("Uniform");
+            assertThat(output).contains("Mean = 8");
+            assertThat(output).contains("Min = 50");
+            assertThat(output).contains("Max = 150");
+        }
+
+        @Test
+        @DisplayName("should omit varied parameters table when specs are empty")
+        void shouldOmitTableWhenNoSpecs() {
+            MonteCarloResult mc = buildMonteCarloResult();
+            StringBuilder html = new StringBuilder();
+            ResultReportGenerator.writeMonteCarloSection(html, mc);
+
+            assertThat(html.toString()).doesNotContain("Varied Parameters");
         }
     }
 
@@ -888,12 +932,22 @@ class ResultReportGeneratorTest {
         return new SweepResult("drainRate", runs);
     }
 
-    private static MonteCarloResult buildMonteCarloResult() {
+    private static List<RunResult> buildRunResults() {
         List<RunResult> runs = new ArrayList<>();
         for (double rate : new double[]{5.0, 7.0, 10.0, 12.0, 15.0}) {
             runs.add(buildSingleRun(rate));
         }
-        return new MonteCarloResult(runs);
+        return runs;
+    }
+
+    private static MonteCarloResult buildMonteCarloResult() {
+        return new MonteCarloResult(buildRunResults());
+    }
+
+    private static MonteCarloResult buildMonteCarloResultWithSpecs() {
+        List<ParameterSpec> specs = List.of(
+                new ParameterSpec("drainRate", "Normal", 10.0, 2.0, "Mean", "Std Dev"));
+        return new MonteCarloResult(buildRunResults(), specs);
     }
 
     private static List<ParameterImpact> buildImpacts() {

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/MonteCarlo.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/MonteCarlo.java
@@ -5,7 +5,9 @@ import systems.courant.sd.measure.TimeUnit;
 import systems.courant.sd.model.Model;
 import systems.courant.sd.model.compile.CompiledModel;
 
+import org.apache.commons.math3.distribution.NormalDistribution;
 import org.apache.commons.math3.distribution.RealDistribution;
+import org.apache.commons.math3.distribution.UniformRealDistribution;
 import org.apache.commons.math3.random.MersenneTwister;
 
 import java.util.ArrayList;
@@ -81,7 +83,28 @@ public class MonteCarlo {
                     paramMap, timeStep, duration));
         }
 
-        return new MonteCarloResult(results);
+        return new MonteCarloResult(results, buildParameterSpecs());
+    }
+
+    private List<ParameterSpec> buildParameterSpecs() {
+        List<ParameterSpec> specs = new ArrayList<>();
+        for (Map.Entry<String, RealDistribution> entry : parameters.entrySet()) {
+            specs.add(toParameterSpec(entry.getKey(), entry.getValue()));
+        }
+        return specs;
+    }
+
+    private static ParameterSpec toParameterSpec(String name, RealDistribution dist) {
+        if (dist instanceof NormalDistribution nd) {
+            return new ParameterSpec(name, "Normal",
+                    nd.getMean(), nd.getStandardDeviation(), "Mean", "Std Dev");
+        } else if (dist instanceof UniformRealDistribution) {
+            return new ParameterSpec(name, "Uniform",
+                    dist.getSupportLowerBound(), dist.getSupportUpperBound(), "Min", "Max");
+        } else {
+            return new ParameterSpec(name, dist.getClass().getSimpleName(),
+                    dist.getNumericalMean(), dist.getNumericalVariance(), "Mean", "Variance");
+        }
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/MonteCarloResult.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/MonteCarloResult.java
@@ -27,6 +27,7 @@ public class MonteCarloResult {
     private static final Logger logger = LoggerFactory.getLogger(MonteCarloResult.class);
 
     private final List<RunResult> results;
+    private final List<ParameterSpec> parameterSpecs;
 
     /**
      * Creates a new Monte Carlo result from the given list of run results.
@@ -34,7 +35,18 @@ public class MonteCarloResult {
      * @param results the list of run results, one per iteration
      */
     public MonteCarloResult(List<RunResult> results) {
+        this(results, List.of());
+    }
+
+    /**
+     * Creates a new Monte Carlo result with parameter distribution metadata.
+     *
+     * @param results        the list of run results, one per iteration
+     * @param parameterSpecs descriptions of the varied parameters and their distributions
+     */
+    public MonteCarloResult(List<RunResult> results, List<ParameterSpec> parameterSpecs) {
         this.results = List.copyOf(results);
+        this.parameterSpecs = List.copyOf(parameterSpecs);
     }
 
     /**
@@ -79,6 +91,13 @@ public class MonteCarloResult {
      */
     public List<RunResult> getResults() {
         return Collections.unmodifiableList(results);
+    }
+
+    /**
+     * Returns the parameter distribution specifications, or an empty list if not available.
+     */
+    public List<ParameterSpec> getParameterSpecs() {
+        return parameterSpecs;
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/sweep/ParameterSpec.java
+++ b/courant-engine/src/main/java/systems/courant/sd/sweep/ParameterSpec.java
@@ -1,0 +1,22 @@
+package systems.courant.sd.sweep;
+
+/**
+ * Describes a varied parameter in a Monte Carlo simulation, capturing the
+ * distribution type and its parameters so that results can be understood
+ * and reproduced.
+ *
+ * @param name             the parameter name
+ * @param distributionType human-readable distribution type (e.g. "Normal", "Uniform")
+ * @param param1           first distribution parameter (mean or min)
+ * @param param2           second distribution parameter (std dev or max)
+ * @param param1Label      label for param1 (e.g. "Mean", "Min")
+ * @param param2Label      label for param2 (e.g. "Std Dev", "Max")
+ */
+public record ParameterSpec(
+        String name,
+        String distributionType,
+        double param1,
+        double param2,
+        String param1Label,
+        String param2Label) {
+}

--- a/courant-engine/src/test/java/systems/courant/sd/sweep/MonteCarloResultTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/sweep/MonteCarloResultTest.java
@@ -124,6 +124,43 @@ class MonteCarloResultTest {
         }
     }
 
+    @Nested
+    @DisplayName("ParameterSpec support")
+    class ParameterSpecSupport {
+
+        @Test
+        @DisplayName("should return empty specs when constructed without them")
+        void shouldReturnEmptySpecsByDefault() {
+            assertThat(result.getParameterSpecs()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should return specs when constructed with them")
+        void shouldReturnProvidedSpecs() {
+            List<ParameterSpec> specs = List.of(
+                    new ParameterSpec("rate", "Normal", 8.0, 2.0, "Mean", "Std Dev"),
+                    new ParameterSpec("capacity", "Uniform", 50.0, 150.0, "Min", "Max"));
+            MonteCarloResult mcWithSpecs = new MonteCarloResult(result.getResults(), specs);
+
+            assertThat(mcWithSpecs.getParameterSpecs()).hasSize(2);
+            assertThat(mcWithSpecs.getParameterSpecs().get(0).name()).isEqualTo("rate");
+            assertThat(mcWithSpecs.getParameterSpecs().get(0).distributionType()).isEqualTo("Normal");
+            assertThat(mcWithSpecs.getParameterSpecs().get(1).name()).isEqualTo("capacity");
+            assertThat(mcWithSpecs.getParameterSpecs().get(1).distributionType()).isEqualTo("Uniform");
+        }
+
+        @Test
+        @DisplayName("should defensively copy parameter specs list")
+        void shouldDefensivelyCopySpecs() {
+            List<ParameterSpec> mutableSpecs = new ArrayList<>(List.of(
+                    new ParameterSpec("rate", "Normal", 8.0, 2.0, "Mean", "Std Dev")));
+            MonteCarloResult mcWithSpecs = new MonteCarloResult(result.getResults(), mutableSpecs);
+
+            mutableSpecs.clear();
+            assertThat(mcWithSpecs.getParameterSpecs()).hasSize(1);
+        }
+    }
+
     @Test
     @DisplayName("constructor should defensively copy the results list (#302)")
     void constructorShouldDefensivelyCopyResults() {


### PR DESCRIPTION
## Summary
- Add `ParameterSpec` record to capture distribution metadata (type, parameters, labels)
- Store parameter specs in `MonteCarloResult` by inspecting distribution objects during execution
- Render a "Varied Parameters" table in the Monte Carlo report section showing each parameter's name, distribution type, and parameters

Fixes #1194

## Test plan
- [x] New tests for `ParameterSpec` storage and defensive copying in `MonteCarloResultTest`
- [x] New tests for varied parameters table rendering in `ResultReportGeneratorTest`
- [x] Test coverage for mixed distribution types (Normal + Uniform)
- [x] Test that table is omitted when no specs are available (backward compatibility)
- [x] All 146 tests pass, zero SpotBugs findings