### PR TITLE
Move CLD tools before stock-and-flow in toolbar

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasToolBar.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasToolBar.java
@@ -142,8 +142,8 @@ public class CanvasToolBar extends ToolBar {
         });
 
         getItems().addAll(selectButton, new Separator(),
+                cldVarButton, causalLinkButton, new Separator(),
                 stockButton, flowButton, auxButton, lookupButton, moduleButton, infoLinkButton,
-                new Separator(), cldVarButton, causalLinkButton,
                 new Separator(), commentButton,
                 new Separator(), loopsButton, new Separator(), validateButton,
                 spacer, searchHint);


### PR DESCRIPTION
## Summary
- Moved Causal Variable and Causal Link buttons to appear immediately after Select, before the stock-and-flow tools
- CLD and stock-and-flow groups remain separated by toolbar dividers
- Comment tool stays in its own shared section accessible from both contexts

New layout: Select | Causal Variable, Causal Link | Stock, Flow, Variable, Lookup, Module, Info Link | Comment | Loops | Validate

Closes #1213