### PR TITLE
Fix long-to-int truncation in FlowTimeDemo delay calculation

### DIFF
--- a/courant-demos/src/main/java/systems/courant/sd/demo/FlowTimeDemo.java
+++ b/courant-demos/src/main/java/systems/courant/sd/demo/FlowTimeDemo.java
@@ -66,8 +66,8 @@ public class FlowTimeDemo {
         Flow demand = Flows.linearGrowth("New Orders", DAY, wip, newOrdersPerDay);
 
         Flow throughput = Flow.create("Delivered Reports", DAY, () -> {
-            int demandDelay = Math.max(0, (int) Math.round(tat.getValue()));
-            int stepToGet = Math.max(0, (int) (sim.getCurrentStep() - demandDelay));
+            long demandDelay = Math.max(0, Math.round(tat.getValue()));
+            long stepToGet = Math.max(0, sim.getCurrentStep() - demandDelay);
             double demandPlusDelay = demand.getHistoryAtTimeStep(stepToGet);
             return new Quantity(Math.min(capacity, demandPlusDelay), ItemUnits.THING);
         });

--- a/courant-demos/src/test/java/systems/courant/sd/demo/DemoSmokeTest.java
+++ b/courant-demos/src/test/java/systems/courant/sd/demo/DemoSmokeTest.java
@@ -342,8 +342,8 @@ class DemoSmokeTest {
         Flow demand = Flows.linearGrowth("New Orders", DAY, wip, 200);
 
         Flow throughput = Flow.create("Delivered Reports", DAY, () -> {
-            int demandDelay = Math.max(0, (int) Math.round(tat.getValue()));
-            int stepToGet = Math.max(0, (int) sim.getCurrentStep() - demandDelay);
+            long demandDelay = Math.max(0, Math.round(tat.getValue()));
+            long stepToGet = Math.max(0, sim.getCurrentStep() - demandDelay);
             double demandPlusDelay = demand.getHistoryAtTimeStep(stepToGet);
             return new Quantity(Math.min(capacity, demandPlusDelay),
                     Units.DIMENSIONLESS);

--- a/courant-demos/src/test/java/systems/courant/sd/demo/FlowTimeDemoTest.java
+++ b/courant-demos/src/test/java/systems/courant/sd/demo/FlowTimeDemoTest.java
@@ -62,8 +62,8 @@ class FlowTimeDemoTest {
         Flow demand = Flows.linearGrowth("New Orders", DAY, wip, newOrdersPerDay);
 
         Flow throughput = Flow.create("Delivered Reports", DAY, () -> {
-            int demandDelay = Math.max(0, (int) Math.round(tat.getValue()));
-            int stepToGet = Math.max(0, (int) sim.getCurrentStep() - demandDelay);
+            long demandDelay = Math.max(0, Math.round(tat.getValue()));
+            long stepToGet = Math.max(0, sim.getCurrentStep() - demandDelay);
             double demandPlusDelay = demand.getHistoryAtTimeStep(stepToGet);
             return new Quantity(Math.min(capacity, demandPlusDelay), ItemUnits.THING);
         });
@@ -105,8 +105,8 @@ class FlowTimeDemoTest {
         // Track throughput values
         double[] throughputSum = {0};
         Flow throughput = Flow.create("Delivered", DAY, () -> {
-            int demandDelay = Math.max(0, (int) Math.round(tat.getValue()));
-            int stepToGet = Math.max(0, (int) sim.getCurrentStep() - demandDelay);
+            long demandDelay = Math.max(0, Math.round(tat.getValue()));
+            long stepToGet = Math.max(0, sim.getCurrentStep() - demandDelay);
             double demandPlusDelay = demand.getHistoryAtTimeStep(stepToGet);
             double rate = Math.min(190, demandPlusDelay);
             throughputSum[0] += rate;


### PR DESCRIPTION
## Summary
- Changed `demandDelay` and `stepToGet` from `int` to `long` in FlowTimeDemo and corresponding test files
- Eliminates silent truncation of `Math.round()` (returns `long`) and `getCurrentStep()` (returns `long`) values
- `getHistoryAtTimeStep()` already accepts `long`, so no downstream changes needed

Closes #1271

## Test plan
- [x] All existing tests pass
- [x] SpotBugs clean