### PR TITLE
Propagate non-zero initialTime from XMILE start element

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileImporter.java
@@ -8,6 +8,7 @@ import systems.courant.sd.model.def.LookupTableDef;
 import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.ModelDefinitionBuilder;
 import systems.courant.sd.model.def.ModuleInstanceDef;
+import systems.courant.sd.model.def.SimulationSettings;
 import systems.courant.sd.model.def.StockDef;
 import systems.courant.sd.model.def.ViewDef;
 
@@ -163,7 +164,8 @@ public class XmileImporter implements ModelImporter {
 
         ModelDefinitionBuilder builder = new ModelDefinitionBuilder()
                 .name(modelName)
-                .defaultSimulation(timeUnit, duration, timeUnit, dt);
+                .defaultSimulation(new SimulationSettings(
+                        timeUnit, duration, timeUnit, dt, false, 1, start));
 
         if (mainModelElem == null) {
             return new ImportResult(builder.build(), warnings);

--- a/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileImporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileImporterTest.java
@@ -338,6 +338,47 @@ class XmileImporterTest {
         }
 
         @Test
+        void shouldPreserveNonZeroInitialTime() {
+            String xmile = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <xmile xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0" version="1.0">
+                      <header><name>Test</name></header>
+                      <sim_specs time_units="year">
+                        <start>1900</start><stop>2000</stop><dt>1</dt>
+                      </sim_specs>
+                      <model><variables>
+                        <aux name="x"><eqn>1</eqn></aux>
+                      </variables></model>
+                    </xmile>
+                    """;
+
+            ImportResult result = importer.importModel(xmile, "Test");
+            var sim = result.definition().defaultSimulation();
+            assertThat(sim.initialTime()).isEqualTo(1900.0);
+            assertThat(sim.duration()).isEqualTo(100.0);
+        }
+
+        @Test
+        void shouldDefaultInitialTimeToZero() {
+            String xmile = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <xmile xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0" version="1.0">
+                      <header><name>Test</name></header>
+                      <sim_specs time_units="day">
+                        <start>0</start><stop>10</stop><dt>1</dt>
+                      </sim_specs>
+                      <model><variables>
+                        <aux name="x"><eqn>1</eqn></aux>
+                      </variables></model>
+                    </xmile>
+                    """;
+
+            ImportResult result = importer.importModel(xmile, "Test");
+            var sim = result.definition().defaultSimulation();
+            assertThat(sim.initialTime()).isEqualTo(0.0);
+        }
+
+        @Test
         void shouldUseModelNameFromHeader() {
             String xmile = """
                     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- XmileImporter now passes the parsed `<start>` value as `initialTime` to `SimulationSettings`
- Models starting at non-zero times (e.g. year 1900) now simulate correctly
- Adds tests for both non-zero and zero initial times

Closes #1225