### PR TITLE
Label chart x-axis with time step unit instead of Step

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
@@ -96,6 +96,7 @@ final class SimulationController {
 
         ModelDefinition def = canvas.navigation().toModelDefinition();
         SimulationSettings finalSettings = settings;
+        dashboardPanel.setTimeStepLabel(settings.timeStep());
 
         // Snapshot parameter values for ghost run labeling
         Map<String, Double> paramSnapshot = new LinkedHashMap<>();
@@ -122,6 +123,7 @@ final class SimulationController {
         if (settings == null) {
             return;
         }
+        dashboardPanel.setTimeStepLabel(settings.timeStep());
 
         ModelEditor activeEditor = canvas.getEditor();
         List<String> parameterNames = activeEditor.getParameterNames();
@@ -177,6 +179,7 @@ final class SimulationController {
         if (settings == null) {
             return;
         }
+        dashboardPanel.setTimeStepLabel(settings.timeStep());
 
         ModelEditor activeEditor = canvas.getEditor();
         List<String> parameterNames = activeEditor.getParameterNames();
@@ -231,6 +234,7 @@ final class SimulationController {
         if (settings == null) {
             return;
         }
+        dashboardPanel.setTimeStepLabel(settings.timeStep());
 
         ModelEditor activeEditor = canvas.getEditor();
         List<String> parameterNames = activeEditor.getParameterNames();
@@ -297,6 +301,7 @@ final class SimulationController {
         if (settings == null) {
             return;
         }
+        dashboardPanel.setTimeStepLabel(settings.timeStep());
 
         ModelEditor activeEditor = canvas.getEditor();
         List<String> parameterNames = activeEditor.getParameterNames();
@@ -373,6 +378,7 @@ final class SimulationController {
         if (settings == null) {
             return;
         }
+        dashboardPanel.setTimeStepLabel(settings.timeStep());
 
         ModelEditor activeEditor = canvas.getEditor();
         List<String> parameterNames = activeEditor.getParameterNames();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/DashboardPanel.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/DashboardPanel.java
@@ -94,6 +94,19 @@ public class DashboardPanel extends VBox {
     private OptimizationResult lastOptimizationResult;
     private LoopDominanceAnalysis lastDominanceResult;
     private List<SensitivitySummary.ParameterImpact> lastSensitivityImpacts;
+    private String timeStepLabel = "Step";
+
+    /**
+     * Sets the label used for the time axis on all charts.
+     * Should be called before showing results (e.g., "Day", "Month").
+     */
+    public void setTimeStepLabel(String label) {
+        this.timeStepLabel = (label != null && !label.isBlank()) ? label : "Step";
+    }
+
+    public String getTimeStepLabel() {
+        return timeStepLabel;
+    }
 
     public DashboardPanel() {
         Label placeholderLabel = new Label("Run a simulation to see results.");
@@ -228,7 +241,7 @@ public class DashboardPanel extends VBox {
     public void showSweepResult(SweepResult result, String paramName) {
         clearStale();
         this.lastSweepResult = result;
-        SweepResultPane pane = new SweepResultPane(result, paramName);
+        SweepResultPane pane = new SweepResultPane(result, paramName, timeStepLabel);
         sweepTab = ensureTab(sweepTab, "Sweep", pane);
         resultTabs.getSelectionModel().select(sweepTab);
     }
@@ -244,7 +257,7 @@ public class DashboardPanel extends VBox {
     public void showOptimizationResult(OptimizationResult result) {
         clearStale();
         this.lastOptimizationResult = result;
-        OptimizationResultPane pane = new OptimizationResultPane(result);
+        OptimizationResultPane pane = new OptimizationResultPane(result, timeStepLabel);
         optimizationTab = ensureTab(optimizationTab, "Optimization", pane);
         resultTabs.getSelectionModel().select(optimizationTab);
     }
@@ -252,14 +265,14 @@ public class DashboardPanel extends VBox {
     public void showCalibrationResult(OptimizationResult result,
                                       List<CalibrateDialog.FitTarget> fitTargets) {
         clearStale();
-        CalibrationResultPane pane = new CalibrationResultPane(result, fitTargets);
+        CalibrationResultPane pane = new CalibrationResultPane(result, fitTargets, timeStepLabel);
         calibrationTab = ensureTab(calibrationTab, "Calibration", pane);
         resultTabs.getSelectionModel().select(calibrationTab);
     }
 
     public void showMultiSweepResult(MultiSweepResult result) {
         clearStale();
-        MultiSweepResultPane pane = new MultiSweepResultPane(result);
+        MultiSweepResultPane pane = new MultiSweepResultPane(result, timeStepLabel);
         multiSweepTab = ensureTab(multiSweepTab, "Multi-Sweep", pane);
         resultTabs.getSelectionModel().select(multiSweepTab);
     }
@@ -282,7 +295,7 @@ public class DashboardPanel extends VBox {
             return;
         }
         this.lastDominanceResult = dominance;
-        LoopDominancePane pane = new LoopDominancePane(dominance);
+        LoopDominancePane pane = new LoopDominancePane(dominance, timeStepLabel);
         unbindCursors();
         dominanceCursor = pane.cursorTimeStepProperty();
         bindCursors();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/SimulationRunner.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/SimulationRunner.java
@@ -77,7 +77,7 @@ public class SimulationRunner {
         CompiledModel compiled = compiler.compile(defWithSettings);
         Simulation sim = compiled.createSimulation();
 
-        DataCaptureHandler handler = new DataCaptureHandler();
+        DataCaptureHandler handler = new DataCaptureHandler(settings.timeStep());
         sim.addEventHandler(handler);
         sim.execute();
 
@@ -91,6 +91,7 @@ public class SimulationRunner {
      */
     public static class DataCaptureHandler implements EventHandler {
 
+        private final String timeStepLabel;
         private final List<String> columnNames = new ArrayList<>();
         private final List<double[]> rows = new ArrayList<>();
         private final Map<String, String> units = new LinkedHashMap<>();
@@ -100,10 +101,14 @@ public class SimulationRunner {
         private List<Stock> capturedStocks;
         private List<Variable> capturedVariables;
 
+        public DataCaptureHandler(String timeStepLabel) {
+            this.timeStepLabel = timeStepLabel;
+        }
+
         @Override
         public void handleSimulationStartEvent(SimulationStartEvent event) {
             Model model = event.getModel();
-            columnNames.add("Step");
+            columnNames.add(timeStepLabel);
 
             capturedStocks = new ArrayList<>(model.getStocks());
             for (Stock stock : capturedStocks) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/CalibrationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/CalibrationResultPane.java
@@ -31,11 +31,14 @@ import systems.courant.sd.app.canvas.Styles;
 public class CalibrationResultPane extends BorderPane {
 
     private final OptimizationResult result;
+    private final String timeStepLabel;
     private LineChart<Number, Number> chart;
 
     public CalibrationResultPane(OptimizationResult result,
-                                  List<CalibrateDialog.FitTarget> fitTargets) {
+                                  List<CalibrateDialog.FitTarget> fitTargets,
+                                  String timeStepLabel) {
         this.result = result;
+        this.timeStepLabel = timeStepLabel;
 
         // Summary grid
         GridPane summaryGrid = new GridPane();
@@ -82,7 +85,7 @@ public class CalibrationResultPane extends BorderPane {
     private LineChart<Number, Number> buildChart(RunResult bestRun,
                                                   List<CalibrateDialog.FitTarget> fitTargets) {
         NumberAxis xAxis = new NumberAxis();
-        xAxis.setLabel("Step");
+        xAxis.setLabel(timeStepLabel);
         NumberAxis yAxis = new NumberAxis();
         yAxis.setLabel("Value");
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/LoopDominancePane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/LoopDominancePane.java
@@ -38,10 +38,10 @@ public final class LoopDominancePane extends VBox {
     private AreaChart<Number, Number> chart;
     private ChartTimeCursor timeCursor;
 
-    public LoopDominancePane(LoopDominanceAnalysis dominance) {
+    public LoopDominancePane(LoopDominanceAnalysis dominance, String timeStepLabel) {
         this.dominance = dominance;
         NumberAxis xAxis = new NumberAxis();
-        xAxis.setLabel("Step");
+        xAxis.setLabel(timeStepLabel);
         xAxis.setAutoRanging(true);
 
         NumberAxis yAxis = new NumberAxis();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/MultiSweepResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/MultiSweepResultPane.java
@@ -38,10 +38,12 @@ import systems.courant.sd.app.canvas.ClipboardExporter;
 public class MultiSweepResultPane extends BorderPane {
 
     private final MultiSweepResult result;
+    private final String timeStepLabel;
     private LineChart<Number, Number> currentChart;
 
-    public MultiSweepResultPane(MultiSweepResult result) {
+    public MultiSweepResultPane(MultiSweepResult result, String timeStepLabel) {
         this.result = result;
+        this.timeStepLabel = timeStepLabel;
 
         TabPane tabPane = new TabPane();
         tabPane.setId("multiSweepTabs");
@@ -152,7 +154,7 @@ public class MultiSweepResultPane extends BorderPane {
 
     private BorderPane buildRunChart(RunResult run) {
         NumberAxis xAxis = new NumberAxis();
-        xAxis.setLabel("Step");
+        xAxis.setLabel(timeStepLabel);
         NumberAxis yAxis = new NumberAxis();
         yAxis.setLabel("Value");
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/OptimizationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/OptimizationResultPane.java
@@ -31,10 +31,12 @@ import systems.courant.sd.app.canvas.Styles;
 public class OptimizationResultPane extends BorderPane {
 
     private final OptimizationResult result;
+    private final String timeStepLabel;
     private LineChart<Number, Number> chart;
 
-    public OptimizationResultPane(OptimizationResult result) {
+    public OptimizationResultPane(OptimizationResult result, String timeStepLabel) {
         this.result = result;
+        this.timeStepLabel = timeStepLabel;
         // Summary grid
         GridPane summaryGrid = new GridPane();
         summaryGrid.setHgap(10);
@@ -79,7 +81,7 @@ public class OptimizationResultPane extends BorderPane {
 
     private LineChart<Number, Number> buildChart(RunResult bestRun) {
         NumberAxis xAxis = new NumberAxis();
-        xAxis.setLabel("Step");
+        xAxis.setLabel(timeStepLabel);
         NumberAxis yAxis = new NumberAxis();
         yAxis.setLabel("Value");
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SweepResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SweepResultPane.java
@@ -31,11 +31,13 @@ public class SweepResultPane extends BorderPane {
 
     private final SweepResult result;
     private final String paramName;
+    private final String timeStepLabel;
     private LineChart<Number, Number> currentChart;
 
-    public SweepResultPane(SweepResult result, String paramName) {
+    public SweepResultPane(SweepResult result, String paramName, String timeStepLabel) {
         this.result = result;
         this.paramName = paramName;
+        this.timeStepLabel = timeStepLabel;
 
         List<String> trackableNames = new ArrayList<>();
         trackableNames.addAll(ChartUtils.filterSimulationSettings(result.getStockNames()));
@@ -63,7 +65,7 @@ public class SweepResultPane extends BorderPane {
 
     private void buildChart(String variableName) {
         NumberAxis xAxis = new NumberAxis();
-        xAxis.setLabel("Step");
+        xAxis.setLabel(timeStepLabel);
 
         NumberAxis yAxis = new NumberAxis();
         yAxis.setLabel(variableName);

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/SimulationRunnerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/SimulationRunnerTest.java
@@ -38,7 +38,7 @@ class SimulationRunnerTest {
 
             SimulationRunner.SimulationResult result = runner.run(def, settings);
 
-            assertThat(result.columnNames()).contains("Step", "Population");
+            assertThat(result.columnNames()).contains("Day", "Population");
         }
 
         @Test
@@ -200,8 +200,8 @@ class SimulationRunnerTest {
 
             SimulationRunner.SimulationResult result = runner.run(def, settings);
 
-            // Should have Step column at minimum
-            assertThat(result.columnNames()).contains("Step");
+            // Should have time step column at minimum
+            assertThat(result.columnNames()).contains("Day");
             assertThat(result.rows()).isNotEmpty();
         }
     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/CalibrationResultPaneFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/CalibrationResultPaneFxTest.java
@@ -42,7 +42,7 @@ class CalibrationResultPaneFxTest {
         List<CalibrateDialog.FitTarget> fitTargets = List.of(
                 new CalibrateDialog.FitTarget("Tank", "Observed_Tank",
                         new double[]{100, 92, 85, 77, 70, 62}));
-        pane = new CalibrationResultPane(result, fitTargets);
+        pane = new CalibrationResultPane(result, fitTargets, "Day");
         stage.setScene(new Scene(pane, 800, 600));
         stage.show();
     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/LoopDominancePaneFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/LoopDominancePaneFxTest.java
@@ -30,7 +30,7 @@ class LoopDominancePaneFxTest {
     @Start
     void start(Stage stage) {
         LoopDominanceAnalysis dominance = buildTestDominance();
-        pane = new LoopDominancePane(dominance);
+        pane = new LoopDominancePane(dominance, "Day");
         stage.setScene(new Scene(pane, 800, 600));
         stage.show();
     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/MultiSweepResultPaneFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/MultiSweepResultPaneFxTest.java
@@ -38,7 +38,7 @@ class MultiSweepResultPaneFxTest {
     @Start
     void start(Stage stage) {
         MultiSweepResult result = buildMultiSweepResult();
-        pane = new MultiSweepResultPane(result);
+        pane = new MultiSweepResultPane(result, "Day");
         stage.setScene(new Scene(pane, 800, 600));
         stage.show();
     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/OptimizationResultPaneFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/OptimizationResultPaneFxTest.java
@@ -37,7 +37,7 @@ class OptimizationResultPaneFxTest {
     @Start
     void start(Stage stage) {
         OptimizationResult result = buildOptimizationResult();
-        pane = new OptimizationResultPane(result);
+        pane = new OptimizationResultPane(result, "Day");
         stage.setScene(new Scene(pane, 800, 600));
         stage.show();
     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/SweepResultPaneFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/charts/SweepResultPaneFxTest.java
@@ -37,7 +37,7 @@ class SweepResultPaneFxTest {
     @Start
     void start(Stage stage) {
         SweepResult result = buildSweepResult();
-        pane = new SweepResultPane(result, "drainRate");
+        pane = new SweepResultPane(result, "drainRate", "Day");
         stage.setScene(new Scene(pane, 800, 600));
         stage.show();
     }


### PR DESCRIPTION
## Summary
- SimulationRunner uses time step unit name (e.g., "Day") as x-axis column instead of "Step"
- All chart panes (sweep, calibration, optimization, multi-sweep, loop dominance) receive and display the correct time step label
- DashboardPanel stores the label and passes it through to chart pane constructors

## Test plan
- [x] Full reactor `mvn clean test` passes (all 14 changed files)
- [x] SpotBugs clean

Closes #1324