### PR TITLE
Fix dimension label not updating on element switch

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/DimensionalAnalysisUI.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/DimensionalAnalysisUI.java
@@ -29,8 +29,24 @@ public class DimensionalAnalysisUI {
     /** Cached registry for dimensional analysis — avoids rebuilding on every keystroke. */
     private final UnitRegistry unitRegistry = new UnitRegistry();
 
+    /** Retained references for revalidation when the selected element changes. */
+    private EquationField attachedField;
+    private Label attachedErrorLabel;
+    private Label attachedDimensionLabel;
+
     public DimensionalAnalysisUI(FormContext ctx) {
         this.ctx = ctx;
+    }
+
+    /**
+     * Re-runs equation validation and dimensional analysis for the currently attached field.
+     * Call this after {@code updateValues()} to refresh the dimension label when the selected
+     * element changes on the fast path (same form type reused).
+     */
+    public void revalidate() {
+        if (attachedField != null && attachedErrorLabel != null && attachedDimensionLabel != null) {
+            validateEquation(attachedField, attachedErrorLabel, attachedDimensionLabel);
+        }
     }
 
     /**
@@ -77,6 +93,11 @@ public class DimensionalAnalysisUI {
                 validateEquation(field, errorLabel, dimensionLabel);
             }
         });
+
+        // Retain references for revalidation on element switch
+        this.attachedField = field;
+        this.attachedErrorLabel = errorLabel;
+        this.attachedDimensionLabel = dimensionLabel;
 
         // Initial validation
         validateEquation(field, errorLabel, dimensionLabel);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FlowForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FlowForm.java
@@ -95,6 +95,7 @@ public class FlowForm implements ElementForm {
         sourceLabel.setText(flow.source() != null ? flow.source() : "(cloud)");
         sinkLabel.setText(flow.sink() != null ? flow.sink() : "(cloud)");
         commentArea.setText(flow.comment() != null ? flow.comment() : "");
+        dimAnalysis.revalidate();
     }
 
     @Override

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/VariableForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/VariableForm.java
@@ -74,6 +74,7 @@ public class VariableForm implements ElementForm {
         equationField.setText(v.equation());
         unitBox.setValue(v.unit() != null ? v.unit() : "");
         commentArea.setText(v.comment() != null ? v.comment() : "");
+        dimAnalysis.revalidate();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- When switching between two variables (or two flows), the fast path reuses the form and calls `updateValues()` inside the `isUpdatingFields` guard, which suppressed the dimension label's debounce listener
- Add `revalidate()` method to `DimensionalAnalysisUI` that directly re-runs validation
- Call it from `VariableForm.updateValues()` and `FlowForm.updateValues()`

## Test plan
- [x] All tests pass
- [x] SpotBugs clean
- [ ] Manual: open Kaibab Deer model, click between variables — dimension label updates correctly