### PR TITLE
Change default negative value policy to ALLOW

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/ArrayedStock.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/ArrayedStock.java
@@ -24,7 +24,7 @@ public class ArrayedStock {
 
     /**
      * Creates an arrayed stock with the same initial value for every element.
-     * Uses {@link NegativeValuePolicy#CLAMP_TO_ZERO} by default.
+     * Uses {@link NegativeValuePolicy#ALLOW} by default.
      *
      * @param baseName     the base name (each stock is named "baseName[label]")
      * @param subscript    the subscript dimension
@@ -32,7 +32,7 @@ public class ArrayedStock {
      * @param unit         the unit of measure
      */
     public ArrayedStock(String baseName, Subscript subscript, double initialValue, Unit unit) {
-        this(baseName, subscript, initialValue, unit, NegativeValuePolicy.CLAMP_TO_ZERO);
+        this(baseName, subscript, initialValue, unit, NegativeValuePolicy.ALLOW);
     }
 
     /**
@@ -59,7 +59,7 @@ public class ArrayedStock {
 
     /**
      * Creates an arrayed stock with per-element initial values.
-     * Uses {@link NegativeValuePolicy#CLAMP_TO_ZERO} by default.
+     * Uses {@link NegativeValuePolicy#ALLOW} by default.
      *
      * @param baseName      the base name (each stock is named "baseName[label]")
      * @param subscript     the subscript dimension
@@ -68,7 +68,7 @@ public class ArrayedStock {
      * @throws IllegalArgumentException if the array length doesn't match the subscript size
      */
     public ArrayedStock(String baseName, Subscript subscript, double[] initialValues, Unit unit) {
-        this(baseName, subscript, initialValues, unit, NegativeValuePolicy.CLAMP_TO_ZERO);
+        this(baseName, subscript, initialValues, unit, NegativeValuePolicy.ALLOW);
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/model/MultiArrayedStock.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/MultiArrayedStock.java
@@ -24,7 +24,7 @@ public class MultiArrayedStock {
 
     /**
      * Creates a multi-arrayed stock with the same initial value for every element.
-     * Uses {@link NegativeValuePolicy#CLAMP_TO_ZERO} by default.
+     * Uses {@link NegativeValuePolicy#ALLOW} by default.
      *
      * @param baseName     the base name (each stock is named "baseName[label0,label1,...]")
      * @param range        the multi-dimensional subscript range
@@ -32,7 +32,7 @@ public class MultiArrayedStock {
      * @param unit         the unit of measure
      */
     public MultiArrayedStock(String baseName, SubscriptRange range, double initialValue, Unit unit) {
-        this(baseName, range, initialValue, unit, NegativeValuePolicy.CLAMP_TO_ZERO);
+        this(baseName, range, initialValue, unit, NegativeValuePolicy.ALLOW);
     }
 
     /**
@@ -58,7 +58,7 @@ public class MultiArrayedStock {
 
     /**
      * Creates a multi-arrayed stock with per-element initial values in row-major order.
-     * Uses {@link NegativeValuePolicy#CLAMP_TO_ZERO} by default.
+     * Uses {@link NegativeValuePolicy#ALLOW} by default.
      *
      * @param baseName      the base name
      * @param range         the multi-dimensional subscript range
@@ -67,7 +67,7 @@ public class MultiArrayedStock {
      * @throws IllegalArgumentException if the array length doesn't match the range's total size
      */
     public MultiArrayedStock(String baseName, SubscriptRange range, double[] initialValues, Unit unit) {
-        this(baseName, range, initialValues, unit, NegativeValuePolicy.CLAMP_TO_ZERO);
+        this(baseName, range, initialValues, unit, NegativeValuePolicy.ALLOW);
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/model/NegativeValuePolicy.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/NegativeValuePolicy.java
@@ -9,10 +9,10 @@ package systems.courant.sd.model;
  */
 public enum NegativeValuePolicy {
 
-    /** Silently clamp negative values to zero (default). */
+    /** Silently clamp negative values to zero. */
     CLAMP_TO_ZERO,
 
-    /** Permit negative values (e.g., bank balances, temperature deltas). */
+    /** Permit negative values (default). Suitable for temperature, bank balances, etc. */
     ALLOW,
 
     /** Throw an {@link IllegalArgumentException} when a negative value is set. */

--- a/courant-engine/src/main/java/systems/courant/sd/model/Stock.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Stock.java
@@ -31,14 +31,14 @@ public class Stock extends Element {
 
     /**
      * Creates a new stock with the given name, initial value, and unit.
-     * Uses {@link NegativeValuePolicy#CLAMP_TO_ZERO} by default.
+     * Uses {@link NegativeValuePolicy#ALLOW} by default.
      *
      * @param name          the stock name
      * @param initialAmount the initial quantity stored in this stock
      * @param unit          the unit of measure for the stored quantity
      */
     public Stock(String name, double initialAmount, Unit unit) {
-        this(name, initialAmount, unit, NegativeValuePolicy.CLAMP_TO_ZERO);
+        this(name, initialAmount, unit, NegativeValuePolicy.ALLOW);
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ModelCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ModelCompiler.java
@@ -408,7 +408,7 @@ public class ModelCompiler {
 
     private NegativeValuePolicy resolvePolicy(String policyName) {
         if (policyName == null) {
-            return NegativeValuePolicy.CLAMP_TO_ZERO;
+            return NegativeValuePolicy.ALLOW;
         }
         try {
             return NegativeValuePolicy.valueOf(policyName);

--- a/courant-engine/src/test/java/systems/courant/sd/SimulationTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/SimulationTest.java
@@ -5,6 +5,7 @@ import systems.courant.sd.measure.TimeUnit;
 import systems.courant.sd.model.Flow;
 import systems.courant.sd.model.Model;
 import systems.courant.sd.model.Module;
+import systems.courant.sd.model.NegativeValuePolicy;
 import systems.courant.sd.model.Stock;
 import systems.courant.sd.model.Variable;
 import org.junit.jupiter.api.DisplayName;
@@ -140,7 +141,7 @@ public class SimulationTest {
     @Test
     public void shouldClampStockToZeroWhenOutflowExceedsValue() {
         Model model = new Model("Clamp Test");
-        Stock tank = new Stock("Tank", 10, GALLON_US);
+        Stock tank = new Stock("Tank", 10, GALLON_US, NegativeValuePolicy.CLAMP_TO_ZERO);
 
         Flow outflow = Flow.create("BigDrain", MINUTE, () -> new Quantity(100, GALLON_US));
 
@@ -744,8 +745,8 @@ public class SimulationTest {
             sim.setSavePer(5);
             sim.execute();
 
-            // Stock should reflect all 11 steps: 100 - 11*10 = -10 → clamped to 0
-            assertThat(stock.getValue()).isEqualTo(0.0);
+            // Stock should reflect all 11 steps: 100 - 11*10 = -10
+            assertThat(stock.getValue()).isEqualTo(-10.0);
         }
 
         @Test

--- a/courant-engine/src/test/java/systems/courant/sd/model/MultiArrayedStockTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/MultiArrayedStockTest.java
@@ -298,8 +298,8 @@ public class MultiArrayedStockTest {
     }
 
     @Test
-    public void shouldDefaultToClampToZero() {
+    public void shouldDefaultToAllowNegativeValues() {
         MultiArrayedStock stock = new MultiArrayedStock("X", range, -50, PEOPLE);
-        assertEquals(0, stock.getValue(0), 0.0);
+        assertEquals(-50, stock.getValue(0), 0.0);
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/model/StockTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/StockTest.java
@@ -71,15 +71,22 @@ public class StockTest {
     }
 
     @Test
-    public void shouldClampNegativeValueToZeroByDefault() {
+    public void shouldAllowNegativeValueByDefault() {
         Stock stock = new Stock("Water", 100, GALLON_US);
         stock.setValue(-50);
-        assertEquals(0, stock.getValue(), 0.0);
+        assertEquals(-50, stock.getValue(), 0.0);
     }
 
     @Test
-    public void shouldClampNegativeInitialValueToZero() {
+    public void shouldAllowNegativeInitialValueByDefault() {
         Stock stock = new Stock("Water", -10, GALLON_US);
+        assertEquals(-10, stock.getValue(), 0.0);
+    }
+
+    @Test
+    public void shouldClampNegativeValueWhenPolicyIsClamp() {
+        Stock stock = new Stock("Water", 100, GALLON_US, NegativeValuePolicy.CLAMP_TO_ZERO);
+        stock.setValue(-50);
         assertEquals(0, stock.getValue(), 0.0);
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ModelCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ModelCompilerTest.java
@@ -178,7 +178,7 @@ class ModelCompilerTest {
         void shouldHandleAuxReferencingAnotherAux() {
             ModelDefinition def = new ModelDefinitionBuilder()
                     .name("Forward Ref")
-                    .stock("S", 100, "Thing")
+                    .stock("S", null, 100, "Thing", "CLAMP_TO_ZERO")
                     .variable("A", "S * 2", "Thing")
                     .variable("B", "A + 10", "Thing")
                     .flow("F", "B", "Day", "S", null)
@@ -190,7 +190,7 @@ class ModelCompilerTest {
             sim.execute();
 
             // Before flow: A = 100*2 = 200, B = 200+10 = 210
-            // After 1 step: S = 100 - 210 is clamped to 0
+            // After 1 step: S = max(0, 100 - 210) = 0
             Stock s = findStock(compiled.getModel(), "S");
             assertThat(s.getValue()).isLessThan(100);
         }


### PR DESCRIPTION
## Summary
- Default negative value policy changed from CLAMP_TO_ZERO to ALLOW
- Stocks now permit negative values by default (temperature, bank balances, etc.)
- Modelers who need clamping can explicitly set CLAMP_TO_ZERO per stock
- Updated all convenience constructors, compiler resolution, and tests

## Test plan
- [x] Full reactor `mvn clean test` passes (9 files changed, all 2409 tests pass)
- [x] SpotBugs clean

Closes #1314