### PR TITLE
Fix false unit mismatch for dimensionless stock unit "1"

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
@@ -31,7 +31,7 @@ public class UnitRegistry {
 
     /** Dimensionless-equivalent names (lowercase). Resolved to DIMENSIONLESS. */
     private static final Set<String> DIMENSIONLESS_NAMES = Set.of(
-            "dmnl", "units", "unit", "dimensionless",
+            "1", "dmnl", "units", "unit", "dimensionless",
             "fraction", "percent", "percentage", "ratio", "index");
 
     /**

--- a/courant-engine/src/test/java/systems/courant/sd/measure/UnitRegistryTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/UnitRegistryTest.java
@@ -195,6 +195,13 @@ class UnitRegistryTest {
         }
 
         @Test
+        @DisplayName("should resolve '1' to DIMENSIONLESS unit")
+        void shouldResolveOneToDimensionless() {
+            Unit unit = registry.resolve("1");
+            assertThat(unit).isSameAs(DimensionlessUnits.DIMENSIONLESS);
+        }
+
+        @Test
         @DisplayName("should silently create unit for domain-specific names like 'Deer'")
         void shouldSilentlyCreateDomainSpecificName() {
             Unit unit = registry.resolve("Deer");


### PR DESCRIPTION
## Summary
- `UnitRegistry.resolve("1")` was auto-creating an `ItemUnit` instead of returning `DIMENSIONLESS`, causing flows connected to stocks with unit `"1"` to show a spurious "Equation yields 1/Second, expected 1/Year" warning
- Added `"1"` to `DIMENSIONLESS_NAMES` so `resolve()` is consistent with `resolveComposite()`
- Added test for `resolve("1")` → `DIMENSIONLESS`

## Test plan
- [x] New test `shouldResolveOneToDimensionless` passes
- [x] Full test suite passes (all modules)
- [x] SpotBugs clean