### PR TITLE
Guard BehaviorModeClassifier against NaN and Infinity values

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/BehaviorModeClassifier.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/BehaviorModeClassifier.java
@@ -22,6 +22,10 @@ public final class BehaviorModeClassifier {
             return "";
         }
 
+        if (containsNonFinite(values)) {
+            return "";
+        }
+
         if (isConstant(values)) {
             return "Equilibrium";
         }
@@ -195,6 +199,15 @@ public final class BehaviorModeClassifier {
         double rise = peakValue - values[0];
         double fall = peakValue - lastValue;
         return rise > 0 && fall > rise * 0.3;
+    }
+
+    private static boolean containsNonFinite(double[] values) {
+        for (double v : values) {
+            if (!Double.isFinite(v)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static double range(double[] values) {

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/BehaviorModeClassifierTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/BehaviorModeClassifierTest.java
@@ -147,5 +147,23 @@ class BehaviorModeClassifierTest {
         void shouldReturnEmptyForNullInput() {
             assertThat(BehaviorModeClassifier.classify(null)).isEmpty();
         }
+
+        @Test
+        void shouldReturnEmptyWhenDataContainsNaN() {
+            double[] values = {1, 2, Double.NaN, 4, 5, 6, 7, 8};
+            assertThat(BehaviorModeClassifier.classify(values)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyWhenDataContainsPositiveInfinity() {
+            double[] values = {1, 2, 3, Double.POSITIVE_INFINITY, 5, 6, 7, 8};
+            assertThat(BehaviorModeClassifier.classify(values)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyWhenDataContainsNegativeInfinity() {
+            double[] values = {1, 2, 3, 4, Double.NEGATIVE_INFINITY, 6, 7, 8};
+            assertThat(BehaviorModeClassifier.classify(values)).isEmpty();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `classify()` now returns empty string when the time series contains any non-finite values (NaN, Infinity)
- Prevents misclassification caused by NaN comparison semantics always returning false

Closes #1229