### PR TITLE
Rebuild lookup data table after chart-driven point changes

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/LookupForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/LookupForm.java
@@ -444,6 +444,7 @@ public class LookupForm implements ElementForm {
         LookupTableDef updated = new LookupTableDef(
                 ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation(), lt.unit());
         ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupTable(ctx.getElementName(), updated));
+        ctx.requestFormRebuild();
     }
 
     public void deletePointByIndex(int index) {
@@ -466,6 +467,7 @@ public class LookupForm implements ElementForm {
         LookupTableDef updated = new LookupTableDef(
                 ctx.getElementName(), lt.comment(), newX, newY, lt.interpolation(), lt.unit());
         ctx.getCanvas().applyMutation(() -> ctx.getEditor().setLookupTable(ctx.getElementName(), updated));
+        ctx.requestFormRebuild();
     }
 
     private void commitChartDrag(int index, double newX, double newY) {


### PR DESCRIPTION
## Summary
- Added `ctx.requestFormRebuild()` after model mutations in `addPointAtPosition()` and `deletePointByIndex()`
- The data point table now updates immediately when points are added via chart double-click or removed via context menu

Closes #1228