### PR TITLE
Clear all model-specific UI state when closing a model

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -1023,7 +1023,14 @@ public class ModelWindow {
         if (dashboardPanel != null) {
             dashboardPanel.clear();
         }
-        statusBar.clearProgress();
+
+        // Reset all model-specific UI state
+        statusBar.clear();
+        loopNavigatorBar.setVisible(false);
+        loopNavigatorBar.setManaged(false);
+        loopNavigatorBar.resetFilter();
+        toolBar.deactivateLoopToggle();
+        canvas.analysis().setLoopHighlightActive(false);
 
         // Reset file state
         fileController.setCurrentFile(null);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasToolBar.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasToolBar.java
@@ -209,6 +209,13 @@ public class CanvasToolBar extends ToolBar {
     }
 
     /**
+     * Deselects the Loops toggle button without firing the toggle callback.
+     */
+    public void deactivateLoopToggle() {
+        loopsButton.setSelected(false);
+    }
+
+    /**
      * Sets a callback invoked when the Loops toggle button is toggled on or off.
      */
     public void setOnLoopToggleChanged(Consumer<Boolean> callback) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/StatusBar.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/StatusBar.java
@@ -214,4 +214,17 @@ public class StatusBar extends HBox {
             Platform.runLater(action);
         }
     }
+
+    /**
+     * Resets the entire status bar to its initial state, clearing all model-specific information.
+     */
+    public void clear() {
+        updateTool(CanvasToolBar.Tool.SELECT);
+        updateSelection(0);
+        updateElements(0, 0, 0, 0, 0, 0, 0);
+        updateZoom(1.0);
+        clearLoops();
+        clearValidation();
+        clearProgress();
+    }
 }


### PR DESCRIPTION
## Summary
- Add `StatusBar.clear()` that resets all labels (tool, selection, elements, zoom) and hides optional sections (loops, validation, progress)
- Add `CanvasToolBar.deactivateLoopToggle()` to deselect the loops button without firing callbacks
- Update `ModelWindow.resetToStartScreen()` to call `statusBar.clear()`, hide the loop navigator bar, reset its filter, deactivate the toolbar loop toggle, and clear loop highlight state on the canvas

Fixes #1209