### PR TITLE
Validate className as valid Java identifier in PipelineConfig

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/PipelineConfig.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/PipelineConfig.java
@@ -58,6 +58,11 @@ public record PipelineConfig(
         if (className == null || className.isBlank()) {
             throw new IllegalArgumentException("className must not be blank");
         }
+        if (!className.matches("[A-Z][a-zA-Z0-9_]*")) {
+            throw new IllegalArgumentException(
+                    "className must be a valid Java class name starting with an uppercase letter: "
+                            + className);
+        }
         if (outputDir == null) {
             throw new IllegalArgumentException("outputDir must not be null");
         }

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/PipelineConfigTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/PipelineConfigTest.java
@@ -56,6 +56,45 @@ class PipelineConfigTest {
         }
 
         @Test
+        void shouldRejectClassNameStartingWithLowercase() {
+            assertThatThrownBy(() -> new PipelineConfig(
+                    SOURCE, METADATA, null, "demo", OUTPUT, false, false))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("className");
+        }
+
+        @Test
+        void shouldRejectClassNameWithHyphen() {
+            assertThatThrownBy(() -> new PipelineConfig(
+                    SOURCE, METADATA, null, "My-Demo", OUTPUT, false, false))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("className");
+        }
+
+        @Test
+        void shouldRejectClassNameWithSpaces() {
+            assertThatThrownBy(() -> new PipelineConfig(
+                    SOURCE, METADATA, null, "My Demo", OUTPUT, false, false))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("className");
+        }
+
+        @Test
+        void shouldRejectClassNameWithDot() {
+            assertThatThrownBy(() -> new PipelineConfig(
+                    SOURCE, METADATA, null, "My.Demo", OUTPUT, false, false))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("className");
+        }
+
+        @Test
+        void shouldAcceptClassNameWithUnderscore() {
+            PipelineConfig config = new PipelineConfig(
+                    SOURCE, METADATA, null, "My_Demo", OUTPUT, false, false);
+            assertThat(config.className()).isEqualTo("My_Demo");
+        }
+
+        @Test
         void shouldRejectNullOutputDir() {
             assertThatThrownBy(() -> new PipelineConfig(
                     SOURCE, METADATA, null, "Demo", null, false, false))


### PR DESCRIPTION
## Summary
- Add regex validation `[A-Z][a-zA-Z0-9_]*` for `className` in the `PipelineConfig` compact constructor
- Rejects names with hyphens, spaces, dots, or lowercase starts that would produce invalid Java source

Closes #1269