### PR TITLE
Preserve Infinity from POW/POWER instead of converting to NaN

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -143,12 +143,14 @@ public class ExprCompiler {
                 boolean[] warned = newWarnedFlag();
                 yield () -> {
                     double result = Math.pow(left.getAsDouble(), right.getAsDouble());
-                    if (Double.isNaN(result) || Double.isInfinite(result)) {
+                    if (Double.isNaN(result)) {
                         if (!warned[0]) {
-                            logger.warn("Power produced non-finite result");
+                            logger.warn("Power produced NaN result");
                             warned[0] = true;
                         }
-                        return Double.NaN;
+                    } else if (Double.isInfinite(result) && !warned[0]) {
+                        logger.warn("Power produced infinite result");
+                        warned[0] = true;
                     }
                     return result;
                 };
@@ -478,12 +480,14 @@ public class ExprCompiler {
         boolean[] warned = newWarnedFlag();
         return () -> {
             double result = Math.pow(a.getAsDouble(), b.getAsDouble());
-            if (Double.isNaN(result) || Double.isInfinite(result)) {
+            if (Double.isNaN(result)) {
                 if (!warned[0]) {
-                    logger.warn("POWER produced non-finite result");
+                    logger.warn("POWER produced NaN result");
                     warned[0] = true;
                 }
-                return Double.NaN;
+            } else if (Double.isInfinite(result) && !warned[0]) {
+                logger.warn("POWER produced infinite result");
+                warned[0] = true;
             }
             return result;
         };

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
@@ -78,6 +78,18 @@ class ExprCompilerTest {
     }
 
     @Test
+    void shouldPreserveInfinityFromPowerOperator() {
+        Formula formula = compiler.compile("2 ** 10000");
+        assertThat(formula.getCurrentValue()).isEqualTo(Double.POSITIVE_INFINITY);
+    }
+
+    @Test
+    void shouldReturnNaNFromPowerOperatorForUndefinedResult() {
+        Formula formula = compiler.compile("(-1) ** 0.5");
+        assertThat(formula.getCurrentValue()).isNaN();
+    }
+
+    @Test
     void shouldCompileNegation() {
         Formula formula = compiler.compile("-Rate");
         assertThat(formula.getCurrentValue()).isCloseTo(-0.05, within(1e-10));
@@ -682,6 +694,18 @@ class ExprCompilerTest {
         void shouldCompilePOWER() {
             Formula formula = compiler.compile("POWER(2, 10)");
             assertThat(formula.getCurrentValue()).isEqualTo(1024.0);
+        }
+
+        @Test
+        void shouldPreserveInfinityFromPOWER() {
+            Formula formula = compiler.compile("POWER(2, 10000)");
+            assertThat(formula.getCurrentValue()).isEqualTo(Double.POSITIVE_INFINITY);
+        }
+
+        @Test
+        void shouldReturnNaNFromPOWERForUndefinedResult() {
+            Formula formula = compiler.compile("POWER(-1, 0.5)");
+            assertThat(formula.getCurrentValue()).isNaN();
         }
     }
 


### PR DESCRIPTION
## Summary
- Both the `^` operator and `POWER()` function now return Infinity for overflow cases instead of silently converting to NaN
- NaN is still returned for truly undefined results (e.g. `(-1)^0.5`)
- Adds tests for both Infinity and NaN cases on both code paths

Closes #1233