### PR TITLE
Fix self-loop causal link highlight rendering

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/InteractionOverlayPass.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/InteractionOverlayPass.java
@@ -363,16 +363,14 @@ final class InteractionOverlayPass implements RenderPass {
 
         if (isCausalLink) {
             if (fromName.equals(toName)) {
-                FlowGeometry.Point2D cf = FlowGeometry.clipToElement(
-                        canvasState, fromName, toX, toY);
-                FlowGeometry.Point2D ct = FlowGeometry.clipToElement(
-                        canvasState, toName, fromX, fromY);
+                double halfW = LayoutMetrics.effectiveWidth(canvasState, fromName) / 2;
+                double halfH = LayoutMetrics.effectiveHeight(canvasState, fromName) / 2;
+                double[] loopPts = CausalLinkGeometry.selfLoopPoints(
+                        fromX, fromY, halfW, halfH, loopCtx, fromName);
                 if (isHover) {
-                    SelectionRenderer.drawConnectionHover(gc,
-                            cf.x(), cf.y(), ct.x(), ct.y());
+                    SelectionRenderer.drawConnectionHoverCubic(gc, loopPts);
                 } else {
-                    SelectionRenderer.drawConnectionSelection(gc,
-                            cf.x(), cf.y(), ct.x(), ct.y());
+                    SelectionRenderer.drawConnectionSelectionCubic(gc, loopPts);
                 }
                 return;
             }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/SelectionRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/SelectionRenderer.java
@@ -98,6 +98,35 @@ public final class SelectionRenderer {
     }
 
     /**
+     * Draws a cubic Bézier hover highlight for a self-loop causal link.
+     *
+     * @param loopPts 8-element array {startX, startY, cp1X, cp1Y, cp2X, cp2Y, endX, endY}
+     */
+    public static void drawConnectionHoverCubic(GraphicsContext gc, double[] loopPts) {
+        gc.setStroke(ColorPalette.HOVER);
+        gc.setLineWidth(3.0);
+        gc.setLineDashes();
+        CausalLinkGeometry.strokeCubicCurve(gc,
+                loopPts[0], loopPts[1], loopPts[2], loopPts[3],
+                loopPts[4], loopPts[5], loopPts[6], loopPts[7], 1.0);
+    }
+
+    /**
+     * Draws a cubic Bézier selection highlight for a self-loop causal link.
+     *
+     * @param loopPts 8-element array {startX, startY, cp1X, cp1Y, cp2X, cp2Y, endX, endY}
+     */
+    public static void drawConnectionSelectionCubic(GraphicsContext gc, double[] loopPts) {
+        gc.setStroke(SELECTION_COLOR);
+        gc.setLineWidth(3.0);
+        gc.setLineDashes(SELECTION_DASH_LENGTH, SELECTION_DASH_GAP);
+        CausalLinkGeometry.strokeCubicCurve(gc,
+                loopPts[0], loopPts[1], loopPts[2], loopPts[3],
+                loopPts[4], loopPts[5], loopPts[6], loopPts[7], 1.0);
+        gc.setLineDashes();
+    }
+
+    /**
      * Draws a hover indicator around the named element.
      * Uses a solid outline (no dashes, no handles) to distinguish from selection.
      */


### PR DESCRIPTION
## Summary
- Self-loop causal links now render hover/selection highlights as cubic Bézier curves matching the actual link shape
- Added `drawConnectionHoverCubic` and `drawConnectionSelectionCubic` to `SelectionRenderer`
- Updated `InteractionOverlayPass.drawClippedHighlight()` to compute loop geometry via `CausalLinkGeometry.selfLoopPoints()`

Closes #1227