### PR TITLE
Fix loop highlight leaking elements from other loops

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/graph/FeedbackAnalysis.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/graph/FeedbackAnalysis.java
@@ -344,7 +344,7 @@ public record FeedbackAnalysis(
             }
         }
         // Include S&F flow edges that mediate between cycle stocks
-        addMediatingFlowEdges(participants, edges, loopEdges);
+        addMediatingFlowEdges(participants, edges, loopEdges, loopPathElements());
         return new FeedbackAnalysis(
                 Collections.unmodifiableSet(participants),
                 Collections.emptyList(),
@@ -371,8 +371,7 @@ public record FeedbackAnalysis(
         for (int i = 0; i < path.size(); i++) {
             edges.add(new Edge(path.get(i), path.get((i + 1) % path.size())));
         }
-        // Include S&F flow edges that mediate between cycle stocks
-        addMediatingFlowEdges(participants, edges, loopEdges);
+        addMediatingFlowEdges(participants, edges, loopEdges, loopPathElements());
         return new FeedbackAnalysis(
                 Collections.unmodifiableSet(participants),
                 Collections.emptyList(),
@@ -402,16 +401,40 @@ public record FeedbackAnalysis(
     }
 
     /**
+     * Returns the set of all elements that appear in any CausalLoop path.
+     * This excludes S&F flow participants that were added by mediation,
+     * so it can be used to distinguish flows from loop variables.
+     */
+    private Set<String> loopPathElements() {
+        Set<String> elements = new LinkedHashSet<>();
+        for (CausalLoop loop : causalLoops) {
+            elements.addAll(loop.path());
+        }
+        return elements;
+    }
+
+    /**
      * Adds flow nodes and their edges when they mediate between stocks
      * already in the participants set. This ensures that when filtering
      * to a single S&F cycle, the connecting flows are also highlighted.
+     *
+     * <p>Only considers intermediary nodes that do NOT appear in any loop's path.
+     * S&F flows are legitimate intermediaries (they don't appear in loop paths,
+     * which contain only stocks). CLD variables DO appear in loop paths, so they
+     * are excluded — without this guard, CLD causal link edges from other loops
+     * would leak elements into a single-loop filter, causing different loops to
+     * highlight the same elements.
+     *
+     * @param loopPathElements all elements that appear in any CausalLoop path,
+     *                        used to exclude CLD variables from mediation
      */
     private static void addMediatingFlowEdges(Set<String> participants,
-            Set<Edge> edges, Set<Edge> allEdges) {
+            Set<Edge> edges, Set<Edge> allEdges, Set<String> loopPathElements) {
         Set<String> stockSet = Set.copyOf(participants);
         for (Edge e : allEdges) {
-            if (stockSet.contains(e.from()) && !stockSet.contains(e.to())) {
-                // e.from() is a stock, e.to() is a flow — check if flow leads to another stock in set
+            if (stockSet.contains(e.from()) && !stockSet.contains(e.to())
+                    && !loopPathElements.contains(e.to())) {
+                // e.to() is a flow (not in any loop path) — check if it leads to a stock in set
                 for (Edge e2 : allEdges) {
                     if (e2.from().equals(e.to()) && stockSet.contains(e2.to())) {
                         participants.add(e.to());

--- a/courant-engine/src/test/java/systems/courant/sd/model/graph/CldLoopDetectionTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/graph/CldLoopDetectionTest.java
@@ -456,6 +456,49 @@ class CldLoopDetectionTest {
     }
 
     @Nested
+    @DisplayName("filterToLoop isolation")
+    class FilterToLoopIsolation {
+
+        @Test
+        void shouldHighlightDifferentElementsForOverlappingLoops() {
+            // Two loops sharing 2 elements but differing on the 3rd:
+            // R1: A → B → C → A
+            // R2: A → B → D → A
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Overlapping")
+                    .cldVariable("A")
+                    .cldVariable("B")
+                    .cldVariable("C")
+                    .cldVariable("D")
+                    .causalLink("A", "B", CausalLinkDef.Polarity.POSITIVE)
+                    .causalLink("B", "C", CausalLinkDef.Polarity.POSITIVE)
+                    .causalLink("C", "A", CausalLinkDef.Polarity.POSITIVE)
+                    .causalLink("B", "D", CausalLinkDef.Polarity.POSITIVE)
+                    .causalLink("D", "A", CausalLinkDef.Polarity.POSITIVE)
+                    .build();
+
+            FeedbackAnalysis analysis = FeedbackAnalysis.analyze(def);
+            assertThat(analysis.loopCount()).isGreaterThanOrEqualTo(2);
+
+            FeedbackAnalysis loop0 = analysis.filterToLoop(0);
+            FeedbackAnalysis loop1 = analysis.filterToLoop(1);
+
+            // Each filtered analysis must contain ONLY its own path elements
+            assertThat(loop0.loopParticipants())
+                    .as("loop 0 participants must match its path exactly")
+                    .containsExactlyInAnyOrderElementsOf(loop0.causalLoops().getFirst().path());
+            assertThat(loop1.loopParticipants())
+                    .as("loop 1 participants must match its path exactly")
+                    .containsExactlyInAnyOrderElementsOf(loop1.causalLoops().getFirst().path());
+
+            // The two loops must NOT highlight identical element sets
+            assertThat(loop0.loopParticipants())
+                    .as("overlapping loops must highlight different elements")
+                    .isNotEqualTo(loop1.loopParticipants());
+        }
+    }
+
+    @Nested
     @DisplayName("loop labels")
     class LoopLabels {
 


### PR DESCRIPTION
## Summary
- `addMediatingFlowEdges` was designed to add S&F flow nodes between stocks, but it used `loopEdges` from ALL loops
- For CLD models, edges from other loops matched the mediation pattern, causing e.g. R1 and R2 to highlight identical elements despite having different paths
- Fix: skip intermediary nodes that appear in any CausalLoop path — S&F flows (not in paths) still get added; CLD variables (in paths) are excluded
- Added test: overlapping loops with shared elements must highlight different element sets when filtered individually

## Root cause
For R1 = [preparedness, progress, trust Paln]: the edge `progress → trust Isi` (from R2) + `trust Isi → preparedness` (from R2) matched the mediation pattern, incorrectly adding "trust Isi in Paln" to R1's highlights.