### PR TITLE
Skip builtin function calls when rewriting subscripted names

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/SubscriptExpander.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/SubscriptExpander.java
@@ -5,6 +5,7 @@ import systems.courant.sd.model.def.FlowDef;
 import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.StockDef;
 import systems.courant.sd.model.def.SubscriptDef;
+import systems.courant.sd.model.expr.BuiltinFunctions;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -226,6 +227,16 @@ public class SubscriptExpander {
             }
 
             int afterMatch = matcher.end();
+
+            // If the name is followed by '(' and matches a built-in function,
+            // treat it as a function call rather than a subscripted variable.
+            if (afterMatch < equation.length()
+                    && equation.charAt(afterMatch) == '('
+                    && BuiltinFunctions.NAMES.contains(rawName.toUpperCase())) {
+                result.append(matchedText);
+                cursor = matcher.end();
+                continue;
+            }
             if (afterMatch < equation.length() && equation.charAt(afterMatch) == '[') {
                 int closeBracket = equation.indexOf(']', afterMatch);
                 if (closeBracket < 0) {

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/SubscriptExpanderTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/SubscriptExpanderTest.java
@@ -137,6 +137,27 @@ class SubscriptExpanderTest {
 
             assertThat(expanded.flows().get(0).equation()).isEqualTo("Pop[X] + density[X]");
         }
+
+        @Test
+        void shouldNotRewriteBuiltinFunctionCallMatchingSubscriptedName() {
+            // "SIN" is both a subscripted element and a built-in function name.
+            // The function call SIN(angle) must not be rewritten to SIN[A](angle).
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Builtin Conflict")
+                    .subscript("Region", List.of("A", "B"))
+                    .stock("SIN", 100, "Thing", List.of("Region"))
+                    .constant("angle", 1.0, "Radian")
+                    .flow("outflow", "SIN * 0.1 + SIN(angle)", "Day", "SIN", null, List.of("Region"))
+                    .build();
+
+            ModelDefinition expanded = SubscriptExpander.expand(def);
+
+            // SIN as a variable reference should be expanded; SIN(angle) as a function call should not
+            assertThat(expanded.flows().get(0).equation())
+                    .isEqualTo("SIN[A] * 0.1 + SIN(angle)");
+            assertThat(expanded.flows().get(1).equation())
+                    .isEqualTo("SIN[B] * 0.1 + SIN(angle)");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- `rewriteEquation` now checks if a matched subscripted name is followed by `(` and matches a built-in function name, treating it as a function call instead of a variable reference
- Prevents corruption like `SIN(x)` → `SIN[North](x)` when a subscripted element shares a name with a built-in function
- Added test covering the builtin-function-name conflict scenario

Closes #1231