### PR TITLE
Prevent ImportPipelineCli.close() from closing System.in

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
@@ -45,10 +45,9 @@ public class ImportPipelineCli implements Closeable {
 
     @Override
     public void close() {
-        if (stdinScanner != null) {
-            stdinScanner.close();
-            stdinScanner = null;
-        }
+        // Do not close stdinScanner — it wraps System.in, and Scanner.close()
+        // would close the underlying stream, breaking later stdin reads in the JVM.
+        stdinScanner = null;
     }
 
     int run(String[] args) throws IOException {


### PR DESCRIPTION
## Summary
- Removed `Scanner.close()` call in `ImportPipelineCli.close()` which was closing the underlying `System.in` stream
- Nulling the reference instead lets the GC handle the Scanner without side effects on stdin

Closes #1270

## Test plan
- [x] All existing tests pass
- [x] SpotBugs clean