### PR TITLE
Fix incorrect unit warnings for Kaibab Deer model

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EditorUnitContext.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EditorUnitContext.java
@@ -34,8 +34,7 @@ public final class EditorUnitContext implements DimensionalAnalyzer.UnitContext 
         if (stockOpt.isPresent()) {
             String unitName = stockOpt.get().unit();
             if (unitName != null && !unitName.isBlank()) {
-                Unit unit = registry.resolve(unitName);
-                return Optional.of(CompositeUnit.of(unit));
+                return Optional.of(registry.resolveComposite(unitName));
             }
             return Optional.of(CompositeUnit.dimensionless());
         }
@@ -60,8 +59,7 @@ public final class EditorUnitContext implements DimensionalAnalyzer.UnitContext 
         if (auxOpt.isPresent()) {
             String unitName = auxOpt.get().unit();
             if (unitName != null && !unitName.isBlank()) {
-                Unit unit = registry.resolve(unitName);
-                return Optional.of(CompositeUnit.of(unit));
+                return Optional.of(registry.resolveComposite(unitName));
             }
             return Optional.of(CompositeUnit.dimensionless());
         }
@@ -74,10 +72,10 @@ public final class EditorUnitContext implements DimensionalAnalyzer.UnitContext 
         if (lookupOpt.isPresent()) {
             String unitName = lookupOpt.get().unit();
             if (unitName != null && !unitName.isBlank()) {
-                Unit unit = registry.resolve(unitName);
-                return Optional.of(CompositeUnit.of(unit));
+                return Optional.of(registry.resolveComposite(unitName));
             }
-            return Optional.of(CompositeUnit.dimensionless());
+            // No declared unit → unknown (not dimensionless)
+            return Optional.empty();
         }
 
         return Optional.empty();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/DimensionalAnalysisUI.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/DimensionalAnalysisUI.java
