### PR TITLE
Fix ModelDefinitionSerializer to write UTF-8 explicitly

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -115,7 +116,7 @@ public class ModelDefinitionSerializer {
      */
     public void toFile(ModelDefinition def, Path path) throws IOException {
         String json = toJson(def);
-        Files.writeString(path, json);
+        Files.writeString(path, json, StandardCharsets.UTF_8);
     }
 
     /**

--- a/courant-engine/src/test/java/systems/courant/sd/io/json/ModelDefinitionSerializerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/json/ModelDefinitionSerializerTest.java
@@ -15,7 +15,12 @@ import systems.courant.sd.model.def.ViewDef;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -534,6 +539,36 @@ class ModelDefinitionSerializerTest {
             assertThatThrownBy(() -> serializer.toJson(deepModel))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("nesting depth");
+        }
+    }
+
+    @Nested
+    @DisplayName("File charset")
+    class FileCharset {
+
+        @TempDir
+        Path tempDir;
+
+        @Test
+        void shouldWriteUtf8SoRoundTripPreservesNonAscii() throws IOException {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Caf\u00e9 Model")
+                    .stock("Temp\u00e9rature", 100, "\u00b0C")
+                    .defaultSimulation("Day", 10, "Day")
+                    .build();
+
+            Path file = tempDir.resolve("test.courant.json");
+            serializer.toFile(def, file);
+
+            // Verify the file is valid UTF-8
+            String raw = Files.readString(file, StandardCharsets.UTF_8);
+            assertThat(raw).contains("Caf\u00e9 Model");
+            assertThat(raw).contains("Temp\u00e9rature");
+
+            // Round-trip
+            ModelDefinition loaded = serializer.fromFile(file);
+            assertThat(loaded.name()).isEqualTo("Caf\u00e9 Model");
+            assertThat(loaded.stocks().get(0).name()).isEqualTo("Temp\u00e9rature");
         }
     }
 


### PR DESCRIPTION
## Summary
- `toFile()` now passes `StandardCharsets.UTF_8` to `Files.writeString()`, matching the UTF-8 assumption in `fromFile()`
- Prevents silent corruption of non-ASCII characters on platforms with non-UTF-8 default charset
- Adds round-trip test with accented characters

Closes #1230