### PR TITLE
Emit savePer, initialTime, strictMode in DemoClassGenerator

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
@@ -111,6 +111,7 @@ public class DemoClassGenerator {
             sb.append("import systems.courant.sd.model.def.StockDef;\n");
         }
         boolean needsList = needsListImport(definition);
+        boolean needsSimSettings = needsFullSimulationConstructor(definition.defaultSimulation());
         if (!definition.modules().isEmpty()) {
             sb.append("import systems.courant.sd.model.def.ModelDefinition;\n");
             sb.append("import systems.courant.sd.model.def.ModuleInstanceDef;\n");
@@ -118,9 +119,14 @@ public class DemoClassGenerator {
             sb.append("\n");
             sb.append("import java.util.List;\n");
             sb.append("import java.util.Map;\n");
-        } else if (needsList) {
-            sb.append("\n");
-            sb.append("import java.util.List;\n");
+        } else {
+            if (needsSimSettings) {
+                sb.append("import systems.courant.sd.model.def.SimulationSettings;\n");
+            }
+            if (needsList) {
+                sb.append("\n");
+                sb.append("import java.util.List;\n");
+            }
         }
 
         sb.append('\n');
@@ -183,16 +189,7 @@ public class DemoClassGenerator {
         sb.append(INDENT2).append(".name(").append(escapeString(definition.name())).append(")");
 
         if (definition.defaultSimulation() != null) {
-            SimulationSettings sim = definition.defaultSimulation();
-            sb.append("\n").append(INDENT2)
-                    .append(".defaultSimulation(")
-                    .append(escapeString(sim.timeStep())).append(", ")
-                    .append(sim.duration()).append(", ")
-                    .append(escapeString(sim.durationUnit()));
-            if (sim.dt() != 1.0) {
-                sb.append(", ").append(sim.dt());
-            }
-            sb.append(")");
+            emitDefaultSimulation(sb, definition.defaultSimulation(), INDENT2);
         }
         sb.append(";\n\n");
 
@@ -305,15 +302,7 @@ public class DemoClassGenerator {
         sb.append(blockIndent).append("var innerBuilder = new ModelDefinitionBuilder()\n");
         sb.append(chainIndent).append(".name(").append(escapeString(inner.name())).append(")");
         if (inner.defaultSimulation() != null) {
-            SimulationSettings sim = inner.defaultSimulation();
-            sb.append("\n").append(chainIndent).append(".defaultSimulation(")
-                    .append(escapeString(sim.timeStep())).append(", ")
-                    .append(sim.duration()).append(", ")
-                    .append(escapeString(sim.durationUnit()));
-            if (sim.dt() != 1.0) {
-                sb.append(", ").append(sim.dt());
-            }
-            sb.append(")");
+            emitDefaultSimulation(sb, inner.defaultSimulation(), chainIndent);
         }
         sb.append(";\n");
 
@@ -358,6 +347,35 @@ public class DemoClassGenerator {
         emitMapLiteral(sb, module.outputBindings(), chainIndent);
         sb.append("));\n");
         sb.append(indent).append("}\n");
+    }
+
+    private static boolean needsFullSimulationConstructor(SimulationSettings sim) {
+        return sim != null && (sim.strictMode() || sim.savePer() != 1 || sim.initialTime() != 0.0);
+    }
+
+    private void emitDefaultSimulation(StringBuilder sb, SimulationSettings sim, String indent) {
+        if (needsFullSimulationConstructor(sim)) {
+            sb.append("\n").append(indent)
+                    .append(".defaultSimulation(new SimulationSettings(")
+                    .append(escapeString(sim.timeStep())).append(", ")
+                    .append(sim.duration()).append(", ")
+                    .append(escapeString(sim.durationUnit())).append(", ")
+                    .append(sim.dt()).append(", ")
+                    .append(sim.strictMode()).append(", ")
+                    .append(sim.savePer()).append(", ")
+                    .append(sim.initialTime())
+                    .append("))");
+        } else {
+            sb.append("\n").append(indent)
+                    .append(".defaultSimulation(")
+                    .append(escapeString(sim.timeStep())).append(", ")
+                    .append(sim.duration()).append(", ")
+                    .append(escapeString(sim.durationUnit()));
+            if (sim.dt() != 1.0) {
+                sb.append(", ").append(sim.dt());
+            }
+            sb.append(")");
+        }
     }
 
     /**

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/DemoClassGeneratorTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/DemoClassGeneratorTest.java
@@ -5,6 +5,7 @@ import systems.courant.sd.model.def.FlowDef;
 import systems.courant.sd.model.def.LookupTableDef;
 import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.ModelDefinitionBuilder;
+import systems.courant.sd.model.def.SimulationSettings;
 import systems.courant.sd.model.def.StockDef;
 import systems.courant.sd.model.def.VariableDef;
 
@@ -545,6 +546,126 @@ class DemoClassGeneratorTest {
             // Subscripted constant should use VariableDef constructor, not builder.constant()
             assertThat(source).contains("new VariableDef(");
             assertThat(source).contains("List.of(\"Region\")");
+        }
+    }
+
+    @Nested
+    @DisplayName("Issue #1262 — savePer, initialTime, strictMode preservation")
+    class SimulationSettingsPreservation {
+
+        @Test
+        void shouldEmitFullConstructorWhenInitialTimeNonDefault() {
+            SimulationSettings sim = new SimulationSettings("Year", 200.0, "Years",
+                    1.0, false, 1, 1990.0);
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Pop", 100.0, "people")
+                    .defaultSimulation(sim)
+                    .build();
+
+            ModelMetadata metadata = ModelMetadata.builder().license("CC-BY-SA-4.0").build();
+            String source = generator.generate(def, metadata, "TestDemo",
+                    "systems.courant.sd.demo", "test.mdl", List.of(), List.of());
+
+            assertThat(source).contains("new SimulationSettings(");
+            assertThat(source).contains("1990.0");
+            assertThat(source).contains("import systems.courant.sd.model.def.SimulationSettings;");
+        }
+
+        @Test
+        void shouldEmitFullConstructorWhenSavePerNonDefault() {
+            SimulationSettings sim = new SimulationSettings("Month", 120.0, "Months",
+                    1.0, false, 4, 0.0);
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Pop", 100.0, "people")
+                    .defaultSimulation(sim)
+                    .build();
+
+            ModelMetadata metadata = ModelMetadata.builder().license("CC-BY-SA-4.0").build();
+            String source = generator.generate(def, metadata, "TestDemo",
+                    "systems.courant.sd.demo", "test.mdl", List.of(), List.of());
+
+            assertThat(source).contains("new SimulationSettings(");
+            assertThat(source).contains(", 4,");
+        }
+
+        @Test
+        void shouldEmitFullConstructorWhenStrictModeTrue() {
+            SimulationSettings sim = new SimulationSettings("Day", 365.0, "Days",
+                    0.5, true, 1, 0.0);
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Pop", 100.0, "people")
+                    .defaultSimulation(sim)
+                    .build();
+
+            ModelMetadata metadata = ModelMetadata.builder().license("CC-BY-SA-4.0").build();
+            String source = generator.generate(def, metadata, "TestDemo",
+                    "systems.courant.sd.demo", "test.mdl", List.of(), List.of());
+
+            assertThat(source).contains("new SimulationSettings(");
+            assertThat(source).contains("true");
+        }
+
+        @Test
+        void shouldEmitAllNonDefaultSimulationFields() {
+            SimulationSettings sim = new SimulationSettings("Month", 240.0, "Months",
+                    0.25, true, 3, 1980.0);
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Pop", 100.0, "people")
+                    .defaultSimulation(sim)
+                    .build();
+
+            ModelMetadata metadata = ModelMetadata.builder().license("CC-BY-SA-4.0").build();
+            String source = generator.generate(def, metadata, "TestDemo",
+                    "systems.courant.sd.demo", "test.mdl", List.of(), List.of());
+
+            assertThat(source).contains(
+                    "new SimulationSettings(\"Month\", 240.0, \"Months\", 0.25, true, 3, 1980.0)");
+        }
+
+        @Test
+        void shouldUseShortFormWhenAllExtrasAreDefault() {
+            SimulationSettings sim = new SimulationSettings("Year", 50.0, "Years",
+                    1.0, false, 1, 0.0);
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Pop", 100.0, "people")
+                    .defaultSimulation(sim)
+                    .build();
+
+            ModelMetadata metadata = ModelMetadata.builder().license("CC-BY-SA-4.0").build();
+            String source = generator.generate(def, metadata, "TestDemo",
+                    "systems.courant.sd.demo", "test.mdl", List.of(), List.of());
+
+            assertThat(source).contains(".defaultSimulation(\"Year\", 50.0, \"Years\")");
+            assertThat(source).doesNotContain("new SimulationSettings(");
+        }
+
+        @Test
+        void shouldEmitFullConstructorForModuleInnerDefinition() {
+            SimulationSettings innerSim = new SimulationSettings("Year", 100.0, "Years",
+                    1.0, false, 1, 1990.0);
+            ModelDefinition innerDef = new ModelDefinitionBuilder()
+                    .name("Inner")
+                    .stock("X", 0, "unit")
+                    .defaultSimulation(innerSim)
+                    .build();
+
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Outer")
+                    .module("sub", innerDef, Map.of(), Map.of())
+                    .defaultSimulation("Year", 50.0, "Years")
+                    .build();
+
+            ModelMetadata metadata = ModelMetadata.builder().license("CC-BY-SA-4.0").build();
+            String source = generator.generate(def, metadata, "TestDemo",
+                    "systems.courant.sd.demo", "test.mdl", List.of(), List.of());
+
+            assertThat(source).contains("new SimulationSettings(\"Year\", 100.0, \"Years\"," +
+                    " 1.0, false, 1, 1990.0)");
         }
     }
 


### PR DESCRIPTION
## Summary
- When `SimulationSettings` has non-default `savePer`, `initialTime`, or `strictMode`, emit the full canonical constructor (`new SimulationSettings(...)`) instead of the shorthand builder overloads that silently dropped these fields
- Extracted shared `emitDefaultSimulation` helper to eliminate duplicate code between top-level and module emission paths
- Added `SimulationSettings` import to generated code when the full constructor is needed

Closes #1262

## Test plan
- [x] 6 new tests covering each non-default field individually, all together, default short-form, and module inner definitions
- [x] All 152 tests pass
- [x] SpotBugs clean