@@ -120,6 +120,7 @@ public class DimensionalAnalysisUI {
             // Build display text
             String inferredDisplay = analysis.inferredUnit().displayString();
             CompositeUnit expected = getExpectedUnit(unitRegistry);
+            String rawExpected = getRawExpectedUnitLabel();
 
             if (!analysis.isConsistent()) {
                 // Show first warning
@@ -127,11 +128,23 @@ public class DimensionalAnalysisUI {
                 dimensionLabel.setText("Warning: " + warning);
                 dimensionLabel.setStyle(Styles.DIMENSION_MISMATCH);
             } else if (expected != null && !expected.isCompatibleWith(analysis.inferredUnit())) {
-                dimensionLabel.setText("Equation yields " + inferredDisplay
-                        + ", expected " + expected.displayString());
-                dimensionLabel.setStyle(Styles.DIMENSION_MISMATCH);
+                // Pure constant expressions carry the declared unit implicitly — no mismatch
+                if (analysis.inferredUnit().isDimensionless() && isPureConstant(expr)) {
+                    String label = rawExpected != null ? rawExpected : expected.displayString();
+                    dimensionLabel.setText("= " + label);
+                    dimensionLabel.setStyle(Styles.DIMENSION_MATCH);
+                } else {
+                    String expectedLabel = rawExpected != null ? rawExpected
+                            : expected.displayString();
+                    dimensionLabel.setText("Equation yields " + inferredDisplay
+                            + ", expected " + expectedLabel);
+                    dimensionLabel.setStyle(Styles.DIMENSION_MISMATCH);
+                }
             } else {
-                dimensionLabel.setText("= " + inferredDisplay);
+                // When matched, prefer showing raw declared unit for readability
+                String label = (rawExpected != null && expected != null)
+                        ? rawExpected : inferredDisplay;
+                dimensionLabel.setText("= " + label);
                 dimensionLabel.setStyle(expected != null ? Styles.DIMENSION_MATCH
                         : Styles.DIMENSION_LABEL);
             }
@@ -140,6 +153,61 @@ public class DimensionalAnalysisUI {
         } catch (ParseException e) {
             hideDimensionLabel(dimensionLabel);
         }
+    }
+
+    /**
+     * Returns the raw declared unit string for the current element, for use in display messages.
+     * Returns null if no raw string is available (e.g. unknown element type or no declared unit).
+     */
+    private String getRawExpectedUnitLabel() {
+        var flowOpt = ctx.getEditor().getFlowByName(ctx.getElementName());
+        if (flowOpt.isPresent()) {
+            var flow = flowOpt.get();
+            String material = null;
+            if (flow.materialUnit() != null && !flow.materialUnit().isBlank()) {
+                material = flow.materialUnit();
+            } else if (flow.sink() != null) {
+                var sink = ctx.getEditor().getStockByName(flow.sink());
+                if (sink.isPresent() && sink.get().unit() != null
+                        && !sink.get().unit().isBlank()) {
+                    material = sink.get().unit();
+                }
+            } else if (flow.source() != null) {
+                var source = ctx.getEditor().getStockByName(flow.source());
+                if (source.isPresent() && source.get().unit() != null
+                        && !source.get().unit().isBlank()) {
+                    material = source.get().unit();
+                }
+            }
+            if (material != null && flow.timeUnit() != null) {
+                return material + "/" + flow.timeUnit();
+            }
+            return null;
+        }
+        var auxOpt = ctx.getEditor().getVariableByName(ctx.getElementName());
+        if (auxOpt.isPresent()) {
+            String unitName = auxOpt.get().unit();
+            if (unitName != null && !unitName.isBlank()) {
+                return unitName;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns true if the expression contains only literals and arithmetic — no variable
+     * references or function calls. Constants carry their declared unit implicitly.
+     */
+    private boolean isPureConstant(Expr expr) {
+        return switch (expr) {
+            case Expr.Literal _ -> true;
+            case Expr.Ref _ -> false;
+            case Expr.BinaryOp op -> isPureConstant(op.left()) && isPureConstant(op.right());
+            case Expr.UnaryOp op -> isPureConstant(op.operand());
+            case Expr.FunctionCall _ -> false;
+            case Expr.Conditional cond -> isPureConstant(cond.condition())
+                    && isPureConstant(cond.thenExpr()) && isPureConstant(cond.elseExpr());
+        };
     }
 
     /**
@@ -179,7 +247,7 @@ public class DimensionalAnalysisUI {
         if (auxOpt.isPresent()) {
             String unitName = auxOpt.get().unit();
             if (unitName != null && !unitName.isBlank()) {
-                return CompositeUnit.of(registry.resolve(unitName));
+                return registry.resolveComposite(unitName);
             }
         }
 

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/EditorUnitContextTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/EditorUnitContextTest.java
@@ -179,7 +179,7 @@ class EditorUnitContextTest {
     class LookupResolution {
 
         @Test
-        void shouldResolveLookupAsDimensionless() {
+        void shouldReturnEmpty_whenLookupHasNoUnit() {
             ModelDefinition def = new ModelDefinitionBuilder()
                     .name("Test")
                     .lookupTable("Effect of Pressure",
@@ -189,12 +189,11 @@ class EditorUnitContextTest {
 
             Optional<CompositeUnit> result = context.resolveUnit("Effect of Pressure");
 
-            assertThat(result).isPresent();
-            assertThat(result.get().isDimensionless()).isTrue();
+            assertThat(result).isEmpty();
         }
 
         @Test
-        void shouldResolveLookupByUnderscoreName() {
+        void shouldReturnEmpty_whenLookupByUnderscoreNameHasNoUnit() {
             ModelDefinition def = new ModelDefinitionBuilder()
                     .name("Test")
                     .lookupTable("Effect of Pressure",
@@ -204,8 +203,45 @@ class EditorUnitContextTest {
 
             Optional<CompositeUnit> result = context.resolveUnit("Effect_of_Pressure");
 
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveUnit with compound unit strings (#1211)")
+    class CompoundUnitResolution {
+
+        @Test
+        void shouldResolveVariableWithCompoundUnit() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .variable("rate", "0.1", "Deer/year")
+                    .build();
+            editor.loadFrom(def);
+
+            Optional<CompositeUnit> result = context.resolveUnit("rate");
+
             assertThat(result).isPresent();
-            assertThat(result.get().isDimensionless()).isTrue();
+            assertThat(result.get().isDimensionless()).isFalse();
+            // Should have ITEM (Deer) and TIME^-1 (year)
+            assertThat(result.get().exponents())
+                    .containsEntry(systems.courant.sd.measure.Dimension.ITEM, 1)
+                    .containsEntry(systems.courant.sd.measure.Dimension.TIME, -1);
+        }
+
+        @Test
+        void shouldResolveStockWithSimpleUnit() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Population", 100, "Deer")
+                    .build();
+            editor.loadFrom(def);
+
+            Optional<CompositeUnit> result = context.resolveUnit("Population");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().exponents())
+                    .containsEntry(systems.courant.sd.measure.Dimension.ITEM, 1);
         }
     }
 

--- a/courant-engine/src/main/java/systems/courant/sd/measure/DimensionalAnalyzer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/DimensionalAnalyzer.java
@@ -227,14 +227,17 @@ public class DimensionalAnalyzer {
 
         if ("LOOKUP".equals(name) || "LOOKUP_AREA".equals(name)) {
             // Resolve the table's declared output unit from the first argument (table name)
+            CompositeUnit tableUnit = null;
             if (!call.arguments().isEmpty()
                     && call.arguments().getFirst() instanceof Expr.Ref tableRef) {
-                CompositeUnit tableUnit = context.resolveUnit(tableRef.name()).orElse(null);
-                if (tableUnit != null) {
-                    return tableUnit;
-                }
+                tableUnit = context.resolveUnit(tableRef.name()).orElse(null);
             }
-            return CompositeUnit.dimensionless();
+            // Analyze remaining arguments for potential internal warnings
+            for (int i = 1; i < call.arguments().size(); i++) {
+                infer(call.arguments().get(i), warnings);
+            }
+            // null signals unknown output unit (table has no declared unit)
+            return tableUnit;
         }
 
         // STEP, RAMP, PULSE, PULSE_TRAIN, TREND, FORECAST, NPV,

--- a/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
@@ -222,6 +222,139 @@ public class UnitRegistry {
     }
 
     /**
+     * Resolves a compound unit string such as {@code "Deer/year"} or {@code "Deer/(year*lion)"}
+     * into a {@link CompositeUnit}. Supports division ({@code /}), multiplication ({@code *}),
+     * and parentheses for grouping. A leading {@code "1"} denotes dimensionless
+     * (e.g. {@code "1/year"} → inverse-time).
+     *
+     * <p>Simple names without operators are resolved via {@link #resolve(String)} and
+     * wrapped with {@link CompositeUnit#of(Unit)}.
+     *
+     * @param unitString the unit string to parse
+     * @return the composite unit, or dimensionless for null/blank/dimensionless inputs
+     */
+    public CompositeUnit resolveComposite(String unitString) {
+        if (unitString == null || unitString.isBlank()) {
+            return CompositeUnit.dimensionless();
+        }
+        String trimmed = unitString.trim();
+
+        if ("1".equals(trimmed) || DIMENSIONLESS_NAMES.contains(trimmed.toLowerCase())) {
+            return CompositeUnit.dimensionless();
+        }
+
+        if (!hasUnitOperators(trimmed)) {
+            return CompositeUnit.of(resolve(trimmed));
+        }
+
+        return new UnitStringParser(trimmed, this).parse();
+    }
+
+    private static boolean hasUnitOperators(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '/' || c == '*' || c == '(' || c == ')') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Recursive-descent parser for compound unit strings.
+     * <pre>
+     * expression → product ('/' product)?
+     * product    → atom ('*' atom)*
+     * atom       → '(' expression ')' | '1' | name
+     * </pre>
+     */
+    private static final class UnitStringParser {
+        private final String input;
+        private final UnitRegistry registry;
+        private int pos;
+
+        UnitStringParser(String input, UnitRegistry registry) {
+            this.input = input;
+            this.registry = registry;
+        }
+
+        CompositeUnit parse() {
+            pos = 0;
+            CompositeUnit result = parseExpression();
+            // If we didn't consume everything, fall back to treating the whole string as a name
+            if (pos < input.length()) {
+                return CompositeUnit.of(registry.resolve(input));
+            }
+            return result;
+        }
+
+        private CompositeUnit parseExpression() {
+            CompositeUnit left = parseProduct();
+            skipSpaces();
+            if (pos < input.length() && input.charAt(pos) == '/') {
+                pos++;
+                CompositeUnit right = parseProduct();
+                return left.divide(right);
+            }
+            return left;
+        }
+
+        private CompositeUnit parseProduct() {
+            CompositeUnit result = parseAtom();
+            while (pos < input.length()) {
+                skipSpaces();
+                if (pos < input.length() && input.charAt(pos) == '*') {
+                    pos++;
+                    result = result.multiply(parseAtom());
+                } else {
+                    break;
+                }
+            }
+            return result;
+        }
+
+        private CompositeUnit parseAtom() {
+            skipSpaces();
+            if (pos >= input.length()) {
+                return CompositeUnit.dimensionless();
+            }
+            if (input.charAt(pos) == '(') {
+                pos++;
+                CompositeUnit inner = parseExpression();
+                skipSpaces();
+                if (pos < input.length() && input.charAt(pos) == ')') {
+                    pos++;
+                }
+                return inner;
+            }
+            String name = readName();
+            if (name.isEmpty() || "1".equals(name)) {
+                return CompositeUnit.dimensionless();
+            }
+            return CompositeUnit.of(registry.resolve(name));
+        }
+
+        private String readName() {
+            skipSpaces();
+            int start = pos;
+            while (pos < input.length()) {
+                char c = input.charAt(pos);
+                if (c == '/' || c == '*' || c == '(' || c == ')') {
+                    break;
+                }
+                pos++;
+            }
+            return input.substring(start, pos).trim();
+        }
+
+        private void skipSpaces() {
+            while (pos < input.length() && input.charAt(pos) == ' ') {
+                pos++;
+            }
+        }
+    }
+
+    /**
      * Resolves a time unit by name. Throws if the resolved unit is not a {@link TimeUnit}.
      *
      * @param name the time unit name

--- a/courant-engine/src/test/java/systems/courant/sd/measure/DimensionalAnalyzerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/DimensionalAnalyzerTest.java
@@ -266,11 +266,31 @@ class DimensionalAnalyzerTest {
         }
 
         @Test
-        void shouldReturnDimensionlessForLOOKUPWithNoUnit() {
+        void shouldReturnDimensionlessForLOOKUPWithExplicitDimensionlessUnit() {
             TestContext ctx = new TestContext().put("table", CompositeUnit.dimensionless());
             var result = analyze("LOOKUP(table, 5)", ctx);
             assertThat(result.inferredUnit().isDimensionless()).isTrue();
             assertThat(result.isConsistent()).isTrue();
+        }
+
+        @Test
+        void shouldReturnNullForLOOKUPWhenTableHasNoUnit() {
+            // Table not in context → unknown unit → return null
+            var result = analyze("LOOKUP(unknown_table, 5)", new TestContext());
+            assertThat(result.inferredUnit()).isNull();
+            assertThat(result.isConsistent()).isTrue();
+        }
+
+        @Test
+        void shouldAnalyzeLOOKUPArgumentsForWarnings() {
+            TestContext ctx = new TestContext()
+                    .put("Pop", ITEMS)
+                    .put("Weight", MASS);
+            // LOOKUP input adds incompatible units → should produce warning
+            var result = analyze("LOOKUP(unknown_table, Pop + Weight)", ctx);
+            assertThat(result.isConsistent()).isFalse();
+            assertThat(result.warnings().getFirst().message())
+                    .contains("incompatible");
         }
 
         @Test

--- a/courant-engine/src/test/java/systems/courant/sd/measure/UnitRegistryTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/UnitRegistryTest.java
@@ -330,6 +330,104 @@ class UnitRegistryTest {
     }
 
     @Nested
+    @DisplayName("Compound unit parsing — resolveComposite (#1211)")
+    class CompoundUnitParsing {
+
+        @Test
+        @DisplayName("should resolve simple unit name")
+        void shouldResolveSimpleUnit() {
+            CompositeUnit result = registry.resolveComposite("Deer");
+            assertThat(result.isDimensionless()).isFalse();
+            assertThat(result.exponents()).containsEntry(Dimension.ITEM, 1);
+        }
+
+        @Test
+        @DisplayName("should resolve rate unit 'Deer/year'")
+        void shouldResolveRateUnit() {
+            CompositeUnit result = registry.resolveComposite("Deer/year");
+            assertThat(result.exponents())
+                    .containsEntry(Dimension.ITEM, 1)
+                    .containsEntry(Dimension.TIME, -1);
+        }
+
+        @Test
+        @DisplayName("should resolve inverse unit '1/year'")
+        void shouldResolveInverseUnit() {
+            CompositeUnit result = registry.resolveComposite("1/year");
+            assertThat(result.exponents())
+                    .containsEntry(Dimension.TIME, -1)
+                    .hasSize(1);
+        }
+
+        @Test
+        @DisplayName("should resolve compound denominator 'Deer/(year*lion)'")
+        void shouldResolveCompoundDenominator() {
+            // Deer and lion are both ITEM, so ITEM cancels: {ITEM:1} / {TIME:1, ITEM:1} = {TIME:-1}
+            CompositeUnit result = registry.resolveComposite("Deer/(year*lion)");
+            assertThat(result.exponents())
+                    .containsEntry(Dimension.TIME, -1)
+                    .hasSize(1);
+        }
+
+        @Test
+        @DisplayName("should resolve 'acre/Deer'")
+        void shouldResolveDivisionWithAreaUnit() {
+            CompositeUnit result = registry.resolveComposite("acre/Deer");
+            assertThat(result.exponents())
+                    .containsEntry(Dimension.LENGTH, 1)
+                    .containsEntry(Dimension.ITEM, -1);
+        }
+
+        @Test
+        @DisplayName("should return dimensionless for null or blank")
+        void shouldReturnDimensionlessForNullOrBlank() {
+            assertThat(registry.resolveComposite(null).isDimensionless()).isTrue();
+            assertThat(registry.resolveComposite("").isDimensionless()).isTrue();
+            assertThat(registry.resolveComposite("  ").isDimensionless()).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return dimensionless for '1'")
+        void shouldReturnDimensionlessForOne() {
+            assertThat(registry.resolveComposite("1").isDimensionless()).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return dimensionless for 'dmnl'")
+        void shouldReturnDimensionlessForDmnl() {
+            assertThat(registry.resolveComposite("dmnl").isDimensionless()).isTrue();
+        }
+
+        @Test
+        @DisplayName("should handle multiplication 'year*lion'")
+        void shouldResolveProductUnit() {
+            CompositeUnit result = registry.resolveComposite("year*lion");
+            assertThat(result.exponents())
+                    .containsEntry(Dimension.TIME, 1)
+                    .containsEntry(Dimension.ITEM, 1);
+        }
+
+        @Test
+        @DisplayName("should handle spaces around operators")
+        void shouldHandleSpacesAroundOperators() {
+            CompositeUnit result = registry.resolveComposite("Deer / year");
+            assertThat(result.exponents())
+                    .containsEntry(Dimension.ITEM, 1)
+                    .containsEntry(Dimension.TIME, -1);
+        }
+
+        @Test
+        @DisplayName("Deer/year and acre/Deer should have expected compatibility")
+        void shouldProduceCompatibleUnitsForKaibabModel() {
+            // Deer * (1/year) should equal Deer/year
+            CompositeUnit deerPerYear = registry.resolveComposite("Deer/year");
+            CompositeUnit deer = registry.resolveComposite("Deer");
+            CompositeUnit inverseYear = registry.resolveComposite("1/year");
+            assertThat(deer.multiply(inverseYear)).isEqualTo(deerPerYear);
+        }
+    }
+
+    @Nested
     @DisplayName("MAX_CUSTOM_UNITS guard on register() (#632)")
     class RegisterGuard {
 


### PR DESCRIPTION
## Summary
- Add compound unit string parser (`UnitRegistry.resolveComposite()`) that correctly handles `Deer/year`, `1/year`, `Deer/(year*lion)`, `acre/Deer` — previously these were all treated as single ITEM units, producing false warnings
- Fix LOOKUP to return unknown when lookup tables have no declared unit, and analyze LOOKUP input arguments for internal consistency warnings
- Suppress false mismatch warnings for pure constant expressions (e.g. `0.2` declared as `1/year`)
- Show raw declared unit names in messages instead of dimension base unit names (e.g. "Deer/year" instead of "Item / Second")

Fixes #1211

## Test plan
- [x] 11 new compound unit parsing tests in `UnitRegistryTest`
- [x] 3 new LOOKUP behavior tests in `DimensionalAnalyzerTest`
- [x] 2 new compound resolution tests in `EditorUnitContextTest`
- [x] 2 updated lookup-without-unit tests in `EditorUnitContextTest`
- [x] All 146 tests pass
- [x] SpotBugs clean