### PR TITLE
Add file name field to model info panel

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -331,6 +331,13 @@ public class ModelWindow {
                 simulationController::runSimulation,
                 simulationController::validateModel,
                 simulationController::openSimulationSettings);
+        propertiesPanel.setFileNameSupplier(() -> {
+            if (fileController == null || fileController.getCurrentFile() == null) {
+                return null;
+            }
+            java.nio.file.Path fn = fileController.getCurrentFile().getFileName();
+            return fn != null ? fn.toString() : null;
+        });
 
         // Right-side TabPane with Properties and Dashboard tabs
         rightTabPane = new TabPane();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/PropertiesPanel.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/PropertiesPanel.java
@@ -66,6 +66,7 @@ public class PropertiesPanel extends VBox {
     private Runnable onRunSimulation;
     private Runnable onValidateModel;
     private Runnable onOpenSettings;
+    private java.util.function.Supplier<String> fileNameSupplier;
 
     public PropertiesPanel() {
         setId("propertiesPanel");
@@ -125,6 +126,13 @@ public class PropertiesPanel extends VBox {
     }
 
     /**
+     * Sets a supplier that returns the current file name (without path), or null if unsaved.
+     */
+    public void setFileNameSupplier(java.util.function.Supplier<String> supplier) {
+        this.fileNameSupplier = supplier;
+    }
+
+    /**
      * Updates the panel to reflect the current selection on the canvas.
      * Called by CourantApp whenever the canvas status changes.
      * Wrapped in updatingFields guard to prevent spurious focus-loss commits.
@@ -180,13 +188,17 @@ public class PropertiesPanel extends VBox {
         TextField nameField = fields.createTextField(
                 editor.getModelName() != null ? editor.getModelName() : "Untitled");
         nameField.setId("modelNameField");
-        fields.addFieldRow(row++, "Model", nameField);
+        fields.addFieldRow(row++, "Name", nameField);
         nameField.setOnAction(e -> commitModelName(nameField, editor));
         nameField.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
             if (!isFocused && !ctx.isUpdatingFields()) {
                 commitModelName(nameField, editor);
             }
         });
+
+        // File name (read-only)
+        String fileName = fileNameSupplier != null ? fileNameSupplier.get() : null;
+        fields.addReadOnlyRow(row++, "File", fileName != null ? fileName : "(not saved)");
 
         // Description (editable)
         TextArea descArea = new TextArea(


### PR DESCRIPTION
## Summary
- Add read-only "File" field to the model summary in the properties panel, showing the file name (or "(not saved)" for new models)
- Rename the model name label from "Model" to "Name" for clarity alongside the new "File" field
- Wire file name supplier from FileController through to PropertiesPanel

Fixes #1212

## Test plan
- [x] All tests pass
- [x] SpotBugs clean
- [ ] Manual: open a saved model — both Name and File fields appear; new model shows "(not saved)"