### PR TITLE
Clamp DelayFixed catch-up loop to prevent int overflow

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/DelayFixed.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/DelayFixed.java
@@ -137,7 +137,8 @@ public class DelayFixed implements Formula, Resettable {
             long delta = step - lastStep;
             // For missed intermediate steps, repeat the last written input (zero-order hold)
             double lastKnownInput = buffer[(writeIndex - 1 + buffer.length) % buffer.length];
-            for (int d = 0; d < delta - 1; d++) {
+            long fillCount = Math.min(delta - 1, buffer.length);
+            for (long d = 0; d < fillCount; d++) {
                 buffer[writeIndex] = lastKnownInput;
                 writeIndex = (writeIndex + 1) % buffer.length;
             }

--- a/courant-engine/src/test/java/systems/courant/sd/model/DelayFixedTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/DelayFixedTest.java
@@ -169,6 +169,25 @@ class DelayFixedTest {
         }
 
         @Test
+        @DisplayName("should clamp iterations to buffer length for huge delta")
+        void shouldClampIterationsForHugeDelta() {
+            long[] step = {0};
+            double[] input = {10};
+            DelayFixed delay = DelayFixed.of(() -> input[0], 3, 0, () -> step[0]);
+
+            // Initialize at step 0
+            delay.getCurrentValue();
+
+            // Jump far beyond buffer size — must not spin or overflow
+            input[0] = 77;
+            step[0] = Integer.MAX_VALUE + 100L;
+            double result = delay.getCurrentValue();
+            // After the huge jump, the entire buffer is filled with last-known (10)
+            // then current input (77) written at the end; output is oldest = 10
+            assertThat(result).as("should complete without spinning").isEqualTo(10);
+        }
+
+        @Test
         @DisplayName("should match step-by-step when delta is always 1")
         void shouldMatchStepByStepWithNoCatchUp() {
             int[] step = {0};


### PR DESCRIPTION
## Summary
- Clamp the catch-up loop iterations to `Math.min(delta - 1, buffer.length)` to prevent spinning when delta far exceeds buffer size
- Change loop variable from `int` to `long` to prevent overflow when delta exceeds `Integer.MAX_VALUE`
- Add test that jumps step counter past `Integer.MAX_VALUE` to verify the fix

Closes #1264