### PR TITLE
Fix ImportPipelineCli.close() closing System.in

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
@@ -43,12 +43,16 @@ public class ImportPipelineCli implements Closeable {
         }
     }
 
+    /**
+     * Releases the scanner reference without closing System.in.
+     *
+     * <p>Closing a {@link Scanner} that wraps {@code System.in} also closes
+     * the underlying stream, making stdin unusable for the rest of the JVM.
+     * We intentionally avoid that by only nulling the reference.
+     */
     @Override
     public void close() {
-        if (stdinScanner != null) {
-            stdinScanner.close();
-            stdinScanner = null;
-        }
+        stdinScanner = null;
     }
 
     int run(String[] args) throws IOException {

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/ImportPipelineCliTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/ImportPipelineCliTest.java
@@ -426,6 +426,30 @@ class ImportPipelineCliTest {
                 System.setIn(originalIn);
             }
         }
+
+        @Test
+        void shouldNotCloseSystemInWhenClosed() {
+            java.io.InputStream originalIn = System.in;
+            boolean[] closed = {false};
+            ByteArrayInputStream testStream = new ByteArrayInputStream(
+                    "line1\n".getBytes(StandardCharsets.UTF_8)) {
+                @Override
+                public void close() {
+                    closed[0] = true;
+                }
+            };
+            System.setIn(testStream);
+            try {
+                ImportPipelineCli cli = new ImportPipelineCli();
+                cli.prompt("Q: "); // forces scanner creation
+                cli.close();
+
+                // close() must NOT have closed the underlying stream
+                assertThat(closed[0]).isFalse();
+            } finally {
+                System.setIn(originalIn);
+            }
+        }
     }
 
     private static Path copyTestModel(Path targetDir) throws IOException {


### PR DESCRIPTION
## Summary
- Stop calling `Scanner.close()` on the stdin-wrapping scanner in `ImportPipelineCli.close()`, which would close `System.in` and make it unusable for the rest of the JVM
- Add test verifying the underlying stream is not closed

Closes #1270