### PR TITLE
Fix AreaUnit dimension to AREA instead of LENGTH

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/measure/Dimension.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/Dimension.java
@@ -1,5 +1,6 @@
 package systems.courant.sd.measure;
 
+import systems.courant.sd.measure.dimension.Area;
 import systems.courant.sd.measure.dimension.Item;
 import systems.courant.sd.measure.dimension.Length;
 import systems.courant.sd.measure.dimension.Mass;
@@ -19,6 +20,7 @@ public interface Dimension {
     Dimension MONEY = Money.INSTANCE;
     Dimension MASS = Mass.INSTANCE;
     Dimension LENGTH = Length.INSTANCE;
+    Dimension AREA = Area.INSTANCE;
     Dimension VOLUME = Volume.INSTANCE;
     Dimension ITEM = Item.INSTANCE;
     Dimension TEMPERATURE = Temperature.INSTANCE;

--- a/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
@@ -389,7 +389,7 @@ public class UnitRegistry {
     }
 
     /**
-     * A simple area unit (Length^2) with a conversion factor to square meters.
+     * A simple area unit with a conversion factor to square meters.
      */
     private static final class AreaUnit implements Unit {
 
@@ -408,17 +408,12 @@ public class UnitRegistry {
 
         @Override
         public Dimension getDimension() {
-            return Dimension.LENGTH;
+            return Dimension.AREA;
         }
 
-        /**
-         * Returns the ratio to the base length unit (Meter) such that
-         * dimensional analysis treats this as Length^2. The actual conversion
-         * factor is sqrt(sqMeters) so that area = unit * unit = sqMeters m^2.
-         */
         @Override
         public double ratioToBaseUnit() {
-            return Math.sqrt(sqMeters);
+            return sqMeters;
         }
 
         @Override

--- a/courant-engine/src/main/java/systems/courant/sd/measure/dimension/Area.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/dimension/Area.java
@@ -1,0 +1,19 @@
+package systems.courant.sd.measure.dimension;
+
+import systems.courant.sd.measure.Dimension;
+import systems.courant.sd.measure.Unit;
+import systems.courant.sd.measure.units.area.AreaUnits;
+
+/**
+ * The area dimension. Base unit is square meters.
+ */
+public enum Area implements Dimension {
+
+    INSTANCE;
+
+    /** {@inheritDoc} Returns {@link AreaUnits#SQUARE_METER}. */
+    @Override
+    public Unit getBaseUnit() {
+        return AreaUnits.SQUARE_METER;
+    }
+}

--- a/courant-engine/src/main/java/systems/courant/sd/measure/units/area/AreaUnits.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/units/area/AreaUnits.java
@@ -1,0 +1,38 @@
+package systems.courant.sd.measure.units.area;
+
+import systems.courant.sd.measure.Dimension;
+import systems.courant.sd.measure.Unit;
+
+/**
+ * Standard units of area. Each constant stores its ratio to the base unit (square meters).
+ */
+public enum AreaUnits implements Unit {
+
+    SQUARE_METER("Square Meter", 1.0);
+
+    private final String name;
+    private final double ratioToBaseUnit;
+
+    AreaUnits(String name, double ratioToBaseUnit) {
+        this.name = name;
+        this.ratioToBaseUnit = ratioToBaseUnit;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    /** {@inheritDoc} Returns {@link Dimension#AREA}. */
+    @Override
+    public Dimension getDimension() {
+        return Dimension.AREA;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double ratioToBaseUnit() {
+        return ratioToBaseUnit;
+    }
+}

--- a/courant-engine/src/test/java/systems/courant/sd/measure/UnitRegistryTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/UnitRegistryTest.java
@@ -287,7 +287,7 @@ class UnitRegistryTest {
         void shouldFindHectare() {
             Unit unit = registry.find("hectare");
             assertThat(unit).isNotNull();
-            assertThat(unit.getDimension()).isSameAs(Dimension.LENGTH);
+            assertThat(unit.getDimension()).isSameAs(Dimension.AREA);
         }
 
         @Test
@@ -295,7 +295,7 @@ class UnitRegistryTest {
         void shouldFindKm2() {
             Unit unit = registry.find("km2");
             assertThat(unit).isNotNull();
-            assertThat(unit.getDimension()).isSameAs(Dimension.LENGTH);
+            assertThat(unit.getDimension()).isSameAs(Dimension.AREA);
         }
 
         @Test
@@ -303,7 +303,7 @@ class UnitRegistryTest {
         void shouldFindAcre() {
             Unit unit = registry.find("acre");
             assertThat(unit).isNotNull();
-            assertThat(unit.getDimension()).isSameAs(Dimension.LENGTH);
+            assertThat(unit.getDimension()).isSameAs(Dimension.AREA);
         }
 
         @Test
@@ -311,6 +311,23 @@ class UnitRegistryTest {
         void shouldFindHectaresPlural() {
             Unit unit = registry.find("hectares");
             assertThat(unit).isNotNull();
+        }
+
+        @Test
+        @DisplayName("area dimension should be distinct from length (#1226)")
+        void areaShouldNotBeLength() {
+            Unit hectare = registry.find("hectare");
+            Unit meter = registry.find("Meter");
+            assertThat(hectare.getDimension()).isNotSameAs(meter.getDimension());
+            assertThat(hectare.getDimension()).isSameAs(Dimension.AREA);
+        }
+
+        @Test
+        @DisplayName("area units should convert via direct square-meter ratio (#1226)")
+        void areaConversionShouldUseDirectRatio() {
+            Unit hectare = registry.find("hectare");
+            // 1 hectare = 10,000 m²
+            assertThat(hectare.ratioToBaseUnit()).isEqualTo(10_000.0);
         }
     }
 
@@ -381,7 +398,7 @@ class UnitRegistryTest {
         void shouldResolveDivisionWithAreaUnit() {
             CompositeUnit result = registry.resolveComposite("acre/Deer");
             assertThat(result.exponents())
-                    .containsEntry(Dimension.LENGTH, 1)
+                    .containsEntry(Dimension.AREA, 1)
                     .containsEntry(Dimension.ITEM, -1);
         }
 


### PR DESCRIPTION
## Summary
- Added dedicated `Area` dimension with `SQUARE_METER` as base unit, following the same pattern as `Volume`/`Length`
- `AreaUnit.getDimension()` now returns `Dimension.AREA` instead of `Dimension.LENGTH`
- `AreaUnit.ratioToBaseUnit()` now returns the direct square-meter conversion factor instead of `sqrt(sqMeters)`
- Dimensional analysis now correctly flags `hectare + meter` as a dimension mismatch

Closes #1226