### PR TITLE
Fix status bar clipped off-screen on small displays

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/CourantApp.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/CourantApp.java
@@ -60,10 +60,21 @@ public class CourantApp extends Application {
         var scene = stage.getScene();
         double sceneWidth = scene != null ? scene.getWidth() : 1200;
         double sceneHeight = scene != null ? scene.getHeight() : 800;
+        double windowWidth = sceneWidth;
         double windowHeight = sceneHeight + DECORATION_ALLOWANCE;
 
+        // Shrink to fit if the window would exceed the screen
+        if (windowHeight > bounds.getHeight()) {
+            stage.setHeight(bounds.getHeight());
+            windowHeight = bounds.getHeight();
+        }
+        if (windowWidth > bounds.getWidth()) {
+            stage.setWidth(bounds.getWidth());
+            windowWidth = bounds.getWidth();
+        }
+
         stage.setX(Math.max(bounds.getMinX(),
-                bounds.getMinX() + (bounds.getWidth() - sceneWidth) / 2));
+                bounds.getMinX() + (bounds.getWidth() - windowWidth) / 2));
         stage.setY(Math.max(bounds.getMinY(),
                 bounds.getMinY() + (bounds.getHeight() - windowHeight) / 2));
     }
@@ -100,6 +111,23 @@ public class CourantApp extends Application {
 
         if (!topVisible) {
             centerOnPrimaryScreen(stage);
+            return;
+        }
+
+        // Ensure the bottom of the window is on-screen so the status bar is visible.
+        Rectangle2D screenBounds = Screen.getScreensForRectangle(x, y, width, height)
+                .stream()
+                .map(Screen::getVisualBounds)
+                .findFirst()
+                .orElse(Screen.getPrimary().getVisualBounds());
+
+        if (height > screenBounds.getHeight()) {
+            stage.setHeight(screenBounds.getHeight());
+            height = screenBounds.getHeight();
+        }
+        double bottomOverflow = (y + height) - screenBounds.getMaxY();
+        if (bottomOverflow > 0) {
+            stage.setY(Math.max(screenBounds.getMinY(), y - bottomOverflow));
         }
     }
 

--- a/courant-app/src/test/java/systems/courant/sd/app/CourantAppFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/CourantAppFxTest.java
@@ -42,6 +42,10 @@ class CourantAppFxTest {
         assertThat(stage.getX())
                 .as("window X should be within the visible screen area")
                 .isGreaterThanOrEqualTo(primaryBounds.getMinX());
+
+        assertThat(stage.getY() + stage.getHeight())
+                .as("window bottom should not extend past the visible screen area")
+                .isLessThanOrEqualTo(primaryBounds.getMaxY() + 1.0);
     }
 
     @Test
@@ -75,7 +79,9 @@ class CourantAppFxTest {
 
         Rectangle2D primaryBounds = Screen.getPrimary().getVisualBounds();
         double targetX = primaryBounds.getMinX() + 100;
-        double targetY = primaryBounds.getMinY() + 100;
+        // Pick a Y where the full window fits on-screen (top and bottom)
+        double targetY = Math.min(primaryBounds.getMinY() + 100,
+                primaryBounds.getMaxY() - stage.getHeight());
 
         WaitForAsyncUtils.asyncFx(() -> {
             stage.setX(targetX);
@@ -105,6 +111,33 @@ class CourantAppFxTest {
                 .isGreaterThanOrEqualTo(primaryBounds.getMinX());
         assertThat(stage.getY())
                 .as("centered Y should be within screen bounds")
+                .isGreaterThanOrEqualTo(primaryBounds.getMinY());
+    }
+
+    @Test
+    @DisplayName("should pull window up when bottom extends past screen")
+    void shouldFixBottomOverflow() {
+        WaitForAsyncUtils.waitForFxEvents();
+
+        Rectangle2D primaryBounds = Screen.getPrimary().getVisualBounds();
+        // Position the window so it starts near the bottom of the screen,
+        // pushing the status bar off-screen.
+        double overflowY = primaryBounds.getMaxY() - 100;
+
+        WaitForAsyncUtils.asyncFx(() -> {
+            stage.setX(primaryBounds.getMinX() + 50);
+            stage.setY(overflowY);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        WaitForAsyncUtils.asyncFx(() -> app.ensureWindowOnScreen(stage));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(stage.getY() + stage.getHeight())
+                .as("window bottom should be pulled back on-screen")
+                .isLessThanOrEqualTo(primaryBounds.getMaxY() + 1.0);
+        assertThat(stage.getY())
+                .as("window top should remain on-screen")
                 .isGreaterThanOrEqualTo(primaryBounds.getMinY());
     }
 


### PR DESCRIPTION
## Summary
- `centerOnPrimaryScreen` now shrinks the window to fit within the screen's visual bounds before centering
- `ensureWindowOnScreen` now checks the bottom edge and adjusts position/size so the status bar stays visible
- Added test for bottom-overflow correction; updated existing test to place window where it fully fits

## Test plan
- [x] All 1880 tests pass
- [x] SpotBugs clean