### PR TITLE
Default new flow time unit to simulation time step

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ElementFactory.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ElementFactory.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static systems.courant.sd.app.canvas.ElementNameValidator.parseIdSuffix;
 import static systems.courant.sd.app.canvas.ElementNameValidator.resolveUniqueName;
@@ -38,6 +39,7 @@ final class ElementFactory {
     private final List<CausalLinkDef> causalLinks;
     private final List<CommentDef> comments;
     private final Set<String> nameIndex;
+    private final Supplier<String> defaultTimeUnit;
 
     private int nextStockId = 1;
     private int nextFlowId = 1;
@@ -51,7 +53,7 @@ final class ElementFactory {
                    List<VariableDef> variables, List<ModuleInstanceDef> modules,
                    List<LookupTableDef> lookupTables, List<CldVariableDef> cldVariables,
                    List<CausalLinkDef> causalLinks, List<CommentDef> comments,
-                   Set<String> nameIndex) {
+                   Set<String> nameIndex, Supplier<String> defaultTimeUnit) {
         this.stocks = stocks;
         this.flows = flows;
         this.variables = variables;
@@ -61,6 +63,7 @@ final class ElementFactory {
         this.causalLinks = causalLinks;
         this.comments = comments;
         this.nameIndex = nameIndex;
+        this.defaultTimeUnit = defaultTimeUnit;
     }
 
     /**
@@ -87,7 +90,8 @@ final class ElementFactory {
     String addFlow(String source, String sink) {
         String name = "Flow " + nextFlowId++;
         String materialUnit = inferMaterialUnit(source, sink);
-        flows.add(new FlowDef(name, null, "0", "Day", materialUnit, source, sink, List.of()));
+        flows.add(new FlowDef(name, null, "0", defaultTimeUnit.get(),
+                materialUnit, source, sink, List.of()));
         nameIndex.add(name);
         return name;
     }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
@@ -64,7 +64,7 @@ public class ModelEditor {
             new EquationReferenceManager(flows, variables);
     private final ElementFactory factory = new ElementFactory(
             stocks, flows, variables, modules, lookupTables, cldVariables,
-            causalLinks, comments, nameIndex);
+            causalLinks, comments, nameIndex, this::resolveDefaultTimeUnit);
     private final ElementCascadeManager cascadeManager = new ElementCascadeManager(
             stocks, flows, variables, modules, lookupTables, cldVariables,
             causalLinks, comments, nameIndex, equationRefManager);
@@ -673,7 +673,8 @@ public class ModelEditor {
         // Create the target S&F element with the same name
         switch (targetType) {
             case STOCK -> stocks.add(new StockDef(name, variable.comment(), 0, "units", null));
-            case FLOW -> flows.add(new FlowDef(name, variable.comment(), "0", "Day", null, null));
+            case FLOW -> flows.add(new FlowDef(name, variable.comment(), "0",
+                    resolveDefaultTimeUnit(), null, null));
             case AUX -> variables.add(new VariableDef(name, variable.comment(), "0", "units"));
             default -> {
                 // Unsupported target type — put the variable back
@@ -697,6 +698,11 @@ public class ModelEditor {
     public String getModelComment() { return queryFacade.getModelComment(); }
     public ModelMetadata getMetadata() { return queryFacade.getMetadata(); }
     public SimulationSettings getSimulationSettings() { return queryFacade.getSimulationSettings(); }
+
+    private String resolveDefaultTimeUnit() {
+        SimulationSettings settings = getSimulationSettings();
+        return settings != null ? settings.timeStep() : "Day";
+    }
     public List<StockDef> getStocks() { return queryFacade.getStocks(); }
     public List<FlowDef> getFlows() { return queryFacade.getFlows(); }
     public List<VariableDef> getVariables() { return queryFacade.getVariables(); }


### PR DESCRIPTION
## Summary
- New flows now inherit the simulation settings time step unit instead of hardcoded "Day"
- CLD-to-flow classifications also use the simulation time step
- Falls back to "Day" when no simulation settings are configured yet

## Test plan
- [x] Full reactor `mvn clean test` passes
- [x] SpotBugs clean

Closes #1321