### PR TITLE
Fix Y-axis range when all chart series are hidden

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SimulationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SimulationResultPane.java
@@ -352,8 +352,15 @@ public class SimulationResultPane extends BorderPane {
                 }
             }
             if (yMin >= yMax) {
-                yMin = yMin - 1;
-                yMax = yMax + 1;
+                if (yMin == Double.MAX_VALUE) {
+                    // No visible data — use a sensible default range
+                    yMin = 0;
+                    yMax = 1;
+                } else {
+                    // Single constant value — expand around it
+                    yMin = yMin - 1;
+                    yMax = yMax + 1;
+                }
             }
             double pad = (yMax - yMin) * 0.05;
             if (pad == 0) {

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/SimulationResultPaneAxisFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/SimulationResultPaneAxisFxTest.java
@@ -132,4 +132,29 @@ class SimulationResultPaneAxisFxTest {
         assertThat(yAxis.getUpperBound()).isGreaterThan(shrunkUpper);
         assertThat(yAxis.getUpperBound()).isGreaterThanOrEqualTo(400.0);
     }
+
+    @Test
+    @DisplayName("y-axis should show sensible default range when all series hidden (#649)")
+    void yAxisShouldShowDefaultRangeWhenAllHidden(FxRobot robot) {
+        WaitForAsyncUtils.waitForFxEvents();
+
+        TabPane tabPane = robot.lookup(".tab-pane").queryAs(TabPane.class);
+        robot.interact(() -> tabPane.getSelectionModel().select(1));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        LineChart<?, ?> chart = robot.lookup(".chart").queryAs(LineChart.class);
+        NumberAxis yAxis = (NumberAxis) chart.getYAxis();
+
+        // Uncheck all checkboxes to hide every series
+        Set<CheckBox> checkBoxes = robot.lookup(".check-box").queryAllAs(CheckBox.class);
+        for (CheckBox cb : checkBoxes) {
+            robot.interact(() -> cb.setSelected(false));
+        }
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Y-axis bounds should be sensible, not astronomically large
+        assertThat(yAxis.getLowerBound()).isGreaterThan(-100.0);
+        assertThat(yAxis.getUpperBound()).isLessThan(100.0);
+        assertThat(yAxis.getUpperBound()).isGreaterThan(yAxis.getLowerBound());
+    }
 }


### PR DESCRIPTION
## Summary
- Detect when no series are visible (yMin/yMax at sentinel values) and default to [0, 1] range
- Previously showed astronomically large axis range ([MAX_VALUE-1, -MAX_VALUE+1])
- Added TestFX test verifying sensible bounds when all checkboxes unchecked

Closes #649