### PR TITLE
Warn when evaluateAtCompileTime falls back to uninitialized state

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -1171,15 +1171,24 @@ public class ExprCompiler {
     }
 
     /**
-     * Compiles an expression and evaluates it immediately. Used for parameters
-     * like delay times that must be known at compile time but may reference
-     * variables or variables (evaluated at their initial/current values).
+     * Evaluates an expression at compile time to obtain a numeric value.
+     * Tries strict constant evaluation first (literals, named constants,
+     * arithmetic on those). If that fails, falls back to compiling and
+     * evaluating the full expression against current model state, which
+     * may contain uninitialized variables. A warning is logged when the
+     * fallback is used so that incorrect initial values can be diagnosed.
      */
     private double evaluateAtCompileTime(Expr expr, String paramDescription) {
         try {
             return evaluateConstant(expr, paramDescription);
         } catch (CompilationException e) {
-            // Fall back to compiling and evaluating the full expression
+            String msg = paramDescription
+                    + ": expression is not a compile-time constant ("
+                    + e.getMessage()
+                    + ") — evaluating against current model state, which may"
+                    + " contain uninitialized variables";
+            logger.warn(msg);
+            context.addWarning(msg);
             DoubleSupplier compiled = compileExpr(expr);
             return compiled.getAsDouble();
         }

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
@@ -1206,6 +1206,22 @@ class ExprCompilerTest {
             // Initial value should be 75 (from init_val)
             assertThat(val).isCloseTo(75.0, within(0.01));
         }
+
+        @Test
+        void shouldWarnWhenInitialValueIsNotCompileTimeConstant() {
+            context.addVariable("normal_price",
+                    new systems.courant.sd.model.Variable("normal_price",
+                            ItemUnits.PEOPLE, () -> 50.0));
+            context.addVariable("input",
+                    new systems.courant.sd.model.Variable("input",
+                            ItemUnits.PEOPLE, () -> 100.0));
+
+            compiler.compile("SMOOTHI(input, 5, normal_price)");
+            assertThat(context.getWarnings())
+                    .anyMatch(w -> w.contains("SMOOTHI initialValue")
+                            && w.contains("not a compile-time constant")
+                            && w.contains("uninitialized variables"));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- When `evaluateConstant` fails for non-constant expressions, the fallback now logs a warning and records it in `CompilationContext` before evaluating against current model state
- Previously this happened silently, masking cases where delay times or initial values were computed from uninitialized variables
- Added test verifying the warning is emitted for non-constant initial value expressions

Closes #1232