### PR TITLE
Change loop highlight color from red to blue

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ColorPalette.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ColorPalette.java
@@ -44,9 +44,9 @@ public final class ColorPalette {
     public static final Color WARNING_BORDER = Color.web("#F39C12", 0.8);
     public static final Color WARNING_FILL = Color.web("#F39C12", 0.06);
 
-    public static final Color LOOP_HIGHLIGHT = Color.web("#E74C3C", 0.8);
-    public static final Color LOOP_EDGE = Color.web("#E74C3C", 0.6);
-    public static final Color LOOP_FILL = Color.web("#E74C3C", 0.08);
+    public static final Color LOOP_HIGHLIGHT = Color.web("#3498DB", 0.8);
+    public static final Color LOOP_EDGE = Color.web("#3498DB", 0.6);
+    public static final Color LOOP_FILL = Color.web("#3498DB", 0.08);
 
     // Loop classification label colors
     public static final Color LOOP_REINFORCING = Color.web("#27AE60");


### PR DESCRIPTION
## Summary
- Loop highlight was red (#E74C3C), too close to orange (#F39C12) warning color
- Changed to blue (#3498DB) — visually distinct from both warnings and errors