### PR TITLE
Fix ExportBounds invalid bounding box with orphan flows

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ExportBounds.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ExportBounds.java
@@ -141,6 +141,11 @@ final class ExportBounds {
             }
         }
 
+        // If no element contributed real coordinates, return empty bounds
+        if (minX > maxX) {
+            return new Bounds(0, 0, 2 * PADDING, 2 * PADDING);
+        }
+
         // Add padding
         minX -= PADDING;
         minY -= PADDING;

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ExportBoundsTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ExportBoundsTest.java
@@ -147,4 +147,28 @@ class ExportBoundsTest {
         ExportBounds.Bounds bounds = ExportBounds.compute(state, editor);
         assertThat(bounds.width()).isGreaterThan(0);
     }
+
+    @Test
+    @DisplayName("should return empty bounds when flows have no cloud positions and draw order is empty")
+    void shouldReturnEmptyBoundsForOrphanFlowsWithNoClouds() {
+        CanvasState state = new CanvasState();
+        // No elements on canvas — draw order is empty
+
+        // Create a flow between two stocks, but don't place anything on the canvas
+        ModelEditor editor = new ModelEditor();
+        editor.loadFrom(new ModelDefinitionBuilder()
+                .name("Test")
+                .stock("S1", 0, null)
+                .stock("S2", 0, null)
+                .flow("F1", "10", "day", "S1", "S2")
+                .build());
+
+        ExportBounds.Bounds bounds = ExportBounds.compute(state, editor);
+
+        // Should return the default empty bounds, not an invalid bounding box
+        assertThat(bounds.minX()).isEqualTo(0);
+        assertThat(bounds.minY()).isEqualTo(0);
+        assertThat(bounds.width()).isEqualTo(100); // 2 * PADDING
+        assertThat(bounds.height()).isEqualTo(100);
+    }
 }


### PR DESCRIPTION
## Summary
- When draw order is empty and all cloud positions are null, `ExportBounds.compute()` returned an invalid bounding box with extreme min/max values
- Added a guard after the computation loops to return empty bounds when no element contributed real coordinates
- Added test for the orphan-flow edge case

Closes #1273