### PR TITLE
Persist parameter sweep dialog values between runs

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
@@ -59,6 +59,7 @@ final class SimulationController {
     private final StatusBar statusBar;
     private final Consumer<String> showError;
     private final Consumer<Consumer<ModelEditListener>> fireLogEvent;
+    private ParameterSweepDialog.Config lastSweepConfig;
 
     SimulationController(ModelCanvas canvas,
                          AnalysisRunner analysisRunner,
@@ -139,13 +140,15 @@ final class SimulationController {
             return;
         }
 
-        ParameterSweepDialog dialog = new ParameterSweepDialog(parameterNames, trackableNames);
+        ParameterSweepDialog dialog = new ParameterSweepDialog(
+                parameterNames, trackableNames, lastSweepConfig);
         Optional<ParameterSweepDialog.Config> configOpt = dialog.showAndWait();
         if (configOpt.isEmpty()) {
             return;
         }
 
         ParameterSweepDialog.Config config = configOpt.get();
+        lastSweepConfig = config;
         ModelDefinition def = canvas.navigation().toModelDefinition();
         SimulationSettings finalSettings = settings;
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ParameterSweepDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ParameterSweepDialog.java
@@ -36,26 +36,34 @@ public class ParameterSweepDialog extends Dialog<ParameterSweepDialog.Config> {
     private final TextField stepField;
     private final ComboBox<String> trackCombo;
 
-    public ParameterSweepDialog(List<String> constantNames, List<String> trackableNames) {
+    public ParameterSweepDialog(List<String> constantNames, List<String> trackableNames,
+                                Config previousConfig) {
         HelpContextResolver.addHelpButton(this);
         setTitle("Parameter Sweep");
         setHeaderText("Configure parameter sweep");
 
         parameterCombo = new ComboBox<>(FXCollections.observableArrayList(constantNames));
         parameterCombo.setId("sweepParameter");
-        startField = new TextField("0");
+        startField = new TextField(previousConfig != null
+                ? String.valueOf(previousConfig.start()) : "0");
         startField.setId("sweepStart");
-        endField = new TextField("10");
+        endField = new TextField(previousConfig != null
+                ? String.valueOf(previousConfig.end()) : "10");
         endField.setId("sweepEnd");
-        stepField = new TextField("1");
+        stepField = new TextField(previousConfig != null
+                ? String.valueOf(previousConfig.step()) : "1");
         stepField.setId("sweepStep");
         trackCombo = new ComboBox<>(FXCollections.observableArrayList(trackableNames));
         trackCombo.setId("sweepTrack");
 
-        if (!constantNames.isEmpty()) {
+        if (previousConfig != null && constantNames.contains(previousConfig.parameterName())) {
+            parameterCombo.setValue(previousConfig.parameterName());
+        } else if (!constantNames.isEmpty()) {
             parameterCombo.setValue(constantNames.getFirst());
         }
-        if (!trackableNames.isEmpty()) {
+        if (previousConfig != null && trackableNames.contains(previousConfig.trackVariable())) {
+            trackCombo.setValue(previousConfig.trackVariable());
+        } else if (!trackableNames.isEmpty()) {
             trackCombo.setValue(trackableNames.getFirst());
         }
 

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/DialogConsistencyFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/DialogConsistencyFxTest.java
@@ -59,7 +59,7 @@ class DialogConsistencyFxTest {
         void sweepWidth(FxRobot robot) {
             DialogPane[] pane = {null};
             Platform.runLater(() -> {
-                var d = new ParameterSweepDialog(List.of("a"), List.of("b"));
+                var d = new ParameterSweepDialog(List.of("a"), List.of("b"), null);
                 pane[0] = d.getDialogPane();
                 d.show();
             });
@@ -119,7 +119,7 @@ class DialogConsistencyFxTest {
         @DisplayName("all controls have fx:id")
         void allIdsPresent(FxRobot robot) {
             Platform.runLater(() -> {
-                var d = new ParameterSweepDialog(List.of("alpha"), List.of("Pop"));
+                var d = new ParameterSweepDialog(List.of("alpha"), List.of("Pop"), null);
                 d.show();
             });
             WaitForAsyncUtils.waitForFxEvents();

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/ParameterSweepDialogFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/ParameterSweepDialogFxTest.java
@@ -37,7 +37,7 @@ class ParameterSweepDialogFxTest {
 
     private void showDialog(List<String> constants, List<String> trackables) {
         Platform.runLater(() -> {
-            dialog = new ParameterSweepDialog(constants, trackables);
+            dialog = new ParameterSweepDialog(constants, trackables, null);
             dialogPane = dialog.getDialogPane();
             dialog.show();
         });


### PR DESCRIPTION
## Summary
- ParameterSweepDialog now accepts a previous Config to pre-populate fields
- SimulationController stores the last-used sweep config and passes it when reopening
- Parameter name, start/end/step, and track variable are preserved between runs

## Test plan
- [x] Full reactor `mvn clean test` passes
- [x] SpotBugs clean

Closes #1323