### PR TITLE
Fix Javadoc errors blocking Maven Central publishing

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/MaturityIndicatorRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/MaturityIndicatorRenderer.java
@@ -17,7 +17,8 @@ import javafx.scene.text.TextAlignment;
  * </ul>
  *
  * <p>Unit-mismatch indicators on connection lines are drawn by
- * {@link ConnectionRenderer} using the color from {@link ColorPalette#UNIT_MISMATCH}.
+ * {@link systems.courant.sd.app.canvas.renderers.ConnectionRenderer ConnectionRenderer}
+ * using the color from {@link ColorPalette#UNIT_MISMATCH}.
  */
 public final class MaturityIndicatorRenderer {
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/ChartTimeCursor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/ChartTimeCursor.java
@@ -20,7 +20,7 @@ import systems.courant.sd.app.canvas.ChartUtils;
  * mouse position and exposes the current time step as a {@link DoubleProperty},
  * allowing multiple charts to share a synchronized cursor.
  *
- * <p>Usage: wrap the chart with {@link #install(XYChart)} which returns a
+ * <p>Usage: wrap the chart with {@link #install(XYChart, ChartTimeCursor[])} which returns a
  * {@code StackPane} containing the chart and the cursor overlay. Bind or
  * listen to {@link #cursorTimeStepProperty()} to synchronize across charts.
  */

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.11.2</version>
+                        <configuration>
+                            <doclint>all,-missing</doclint>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
## Summary
- Add `<doclint>all,-missing</doclint>` to the `maven-javadoc-plugin` in the release profile, suppressing missing-doc checks that caused all 8 prior releases to fail before reaching Sonatype Central
- Fix broken `@link` to `ConnectionRenderer` (cross-package reference needed FQN)
- Fix broken `@link` to `ChartTimeCursor#install` (method signature had wrong arity)

## Test plan
- [x] `mvn clean javadoc:jar -Prelease` completes with no errors
- [x] Full test suite passes (146 tests, 0 failures)
- [x] SpotBugs clean