### PR TITLE
Fix fragile XHTML regex patterns in PdfReportExporter

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/PdfReportExporter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/PdfReportExporter.java
@@ -90,12 +90,12 @@ public final class PdfReportExporter {
                 "<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en\">");
 
         // Close self-closing tags that are not closed in HTML5
-        xhtml = xhtml.replaceAll("<meta ([^>]*[^/])>", "<meta $1/>");
-        xhtml = xhtml.replaceAll("<link ([^>]*[^/])>", "<link $1/>");
-        xhtml = xhtml.replaceAll("<input ([^>]*[^/])>", "<input $1/>");
-        xhtml = xhtml.replaceAll("<br>", "<br/>");
-        xhtml = xhtml.replaceAll("<hr>", "<hr/>");
-        xhtml = xhtml.replaceAll("<img ([^>]*[^/])>", "<img $1/>");
+        xhtml = xhtml.replaceAll("<meta(\\s[^>]*[^/])?>", "<meta$1/>");
+        xhtml = xhtml.replaceAll("<link(\\s[^>]*[^/])?>", "<link$1/>");
+        xhtml = xhtml.replaceAll("<input(\\s[^>]*[^/])?>", "<input$1/>");
+        xhtml = xhtml.replaceAll("<br\\s*/?>", "<br/>");
+        xhtml = xhtml.replaceAll("<hr\\s*/?>", "<hr/>");
+        xhtml = xhtml.replaceAll("<img(\\s[^>]*[^/])?>", "<img$1/>");
 
         return xhtml;
     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/PdfReportExporterTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/PdfReportExporterTest.java
@@ -52,6 +52,37 @@ class PdfReportExporterTest {
         }
 
         @Test
+        @DisplayName("should close br tags with whitespace")
+        void shouldCloseBrTagsWithWhitespace() {
+            assertThat(PdfReportExporter.toXhtml("a<br >b")).contains("<br/>");
+            assertThat(PdfReportExporter.toXhtml("a<br/>b")).contains("<br/>");
+            assertThat(PdfReportExporter.toXhtml("a<br />b")).contains("<br/>");
+        }
+
+        @Test
+        @DisplayName("should close hr tags with whitespace")
+        void shouldCloseHrTagsWithWhitespace() {
+            assertThat(PdfReportExporter.toXhtml("<hr >")).contains("<hr/>");
+            assertThat(PdfReportExporter.toXhtml("<hr/>")).contains("<hr/>");
+            assertThat(PdfReportExporter.toXhtml("<hr />")).contains("<hr/>");
+        }
+
+        @Test
+        @DisplayName("should close meta tag without attributes")
+        void shouldCloseMetaTagWithoutAttributes() {
+            String xhtml = PdfReportExporter.toXhtml("<meta>");
+            assertThat(xhtml).isEqualTo("<meta/>");
+        }
+
+        @Test
+        @DisplayName("should not double-close already self-closed tags")
+        void shouldNotDoubleCloseSelfClosedTags() {
+            assertThat(PdfReportExporter.toXhtml("<meta charset=\"UTF-8\"/>"))
+                    .isEqualTo("<meta charset=\"UTF-8\"/>");
+            assertThat(PdfReportExporter.toXhtml("<br/>")).isEqualTo("<br/>");
+        }
+
+        @Test
         @DisplayName("should preserve existing content")
         void shouldPreserveContent() {
             String html = "<div class=\"container\"><p>Hello World</p></div>";


### PR DESCRIPTION
## Summary
- Fix br/hr patterns to handle whitespace variants (`<br >`, `<br/>`, `<br />`)
- Fix meta/link/input/img patterns to handle tags without attributes (`<meta>`)
- Add edge-case tests for whitespace variants and bare void tags

Closes #1268