### PR TITLE
Move File field to Model Info dialog

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelInfoDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelInfoDialog.java
@@ -26,6 +26,13 @@ final class ModelInfoDialog {
      * {@code editor} and invokes {@code onSaved}.
      */
     static void show(ModelEditor editor, Stage owner, Runnable onSaved) {
+        show(editor, owner, null, onSaved);
+    }
+
+    /**
+     * Shows the Model Info dialog with an optional file name display.
+     */
+    static void show(ModelEditor editor, Stage owner, String fileName, Runnable onSaved) {
         Dialog<ButtonType> dialog = new Dialog<>();
         dialog.setTitle("Model Info");
         dialog.setHeaderText(null);
@@ -64,6 +71,10 @@ final class ModelInfoDialog {
         int row = 0;
         grid.add(new Label("Name:"), 0, row);
         grid.add(nameField, 1, row++);
+        Label fileLabel = new Label(fileName != null ? fileName : "(not saved)");
+        fileLabel.setStyle("-fx-text-fill: #666;");
+        grid.add(new Label("File:"), 0, row);
+        grid.add(fileLabel, 1, row++);
         grid.add(new Label("Comment:"), 0, row);
         grid.add(commentArea, 1, row++);
         grid.add(new Label("Author:"), 0, row);

--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -333,8 +333,6 @@ public class ModelWindow {
                 simulationController::runSimulation,
                 simulationController::validateModel,
                 simulationController::openSimulationSettings);
-        propertiesPanel.setFileNameSupplier(() ->
-                fileController != null ? fileController.getDisplayFileName() : null);
 
         // Right-side TabPane with Properties and Dashboard tabs
         rightTabPane = new TabPane();
@@ -611,7 +609,8 @@ public class ModelWindow {
                         dashboardPanel),
                 null, "menuExportReport");
         commandRegistry.add("Model Info", "File",
-                () -> ModelInfoDialog.show(editor, stage, this::updateTitle));
+                () -> ModelInfoDialog.show(editor, stage,
+                        fileController.getDisplayFileName(), this::updateTitle));
         commandRegistry.add("Import Reference Data", "File",
                 () -> fileController.importReferenceData(
                         simulationController::runSimulation),

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/PropertiesPanel.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/PropertiesPanel.java
@@ -66,7 +66,6 @@ public class PropertiesPanel extends VBox {
     private Runnable onRunSimulation;
     private Runnable onValidateModel;
     private Runnable onOpenSettings;
-    private java.util.function.Supplier<String> fileNameSupplier;
 
     public PropertiesPanel() {
         setId("propertiesPanel");
@@ -126,13 +125,6 @@ public class PropertiesPanel extends VBox {
     }
 
     /**
-     * Sets a supplier that returns the current file name (without path), or null if unsaved.
-     */
-    public void setFileNameSupplier(java.util.function.Supplier<String> supplier) {
-        this.fileNameSupplier = supplier;
-    }
-
-    /**
      * Updates the panel to reflect the current selection on the canvas.
      * Called by CourantApp whenever the canvas status changes.
      * Wrapped in updatingFields guard to prevent spurious focus-loss commits.
@@ -188,17 +180,13 @@ public class PropertiesPanel extends VBox {
         TextField nameField = fields.createTextField(
                 editor.getModelName() != null ? editor.getModelName() : "Untitled");
         nameField.setId("modelNameField");
-        fields.addFieldRow(row++, "Name", nameField);
+        fields.addFieldRow(row++, "Model", nameField);
         nameField.setOnAction(e -> commitModelName(nameField, editor));
         nameField.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
             if (!isFocused && !ctx.isUpdatingFields()) {
                 commitModelName(nameField, editor);
             }
         });
-
-        // File name (read-only)
-        String fileName = fileNameSupplier != null ? fileNameSupplier.get() : null;
-        fields.addReadOnlyRow(row++, "File", fileName != null ? fileName : "(not saved)");
 
         // Description (editable)
         TextArea descArea = new TextArea(


### PR DESCRIPTION
## Summary
- Move the File name field from the properties panel to the Model Info dialog (File → Model Info)
- Properties panel reverts to showing just "Model" with the model name
- Model Info dialog now shows both Name (editable) and File (read-only) as separate fields

Fixes #1212

## Test plan
- [x] All tests pass
- [x] SpotBugs clean
- [ ] Manual: properties panel shows only model name; File → Model Info shows both Name and File