### PR TITLE
Always show model name in title bar, not file name

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -899,11 +899,8 @@ public class ModelWindow {
             return;
         }
         String name;
-        if (editor != null && !"Untitled".equals(editor.getModelName())) {
+        if (editor != null && editor.getModelName() != null && !editor.getModelName().isBlank()) {
             name = editor.getModelName();
-        } else if (fileController != null && fileController.getCurrentFile() != null) {
-            Path fn = fileController.getCurrentFile().getFileName();
-            name = fn != null ? fn.toString() : fileController.getCurrentFile().toString();
         } else {
             name = "Untitled";
         }


### PR DESCRIPTION
## Summary
- Title bar now always shows the model name from the definition, never falls back to the file name
- The file name is available in the new "File" field on the properties panel (added in #1218)

Part of #1212

## Test plan
- [x] All tests pass
- [x] SpotBugs clean
- [ ] Manual: open a model — title shows model name; save as new file — title still shows model name