### PR TITLE
Remove redundant null checks flagged by SpotBugs

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationReferenceManager.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationReferenceManager.java
@@ -144,7 +144,7 @@ public final class EquationReferenceManager {
                 if (containsWholeToken(eq, token)) {
                     return true;
                 }
-                String updated = (eq == null || "0".equals(eq.trim())) ? token : eq + " * " + token;
+                String updated = "0".equals(eq.trim()) ? token : eq + " * " + token;
                 flows.set(i, new FlowDef(f.name(), f.comment(), updated,
                         f.timeUnit(), f.materialUnit(), f.source(), f.sink(), f.subscripts()));
                 return true;
@@ -161,7 +161,7 @@ public final class EquationReferenceManager {
                 if (containsWholeToken(eq, token)) {
                     return true;
                 }
-                String updated = (eq == null || "0".equals(eq.trim())) ? token : eq + " * " + token;
+                String updated = "0".equals(eq.trim()) ? token : eq + " * " + token;
                 variables.set(i, new VariableDef(a.name(), a.comment(), updated, a.unit(), a.subscripts()));
                 return true;
             }


### PR DESCRIPTION
## Summary
- Remove dead `eq == null ||` in `addConnectionReference` ternary expressions — the early-return null guard above already handles null, making SpotBugs flag these as `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE`
- Fixes CI failure on master from SpotBugs

## Test plan
- [x] Full test suite passes
- [x] SpotBugs clean