### PR TITLE
Widen properties panel label column and add tooltips

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/PropertiesPanel.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/PropertiesPanel.java
@@ -83,8 +83,9 @@ public class PropertiesPanel extends VBox {
         propertyGrid.setPadding(new Insets(8));
 
         ColumnConstraints labelCol = new ColumnConstraints();
-        labelCol.setMinWidth(70);
-        labelCol.setHgrow(Priority.NEVER);
+        labelCol.setMinWidth(90);
+        labelCol.setPrefWidth(110);
+        labelCol.setHgrow(Priority.SOMETIMES);
         ColumnConstraints fieldCol = new ColumnConstraints();
         fieldCol.setHgrow(Priority.ALWAYS);
         propertyGrid.getColumnConstraints().addAll(labelCol, fieldCol);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormFieldBuilder.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormFieldBuilder.java
@@ -168,6 +168,10 @@ public class FormFieldBuilder {
     }
 
     private Node buildLabelNode(Label label, String helpText) {
+        Tooltip labelTip = new Tooltip(label.getText());
+        labelTip.setShowDelay(Duration.millis(400));
+        label.setTooltip(labelTip);
+
         if (helpText == null) {
             return label;
         }


### PR DESCRIPTION
## Summary
- Increases label column min width from 70 to 90px with 110px preferred width
- Allows proportional growth (SOMETIMES) so labels expand when panel is resized
- Adds tooltip to every form label showing full text for truncated labels

## Test plan
- [x] Full reactor `mvn clean test` passes
- [x] SpotBugs clean

Closes #1332