### PR TITLE
Register AreaUnits base unit in UnitRegistry

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
+++ b/courant-engine/src/main/java/systems/courant/sd/measure/UnitRegistry.java
@@ -1,5 +1,6 @@
 package systems.courant.sd.measure;
 
+import systems.courant.sd.measure.units.area.AreaUnits;
 import systems.courant.sd.measure.units.dimensionless.DimensionlessUnits;
 import systems.courant.sd.measure.units.item.ItemUnit;
 import systems.courant.sd.measure.units.item.ItemUnits;
@@ -66,6 +67,7 @@ public class UnitRegistry {
         registerAll(MoneyUnits.values());
         registerAll(VolumeUnits.values());
         registerAll(TemperatureUnits.values());
+        registerAll(AreaUnits.values());
         registerAll(DimensionlessUnits.values());
         registerTimeUnitAliases();
         registerCurrencyAliases();
@@ -97,7 +99,7 @@ public class UnitRegistry {
     }
 
     /**
-     * Registers area units as composite Length^2 constants with conversion factors to m^2.
+     * Registers named area units with conversion factors to square meters.
      */
     private void registerAreaUnits() {
         // hectare = 10,000 m^2
@@ -418,8 +420,12 @@ public class UnitRegistry {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             AreaUnit areaUnit = (AreaUnit) o;
             return name.equals(areaUnit.name);
         }


### PR DESCRIPTION
## Summary
- Register `AreaUnits.SQUARE_METER` in the `UnitRegistry` constructor so it's findable by name
- Fix missing braces on single-line `if` statements in `AreaUnit.equals()` per style guide
- Update stale Javadoc on `registerAreaUnits()`

Follow-up to #1226 — caught by code review agent.