### PR TITLE
Fix case-insensitive collision in UnitRegistry

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
@@ -160,7 +160,7 @@ public class UnitRegistry {
                                 + " custom units — possible unbounded auto-creation");
             }
             byName.put(unit.getName(), unit);
-            byNameLower.put(unit.getName().toLowerCase(), unit);
+            byNameLower.putIfAbsent(unit.getName().toLowerCase(), unit);
             customUnitCount++;
         }
     }

--- a/courant-engine/src/test/java/systems/courant/sd/measure/UnitRegistryTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/measure/UnitRegistryTest.java
@@ -453,6 +453,23 @@ class UnitRegistryTest {
         }
 
         @Test
+        @DisplayName("case-insensitive lookup should return first registered variant")
+        void shouldNotOverwriteCaseInsensitiveEntryOnCollision() {
+            UnitRegistry reg = new UnitRegistry();
+            ItemUnit upper = new ItemUnit("Foo");
+            ItemUnit lower = new ItemUnit("foo");
+            reg.register(upper);
+            reg.register(lower);
+
+            // Case-sensitive lookups return their exact match
+            assertThat(reg.find("Foo")).isSameAs(upper);
+            assertThat(reg.find("foo")).isSameAs(lower);
+
+            // Case-insensitive fallback returns the first registered (Foo)
+            assertThat(reg.find("FOO")).isSameAs(upper);
+        }
+
+        @Test
         @DisplayName("re-registering same name should not increment count")
         void shouldNotIncrementCountForReRegistration() {
             UnitRegistry reg = new UnitRegistry();


### PR DESCRIPTION
## Summary
- Use `putIfAbsent` for `byNameLower` so the first registered case variant wins for case-insensitive lookups
- Registering "Foo" then "foo" no longer silently overwrites the case-insensitive entry
- Added test verifying both case-sensitive and case-insensitive lookup behavior

Closes #1240