### PR TITLE
Fire dirty flag on model name/comment changes

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/FileController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/FileController.java
@@ -292,6 +292,11 @@ final class FileController {
                 markDirty();
             }
 
+            @Override
+            public void onModelMetadataChanged() {
+                markDirty();
+            }
+
         };
     }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditListener.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditListener.java
@@ -19,6 +19,9 @@ public interface ModelEditListener {
     default void onEquationChanged(String elementName) {
     }
 
+    default void onModelMetadataChanged() {
+    }
+
     default void onSimulationRun() {
     }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
@@ -112,6 +112,10 @@ public class ModelEditor {
         for (ModelEditListener l : listeners) { l.onEquationChanged(elementName); }
     }
 
+    private void fireModelMetadataChanged() {
+        for (ModelEditListener l : listeners) { l.onModelMetadataChanged(); }
+    }
+
     // ── Load / Snapshot ──────────────────────────────────────────────────
 
     /**
@@ -555,14 +559,19 @@ public class ModelEditor {
 
     public void setModelName(String name) {
         checkFxThread();
-        if (name != null && !name.isBlank()) {
+        if (name != null && !name.isBlank() && !name.equals(queryFacade.modelName)) {
             queryFacade.modelName = name;
+            fireModelMetadataChanged();
         }
     }
 
     public void setModelComment(String comment) {
         checkFxThread();
-        queryFacade.modelComment = comment != null ? comment : "";
+        String value = comment != null ? comment : "";
+        if (!value.equals(queryFacade.modelComment)) {
+            queryFacade.modelComment = value;
+            fireModelMetadataChanged();
+        }
     }
 
     public void setMetadata(ModelMetadata metadata) {

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelEditorTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelEditorTest.java
@@ -2327,4 +2327,63 @@ class ModelEditorTest {
                     c.from().equals("Variable 1") && c.to().equals("Module 1"));
         }
     }
+
+    @Nested
+    @DisplayName("Model metadata change notifications (#318)")
+    class MetadataNotifications {
+
+        @Test
+        void shouldFireMetadataChangedOnModelNameChange() {
+            List<String> events = new ArrayList<>();
+            editor.addListener(new ModelEditListener() {
+                @Override
+                public void onModelMetadataChanged() {
+                    events.add("metadataChanged");
+                }
+            });
+            editor.setModelName("NewName");
+            assertThat(events).containsExactly("metadataChanged");
+        }
+
+        @Test
+        void shouldNotFireMetadataChangedWhenNameUnchanged() {
+            editor.setModelName("SameName");
+            List<String> events = new ArrayList<>();
+            editor.addListener(new ModelEditListener() {
+                @Override
+                public void onModelMetadataChanged() {
+                    events.add("metadataChanged");
+                }
+            });
+            editor.setModelName("SameName");
+            assertThat(events).isEmpty();
+        }
+
+        @Test
+        void shouldFireMetadataChangedOnCommentChange() {
+            List<String> events = new ArrayList<>();
+            editor.addListener(new ModelEditListener() {
+                @Override
+                public void onModelMetadataChanged() {
+                    events.add("metadataChanged");
+                }
+            });
+            editor.setModelComment("New comment");
+            assertThat(events).containsExactly("metadataChanged");
+        }
+
+        @Test
+        void shouldNotFireMetadataChangedWhenCommentUnchanged() {
+            editor.setModelComment("Same comment");
+            List<String> events = new ArrayList<>();
+            editor.addListener(new ModelEditListener() {
+                @Override
+                public void onModelMetadataChanged() {
+                    events.add("metadataChanged");
+                }
+            });
+            editor.setModelComment("Same comment");
+            assertThat(events).isEmpty();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `onModelMetadataChanged` callback to `ModelEditListener`
- `ModelEditor.setModelName/setModelComment` now fire the event when values actually change
- `FileController` marks model dirty in response, enabling save prompts
- Undo support was already in place via `PropertiesPanel.commitModelName/commitModelComment`

Closes #318