### PR TITLE
Add SD terminology glossary to Help System

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/MenuBarBuilder.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/MenuBarBuilder.java
@@ -265,6 +265,7 @@ final class MenuBarBuilder {
                 supplyChainItem, cldTutorialItem);
 
         MenuItem sdConceptsItem = registry.toMenuItem("SD Concepts");
+        MenuItem sdTerminologyItem = registry.toMenuItem("SD Terminology");
         MenuItem exprLangItem = registry.toMenuItem("Expression Language");
         MenuItem shortcutsItem = registry.toMenuItem("Keyboard Shortcuts");
         MenuItem aboutItem = registry.toMenuItem("About Courant");
@@ -272,7 +273,8 @@ final class MenuBarBuilder {
         helpMenu.getItems().addAll(contextHelpItem,
                 new SeparatorMenuItem(),
                 tutorialsMenu,
-                new SeparatorMenuItem(), sdConceptsItem, exprLangItem,
+                new SeparatorMenuItem(), sdConceptsItem, sdTerminologyItem,
+                exprLangItem,
                 new SeparatorMenuItem(), shortcutsItem,
                 new SeparatorMenuItem(), aboutItem);
 

--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -653,6 +653,8 @@ public class ModelWindow {
         commandRegistry.add("SD Concepts", "Help",
                 () -> helpWindows.showOrBring(SdConceptsDialog.class,
                         SdConceptsDialog::new));
+        commandRegistry.add("SD Terminology", "Help",
+                this::showGlossary);
         commandRegistry.add("Expression Language", "Help",
                 () -> helpWindows.showOrBring(ExpressionLanguageDialog.class,
                         ExpressionLanguageDialog::new));
@@ -807,6 +809,19 @@ public class ModelWindow {
             contextHelpDialog.initOwner(stage);
         }
         contextHelpDialog.showTopic(topic);
+        if (!contextHelpDialog.isShowing()) {
+            contextHelpDialog.show();
+        } else {
+            HelpWindowManager.bringToFront(contextHelpDialog);
+        }
+    }
+
+    private void showGlossary() {
+        if (contextHelpDialog == null || !contextHelpDialog.isShowing()) {
+            contextHelpDialog = new ContextHelpDialog();
+            contextHelpDialog.initOwner(stage);
+        }
+        contextHelpDialog.showGlossaryTerm(null);
         if (!contextHelpDialog.isShowing()) {
             contextHelpDialog.show();
         } else {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/Glossary.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/Glossary.java
@@ -1,0 +1,150 @@
+package systems.courant.sd.app.canvas;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Loads and provides access to the System Dynamics terminology glossary.
+ * Entries are loaded from {@code sd-glossary.json} on the classpath.
+ *
+ * <p>This class is thread-safe after construction; the glossary is immutable once loaded.
+ */
+public final class Glossary {
+
+    /**
+     * A single glossary entry.
+     */
+    public record Entry(
+            String term,
+            List<String> aliases,
+            String definition,
+            String relevance,
+            List<String> related
+    ) {
+        @JsonCreator
+        public Entry(
+                @JsonProperty("term") String term,
+                @JsonProperty("aliases") List<String> aliases,
+                @JsonProperty("definition") String definition,
+                @JsonProperty("relevance") String relevance,
+                @JsonProperty("related") List<String> related
+        ) {
+            this.term = term;
+            this.aliases = aliases != null ? List.copyOf(aliases) : List.of();
+            this.definition = definition;
+            this.relevance = relevance;
+            this.related = related != null ? List.copyOf(related) : List.of();
+        }
+    }
+
+    private static final Glossary INSTANCE = load();
+
+    private final List<Entry> entries;
+    /** Maps lowercase term/alias to its canonical Entry. */
+    private final Map<String, Entry> lookup;
+
+    private Glossary(List<Entry> entries) {
+        List<Entry> sorted = new ArrayList<>(entries);
+        sorted.sort(Comparator.comparing(e -> e.term().toLowerCase(Locale.ROOT)));
+        this.entries = Collections.unmodifiableList(sorted);
+
+        Map<String, Entry> map = new LinkedHashMap<>();
+        for (Entry entry : this.entries) {
+            map.put(entry.term().toLowerCase(Locale.ROOT), entry);
+            for (String alias : entry.aliases()) {
+                map.putIfAbsent(alias.toLowerCase(Locale.ROOT), entry);
+            }
+        }
+        this.lookup = Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Returns the singleton glossary instance.
+     */
+    public static Glossary instance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Returns all entries in alphabetical order by term.
+     */
+    public List<Entry> entries() {
+        return entries;
+    }
+
+    /**
+     * Looks up an entry by its term or any alias (case-insensitive).
+     */
+    public Optional<Entry> lookup(String termOrAlias) {
+        if (termOrAlias == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(lookup.get(termOrAlias.toLowerCase(Locale.ROOT)));
+    }
+
+    /**
+     * Returns all term names and aliases that map to entries (lowercase keys).
+     */
+    public Map<String, Entry> lookupMap() {
+        return lookup;
+    }
+
+    /**
+     * Searches entries for a query string, matching against term, aliases, and definition.
+     * Returns entries in relevance order: term match first, then alias match, then definition match.
+     */
+    public List<Entry> search(String query) {
+        if (query == null || query.isBlank()) {
+            return entries;
+        }
+        String q = query.toLowerCase(Locale.ROOT).trim();
+        List<Entry> termMatches = new ArrayList<>();
+        List<Entry> aliasMatches = new ArrayList<>();
+        List<Entry> definitionMatches = new ArrayList<>();
+
+        for (Entry entry : entries) {
+            if (entry.term().toLowerCase(Locale.ROOT).contains(q)) {
+                termMatches.add(entry);
+            } else if (entry.aliases().stream()
+                    .anyMatch(a -> a.toLowerCase(Locale.ROOT).contains(q))) {
+                aliasMatches.add(entry);
+            } else if (entry.definition().toLowerCase(Locale.ROOT).contains(q)
+                    || entry.relevance().toLowerCase(Locale.ROOT).contains(q)) {
+                definitionMatches.add(entry);
+            }
+        }
+
+        List<Entry> result = new ArrayList<>(termMatches.size()
+                + aliasMatches.size() + definitionMatches.size());
+        result.addAll(termMatches);
+        result.addAll(aliasMatches);
+        result.addAll(definitionMatches);
+        return Collections.unmodifiableList(result);
+    }
+
+    private static Glossary load() {
+        try (InputStream in = Glossary.class.getResourceAsStream("/sd-glossary.json")) {
+            if (in == null) {
+                throw new IllegalStateException("sd-glossary.json not found on classpath");
+            }
+            ObjectMapper mapper = new ObjectMapper();
+            Entry[] entries = mapper.readValue(in, Entry[].class);
+            return new Glossary(List.of(entries));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load glossary", e);
+        }
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/GlossaryPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/GlossaryPane.java
@@ -1,0 +1,157 @@
+package systems.courant.sd.app.canvas;
+
+import javafx.geometry.Insets;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * A pane displaying the SD terminology glossary with search filtering.
+ * Each entry shows the term, definition, relevance, and cross-reference links.
+ */
+public final class GlossaryPane extends VBox {
+
+    private final TextField searchField;
+    private final VBox entriesBox;
+    private final ScrollPane scrollPane;
+    private Consumer<String> onTermNavigate;
+    private String highlightedTerm;
+
+    public GlossaryPane() {
+        setSpacing(0);
+        setPadding(Insets.EMPTY);
+
+        searchField = new TextField();
+        searchField.setPromptText("Search glossary\u2026");
+        searchField.setId("glossarySearch");
+        VBox.setMargin(searchField, new Insets(8, 12, 8, 12));
+
+        entriesBox = new VBox(0);
+        entriesBox.setPadding(new Insets(0, 12, 12, 12));
+
+        scrollPane = new ScrollPane(entriesBox);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setId("glossaryScroll");
+
+        getChildren().addAll(searchField, scrollPane);
+
+        searchField.textProperty().addListener((obs, oldVal, newVal) -> refresh(newVal));
+        refresh("");
+    }
+
+    /**
+     * Sets a callback invoked when the user clicks a cross-reference link.
+     */
+    public void setOnTermNavigate(Consumer<String> callback) {
+        this.onTermNavigate = callback;
+    }
+
+    /**
+     * Scrolls to and highlights the entry for the given term.
+     */
+    public void showTerm(String term) {
+        highlightedTerm = term;
+        searchField.clear();
+        refresh("");
+
+        // Find the entry node and scroll to it
+        for (var node : entriesBox.getChildren()) {
+            if (node instanceof VBox entryBox && term.equals(entryBox.getUserData())) {
+                scrollPane.layout();
+                double y = entryBox.getBoundsInParent().getMinY();
+                double contentHeight = entriesBox.getBoundsInLocal().getHeight();
+                double viewportHeight = scrollPane.getViewportBounds().getHeight();
+                if (contentHeight > viewportHeight) {
+                    scrollPane.setVvalue(y / (contentHeight - viewportHeight));
+                }
+                break;
+            }
+        }
+    }
+
+    private void refresh(String query) {
+        entriesBox.getChildren().clear();
+        Glossary glossary = Glossary.instance();
+        List<Glossary.Entry> results = glossary.search(query);
+
+        for (Glossary.Entry entry : results) {
+            entriesBox.getChildren().add(buildEntryNode(entry));
+        }
+    }
+
+    private VBox buildEntryNode(Glossary.Entry entry) {
+        VBox box = new VBox(4);
+        box.setPadding(new Insets(10, 0, 10, 0));
+        box.setUserData(entry.term());
+        box.setStyle("-fx-border-color: transparent transparent #e0e0e0 transparent; "
+                + "-fx-border-width: 0 0 1 0;");
+
+        if (entry.term().equals(highlightedTerm)) {
+            box.setStyle(box.getStyle()
+                    + " -fx-background-color: #fff3cd; -fx-background-radius: 4;");
+        }
+
+        // Term heading
+        Text termText = new Text(entry.term());
+        termText.setStyle("-fx-font-weight: bold; -fx-font-size: 14px;");
+        TextFlow heading = new TextFlow(termText);
+
+        // Aliases
+        if (!entry.aliases().isEmpty()) {
+            Text aliasLabel = new Text("  Also: ");
+            aliasLabel.setStyle("-fx-fill: #666;");
+            Text aliasText = new Text(String.join(", ", entry.aliases()));
+            aliasText.setStyle("-fx-fill: #666; -fx-font-style: italic;");
+            heading.getChildren().addAll(aliasLabel, aliasText);
+        }
+
+        // Definition
+        Text defText = new Text(entry.definition());
+        TextFlow defFlow = new TextFlow(defText);
+        defFlow.setMaxWidth(480);
+
+        // Relevance
+        Text relLabel = new Text("Relevance: ");
+        relLabel.setStyle("-fx-font-weight: bold; -fx-fill: #444;");
+        Text relText = new Text(entry.relevance());
+        relText.setStyle("-fx-fill: #444;");
+        TextFlow relFlow = new TextFlow(relLabel, relText);
+        relFlow.setMaxWidth(480);
+
+        box.getChildren().addAll(heading, defFlow, relFlow);
+
+        // Related terms as hyperlinks
+        if (!entry.related().isEmpty()) {
+            TextFlow relatedFlow = new TextFlow();
+            relatedFlow.setMaxWidth(480);
+            Text seeAlso = new Text("See also: ");
+            seeAlso.setStyle("-fx-font-weight: bold; -fx-fill: #444;");
+            relatedFlow.getChildren().add(seeAlso);
+
+            for (int i = 0; i < entry.related().size(); i++) {
+                String related = entry.related().get(i);
+                Hyperlink link = new Hyperlink(related);
+                link.setOnAction(e -> {
+                    if (onTermNavigate != null) {
+                        onTermNavigate.accept(related);
+                    } else {
+                        showTerm(related);
+                    }
+                });
+                relatedFlow.getChildren().add(link);
+                if (i < entry.related().size() - 1) {
+                    relatedFlow.getChildren().add(new Text(", "));
+                }
+            }
+            box.getChildren().add(relatedFlow);
+        }
+
+        return box;
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContent.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContent.java
@@ -2,9 +2,22 @@ package systems.courant.sd.app.canvas;
 
 import javafx.geometry.Insets;
 import javafx.scene.Node;
+import javafx.scene.control.Hyperlink;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Tooltip;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Provides help content for each {@link HelpTopic}.
@@ -17,12 +30,24 @@ public final class HelpContent {
     }
 
     /**
-     * Returns the help content node for the given topic.
+     * Returns the help content node for the given topic (without glossary annotation).
      *
      * @param topic the help topic
      * @return a scrollable node containing the help content
      */
     public static Node forTopic(HelpTopic topic) {
+        return forTopic(topic, null);
+    }
+
+    /**
+     * Returns the help content node for the given topic, with glossary terms annotated
+     * as tooltips and hyperlinks when a navigation callback is provided.
+     *
+     * @param topic             the help topic
+     * @param onGlossaryNavigate callback invoked when a glossary term link is clicked, or null
+     * @return a scrollable node containing the help content
+     */
+    public static Node forTopic(HelpTopic topic, Consumer<String> onGlossaryNavigate) {
         TextFlow content = switch (topic) {
             case OVERVIEW -> overviewContent();
             case STOCK -> stockContent();
@@ -48,6 +73,11 @@ public final class HelpContent {
             case CAUSAL_TRACE -> causalTraceContent();
             case MODULE_PORTS -> modulePortsContent();
         };
+
+        if (onGlossaryNavigate != null) {
+            annotateGlossaryTerms(content, onGlossaryNavigate);
+        }
+
         content.setPadding(new Insets(16));
         content.setLineSpacing(4);
         content.setMaxWidth(520);
@@ -584,5 +614,98 @@ public final class HelpContent {
         Text text = new Text(content);
         text.setStyle("-fx-font-family: monospace;");
         return text;
+    }
+
+    // --- Glossary annotation ---
+
+    /**
+     * Post-processes a TextFlow to annotate glossary terms in plain text nodes
+     * with tooltips and hyperlinks. Only the first occurrence of each term is annotated.
+     */
+    static void annotateGlossaryTerms(TextFlow flow, Consumer<String> onNavigate) {
+        Map<String, Glossary.Entry> lookupMap = Glossary.instance().lookupMap();
+        if (lookupMap.isEmpty()) {
+            return;
+        }
+        Pattern pattern = buildTermPattern(lookupMap);
+        Set<String> annotated = new HashSet<>();
+
+        List<Node> original = new ArrayList<>(flow.getChildren());
+        flow.getChildren().clear();
+
+        for (Node node : original) {
+            if (!(node instanceof Text textNode)
+                    || textNode.getStyle() != null && !textNode.getStyle().isEmpty()) {
+                // Skip bold, mono, or styled text
+                flow.getChildren().add(node);
+                continue;
+            }
+            String source = textNode.getText();
+            List<Node> replacement = splitAtTerms(source, pattern, lookupMap, annotated, onNavigate);
+            flow.getChildren().addAll(replacement);
+        }
+    }
+
+    private static Pattern buildTermPattern(Map<String, Glossary.Entry> lookupMap) {
+        // Sort keys longest-first so "Causal Loop Diagram" matches before "Loop"
+        List<String> keys = new ArrayList<>(lookupMap.keySet());
+        keys.sort(Comparator.comparingInt(String::length).reversed());
+
+        StringBuilder sb = new StringBuilder("(?i)\\b(");
+        for (int i = 0; i < keys.size(); i++) {
+            if (i > 0) {
+                sb.append('|');
+            }
+            sb.append(Pattern.quote(keys.get(i)));
+        }
+        sb.append(")\\b");
+        return Pattern.compile(sb.toString());
+    }
+
+    private static List<Node> splitAtTerms(String text, Pattern pattern,
+                                            Map<String, Glossary.Entry> lookupMap,
+                                            Set<String> annotated,
+                                            Consumer<String> onNavigate) {
+        List<Node> nodes = new ArrayList<>();
+        Matcher matcher = pattern.matcher(text);
+        int lastEnd = 0;
+
+        while (matcher.find()) {
+            String matched = matcher.group();
+            String key = matched.toLowerCase(Locale.ROOT);
+            Glossary.Entry entry = lookupMap.get(key);
+            if (entry == null || annotated.contains(entry.term())) {
+                continue;
+            }
+            annotated.add(entry.term());
+
+            // Add text before the match
+            if (matcher.start() > lastEnd) {
+                nodes.add(new Text(text.substring(lastEnd, matcher.start())));
+            }
+
+            // Create annotated hyperlink
+            Hyperlink link = new Hyperlink(matched);
+            link.setStyle("-fx-text-fill: #1a73e8; -fx-border-color: transparent;");
+            link.setPadding(Insets.EMPTY);
+            Tooltip tip = new Tooltip(entry.term() + ": " + entry.definition());
+            tip.setWrapText(true);
+            tip.setMaxWidth(350);
+            Tooltip.install(link, tip);
+            link.setOnAction(e -> onNavigate.accept(entry.term()));
+            nodes.add(link);
+
+            lastEnd = matcher.end();
+        }
+
+        // Add remaining text
+        if (lastEnd < text.length()) {
+            nodes.add(new Text(text.substring(lastEnd)));
+        }
+
+        if (nodes.isEmpty()) {
+            nodes.add(new Text(text));
+        }
+        return nodes;
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ContextHelpDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ContextHelpDialog.java
@@ -10,21 +10,28 @@ import javafx.stage.Stage;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import systems.courant.sd.app.canvas.GlossaryPane;
 import systems.courant.sd.app.canvas.HelpContent;
 import systems.courant.sd.app.canvas.HelpTopic;
 
 /**
  * A two-pane help dialog with a {@link TreeView} sidebar for navigation
  * and a content area displaying help for the selected {@link HelpTopic}.
+ * Includes an SD Terminology glossary section.
  *
  * <p>Intended to be used as a singleton window: call {@link #showTopic(HelpTopic)}
  * to navigate to a topic, bringing the window to front if already showing.
  */
 public class ContextHelpDialog extends Stage {
 
+    /** Sentinel value used for the glossary leaf node in the tree. */
+    static final String GLOSSARY_CATEGORY = "Glossary";
+
     private final TreeView<HelpTopic> treeView;
     private final StackPane contentPane;
     private final Map<HelpTopic, TreeItem<HelpTopic>> itemsByTopic = new LinkedHashMap<>();
+    private TreeItem<HelpTopic> glossaryItem;
+    private GlossaryPane glossaryPane;
 
     public ContextHelpDialog() {
         setTitle("Help");
@@ -46,8 +53,12 @@ public class ContextHelpDialog extends Stage {
         // Show content when tree selection changes
         treeView.getSelectionModel().selectedItemProperty().addListener(
                 (obs, oldItem, newItem) -> {
-                    if (newItem != null && newItem.getValue() != null && newItem.isLeaf()) {
-                        showContent(newItem.getValue());
+                    if (newItem != null && newItem.isLeaf()) {
+                        if (newItem == glossaryItem) {
+                            showGlossary(null);
+                        } else if (newItem.getValue() != null) {
+                            showContent(newItem.getValue());
+                        }
                     }
                 });
 
@@ -72,8 +83,37 @@ public class ContextHelpDialog extends Stage {
         requestFocus();
     }
 
+    /**
+     * Navigates to the glossary, optionally scrolling to a specific term.
+     *
+     * @param term the term to highlight, or null to show the full glossary
+     */
+    public void showGlossaryTerm(String term) {
+        if (glossaryItem != null) {
+            if (glossaryItem.getParent() != null) {
+                glossaryItem.getParent().setExpanded(true);
+            }
+            treeView.getSelectionModel().select(glossaryItem);
+        }
+        showGlossary(term);
+        toFront();
+        requestFocus();
+    }
+
     private void showContent(HelpTopic topic) {
-        contentPane.getChildren().setAll(HelpContent.forTopic(topic));
+        contentPane.getChildren().setAll(
+                HelpContent.forTopic(topic, this::showGlossaryTerm));
+    }
+
+    private void showGlossary(String term) {
+        if (glossaryPane == null) {
+            glossaryPane = new GlossaryPane();
+            glossaryPane.setOnTermNavigate(this::showGlossaryTerm);
+        }
+        contentPane.getChildren().setAll(glossaryPane);
+        if (term != null) {
+            glossaryPane.showTerm(term);
+        }
     }
 
     private TreeView<HelpTopic> buildTreeView() {
@@ -98,6 +138,13 @@ public class ContextHelpDialog extends Stage {
             root.getChildren().add(entry.getValue());
         }
 
+        // Add glossary as a leaf under a "Glossary" category
+        TreeItem<HelpTopic> glossaryCat = new TreeItem<>(null);
+        glossaryCat.setExpanded(true);
+        glossaryItem = new TreeItem<>(null);
+        glossaryCat.getChildren().add(glossaryItem);
+        root.getChildren().add(glossaryCat);
+
         TreeView<HelpTopic> tree = new TreeView<>(root);
         tree.setCellFactory(tv -> new TreeCell<>() {
             @Override
@@ -106,10 +153,16 @@ public class ContextHelpDialog extends Stage {
                 if (empty || getTreeItem() == null) {
                     setText(null);
                     setStyle("");
+                } else if (getTreeItem() == glossaryItem) {
+                    setText("SD Terminology");
+                    setStyle("");
                 } else if (item == null) {
                     // Category node — find category name from first child
                     TreeItem<HelpTopic> treeItem = getTreeItem();
-                    if (!treeItem.getChildren().isEmpty()) {
+                    if (treeItem == glossaryItem.getParent()) {
+                        setText(GLOSSARY_CATEGORY);
+                        setStyle("-fx-font-weight: bold;");
+                    } else if (!treeItem.getChildren().isEmpty()) {
                         HelpTopic firstChild = treeItem.getChildren().getFirst().getValue();
                         setText(firstChild != null ? firstChild.category() : "");
                         setStyle("-fx-font-weight: bold;");

--- a/courant-app/src/main/resources/sd-glossary.json
+++ b/courant-app/src/main/resources/sd-glossary.json
@@ -1,0 +1,401 @@
+[
+  {
+    "term": "Stock",
+    "aliases": ["Level", "State Variable", "Accumulation"],
+    "definition": "A variable that accumulates over time, representing the state of a system at any point. Stocks change only through inflows and outflows.",
+    "relevance": "Stocks are the foundation of system dynamics models, capturing quantities that persist between time steps — such as population, inventory, or water in a reservoir.",
+    "related": ["Flow", "Integration", "Euler Integration", "Runge-Kutta"]
+  },
+  {
+    "term": "Flow",
+    "aliases": ["Rate", "Rate Variable"],
+    "definition": "A variable that represents the rate of change of a stock per unit time. Flows fill or drain stocks.",
+    "relevance": "Flows are the only way stocks change value. Every causal mechanism that alters an accumulation must pass through a flow.",
+    "related": ["Stock", "Auxiliary", "DT"]
+  },
+  {
+    "term": "Auxiliary",
+    "aliases": ["Converter", "Variable"],
+    "definition": "An intermediate variable used to compute values that feed into flows or other auxiliaries. Auxiliaries do not accumulate.",
+    "relevance": "Auxiliaries break complex equations into understandable pieces and make model logic transparent.",
+    "related": ["Flow", "Constant", "Connector"]
+  },
+  {
+    "term": "Constant",
+    "aliases": ["Parameter"],
+    "definition": "A model element whose value does not change during a simulation run. Constants represent fixed assumptions or parameters.",
+    "relevance": "Constants capture assumptions that can be varied across scenarios, sensitivity analyses, or optimization runs.",
+    "related": ["Auxiliary", "Parameter Sweep", "Sensitivity Analysis"]
+  },
+  {
+    "term": "Connector",
+    "aliases": ["Information Link", "Causal Arrow"],
+    "definition": "An arrow indicating that one variable's value is used in the equation of another. Connectors carry information, not material.",
+    "relevance": "Connectors make the causal structure of a model explicit, showing which variables influence which equations.",
+    "related": ["Auxiliary", "Flow", "Causal Loop Diagram"]
+  },
+  {
+    "term": "Feedback Loop",
+    "aliases": ["Feedback"],
+    "definition": "A closed chain of causal links where a variable eventually influences itself. Feedback loops are the primary source of dynamic behavior.",
+    "relevance": "All interesting dynamic behavior — growth, oscillation, goal-seeking — arises from feedback loops, making them central to system dynamics analysis.",
+    "related": ["Balancing Loop", "Reinforcing Loop", "Loop Dominance"]
+  },
+  {
+    "term": "Balancing Loop",
+    "aliases": ["Negative Loop", "Goal-Seeking Loop"],
+    "definition": "A feedback loop with an odd number of negative causal links, which acts to counteract change and drive the system toward equilibrium.",
+    "relevance": "Balancing loops produce goal-seeking and oscillatory behavior. They resist change and tend to stabilize systems.",
+    "related": ["Feedback Loop", "Reinforcing Loop", "Goal-Seeking", "Oscillation"]
+  },
+  {
+    "term": "Reinforcing Loop",
+    "aliases": ["Positive Loop", "Virtuous Circle", "Vicious Circle"],
+    "definition": "A feedback loop with an even number of negative causal links (or all positive), which amplifies change in whatever direction it starts.",
+    "relevance": "Reinforcing loops drive exponential growth or collapse. They are responsible for compounding effects and self-reinforcing dynamics.",
+    "related": ["Feedback Loop", "Balancing Loop", "Exponential Growth", "Collapse"]
+  },
+  {
+    "term": "Causal Loop Diagram",
+    "aliases": ["CLD"],
+    "definition": "A diagram showing variables connected by causal arrows annotated with polarity (+ or −), used to map feedback structure without specifying equations.",
+    "relevance": "CLDs are the primary tool for qualitative system dynamics analysis, communicating feedback structure to stakeholders before building a simulation model.",
+    "related": ["Feedback Loop", "Stock-and-Flow Diagram", "Connector"]
+  },
+  {
+    "term": "Stock-and-Flow Diagram",
+    "aliases": ["SFD", "Stock-Flow Diagram"],
+    "definition": "A diagram showing stocks, flows, auxiliaries, and connectors with full equation specifications, suitable for simulation.",
+    "relevance": "SFDs are the quantitative core of system dynamics modeling. Unlike CLDs, they can be simulated to produce time-series behavior.",
+    "related": ["Causal Loop Diagram", "Stock", "Flow", "Simulation"]
+  },
+  {
+    "term": "Aging Chain",
+    "aliases": ["Chain of Stocks", "Cohort Model"],
+    "definition": "A series of stocks connected by flows where material moves sequentially through stages, often representing time-in-stage progression.",
+    "relevance": "Aging chains model processes like disease progression (susceptible → infectious → recovered), workforce tenure, or product lifecycle stages.",
+    "related": ["Stock", "Flow", "Delay", "Conveyor"]
+  },
+  {
+    "term": "Co-flow",
+    "aliases": ["Coflow"],
+    "definition": "A parallel stock-and-flow structure that tracks an attribute of the material in a main stock (e.g., average experience of a workforce).",
+    "relevance": "Co-flows enable tracking of average qualities or attributes associated with the material in a primary stock without losing aggregation.",
+    "related": ["Stock", "Aging Chain"]
+  },
+  {
+    "term": "Conveyor",
+    "aliases": ["Pipeline Delay"],
+    "definition": "A stock structure that delays material by a fixed transit time, delivering it in the same order it entered.",
+    "relevance": "Conveyors model processes with fixed delays such as shipping pipelines, production lines, or construction projects.",
+    "related": ["Delay", "Stock", "Aging Chain"]
+  },
+  {
+    "term": "Delay",
+    "aliases": ["Material Delay", "Information Delay"],
+    "definition": "A structure that introduces a time lag between an input and its effect on an output. Material delays conserve the quantity; information delays smooth a signal.",
+    "relevance": "Delays are a major source of oscillation and instability in systems. Recognizing and correctly modeling delays is essential for realistic behavior.",
+    "related": ["Smooth", "Conveyor", "Oscillation"]
+  },
+  {
+    "term": "Smooth",
+    "aliases": ["SMTH", "Exponential Smooth", "Information Delay"],
+    "definition": "A first-order exponential smoothing function that gradually adjusts its output toward its input over an averaging time.",
+    "relevance": "Smooths represent perception, forecasting, and information averaging processes where actors base decisions on perceived rather than actual values.",
+    "related": ["Delay", "Auxiliary"]
+  },
+  {
+    "term": "Equilibrium",
+    "aliases": ["Steady State"],
+    "definition": "A state where all stocks are constant because their net flows are zero. The system is at rest unless perturbed.",
+    "relevance": "Equilibrium analysis reveals the long-run tendencies of a system and helps identify conditions under which the system is stable or unstable.",
+    "related": ["Balancing Loop", "Goal-Seeking", "S-Shaped Growth"]
+  },
+  {
+    "term": "Oscillation",
+    "aliases": ["Cyclic Behavior"],
+    "definition": "Repeated fluctuation around an equilibrium or reference value, driven by delayed balancing feedback.",
+    "relevance": "Oscillations often indicate management problems — delays in information or response cause overcorrection, producing boom-bust cycles.",
+    "related": ["Balancing Loop", "Delay", "Overshoot"]
+  },
+  {
+    "term": "Overshoot",
+    "aliases": ["Overshoot and Collapse"],
+    "definition": "Behavior where a system exceeds its sustainable limit due to delayed feedback, followed by decline or collapse.",
+    "relevance": "Overshoot is a critical behavior mode in resource and population models, showing how growth can exceed carrying capacity before corrective feedback takes effect.",
+    "related": ["Oscillation", "Collapse", "Delay", "Carrying Capacity"]
+  },
+  {
+    "term": "Exponential Growth",
+    "aliases": ["Compound Growth"],
+    "definition": "Behavior where a quantity increases at a rate proportional to its current value, producing a J-shaped curve.",
+    "relevance": "Exponential growth is the signature of unchecked reinforcing loops. Understanding it is essential for recognizing unsustainable trajectories.",
+    "related": ["Reinforcing Loop", "S-Shaped Growth", "Doubling Time"]
+  },
+  {
+    "term": "S-Shaped Growth",
+    "aliases": ["Logistic Growth", "Sigmoid Growth"],
+    "definition": "Behavior that transitions from exponential growth to equilibrium as a limiting factor activates a balancing loop.",
+    "relevance": "S-shaped growth is one of the most common real-world behavior modes — product adoption, population growth with resource limits, and market saturation all follow this pattern.",
+    "related": ["Exponential Growth", "Balancing Loop", "Carrying Capacity", "Equilibrium"]
+  },
+  {
+    "term": "Goal-Seeking",
+    "aliases": ["Goal Seeking Behavior"],
+    "definition": "Behavior where a system moves toward a target value through balancing feedback, typically following an exponential approach curve.",
+    "relevance": "Goal-seeking is the fundamental behavior mode of balancing loops. Thermostats, inventory management, and homeostasis are all goal-seeking systems.",
+    "related": ["Balancing Loop", "Equilibrium"]
+  },
+  {
+    "term": "Collapse",
+    "aliases": ["Decay", "Decline"],
+    "definition": "Behavior where a system's key variables decline to zero or a much lower value, often following a period of overshoot.",
+    "relevance": "Collapse can result from reinforcing feedback in the negative direction, resource depletion, or positive feedback between declining stocks.",
+    "related": ["Overshoot", "Reinforcing Loop", "Exponential Growth"]
+  },
+  {
+    "term": "Sensitivity Analysis",
+    "aliases": ["Sensitivity Test"],
+    "definition": "Systematically varying one or more parameters to see how they affect model behavior and identify which assumptions matter most.",
+    "relevance": "Sensitivity analysis builds confidence in model results by showing which parameters drive behavior and which are relatively unimportant.",
+    "related": ["Parameter Sweep", "Monte Carlo Analysis", "Calibration"]
+  },
+  {
+    "term": "Phase Diagram",
+    "aliases": ["Phase Plot", "Phase Portrait"],
+    "definition": "A plot showing the trajectory of two or more state variables against each other (rather than against time), revealing system dynamics geometrically.",
+    "relevance": "Phase diagrams reveal cycles, spirals, and equilibria that may not be obvious in time-series plots, making them valuable for understanding coupled-stock dynamics.",
+    "related": ["Time Series", "Stock", "Oscillation"]
+  },
+  {
+    "term": "Time Series",
+    "aliases": ["Time Plot", "Behavior Over Time Graph"],
+    "definition": "A plot of one or more variables against time, showing how values evolve during a simulation run.",
+    "relevance": "Time series are the most common way to visualize and communicate simulation results, directly showing the dynamic behavior the model produces.",
+    "related": ["Behavior Over Time", "Reference Mode", "Simulation"]
+  },
+  {
+    "term": "Reference Mode",
+    "aliases": ["Reference Behavior"],
+    "definition": "A qualitative or quantitative sketch of the expected behavior pattern over time, drawn before modeling, that the model should reproduce.",
+    "relevance": "Reference modes define success — they are the behavioral hypothesis that drives model construction and the standard against which results are compared.",
+    "related": ["Behavior Over Time", "Time Series", "Calibration"]
+  },
+  {
+    "term": "Behavior Over Time",
+    "aliases": ["BOT", "BOT Graph"],
+    "definition": "A graph showing how key variables change over time, used both as a reference mode and as a presentation of simulation results.",
+    "relevance": "BOT graphs are the primary communication tool in system dynamics, conveying dynamic behavior in an intuitive visual form.",
+    "related": ["Reference Mode", "Time Series"]
+  },
+  {
+    "term": "Integration",
+    "aliases": ["Accumulation"],
+    "definition": "The mathematical operation by which a stock's value is updated: the new value equals the old value plus the net flow multiplied by the time step.",
+    "relevance": "Integration is the mechanism that gives stocks memory — they accumulate past flows, making system dynamics models inherently dynamic and history-dependent.",
+    "related": ["Stock", "Flow", "DT", "Euler Integration", "Runge-Kutta"]
+  },
+  {
+    "term": "Differentiation",
+    "aliases": [],
+    "definition": "The mathematical operation of computing the rate of change of a variable. In SD, net flow represents the derivative of a stock.",
+    "relevance": "While stocks integrate flows, understanding differentiation helps modelers reason about how fast stocks are changing at any point in time.",
+    "related": ["Integration", "Flow", "Stock"]
+  },
+  {
+    "term": "DT",
+    "aliases": ["Time Step", "Delta T"],
+    "definition": "The discrete time increment used in numerical integration. Smaller DT increases accuracy but slows computation.",
+    "relevance": "Choosing an appropriate DT is critical — too large causes integration errors and instability; too small wastes computation. A common guideline is DT ≤ one-quarter of the shortest time constant.",
+    "related": ["Integration", "Euler Integration", "Runge-Kutta", "Simulation"]
+  },
+  {
+    "term": "Euler Integration",
+    "aliases": ["Euler Method", "First-Order Integration"],
+    "definition": "The simplest numerical integration method, computing new stock values as: Stock(t+dt) = Stock(t) + NetFlow(t) × dt.",
+    "relevance": "Euler integration is the default method in many SD tools due to its simplicity and transparency. It works well with sufficiently small DT.",
+    "related": ["Integration", "DT", "Runge-Kutta", "Stock"]
+  },
+  {
+    "term": "Runge-Kutta",
+    "aliases": ["RK4", "Fourth-Order Runge-Kutta"],
+    "definition": "A higher-order numerical integration method that evaluates flows at multiple points within each time step for greater accuracy.",
+    "relevance": "Runge-Kutta methods allow larger time steps while maintaining accuracy, particularly for models with rapid dynamics or stiff equations.",
+    "related": ["Integration", "DT", "Euler Integration"]
+  },
+  {
+    "term": "Lookup Table",
+    "aliases": ["Table Function", "Graphical Function"],
+    "definition": "A nonlinear function defined by a set of (x, y) data points with interpolation between them, used when an algebraic relationship is unknown or complex.",
+    "relevance": "Lookup tables capture empirical or judgment-based relationships — such as how price affects demand or how crowding affects productivity — that cannot easily be expressed algebraically.",
+    "related": ["Auxiliary", "Nonlinear"]
+  },
+  {
+    "term": "Nonlinear",
+    "aliases": ["Non-linear"],
+    "definition": "A relationship where the effect is not proportional to the cause — the response changes shape as the input changes magnitude.",
+    "relevance": "Most real-world relationships are nonlinear. System dynamics models routinely use lookup tables and multiplicative formulations to capture these effects.",
+    "related": ["Lookup Table", "Feedback Loop"]
+  },
+  {
+    "term": "Mental Model",
+    "aliases": [],
+    "definition": "The internal, often implicit, assumptions and beliefs a person holds about how a system works.",
+    "relevance": "System dynamics models formalize mental models, making assumptions explicit and testable. Simulation reveals where mental models produce unexpected consequences.",
+    "related": ["Endogenous", "Model Boundary"]
+  },
+  {
+    "term": "Model Boundary",
+    "aliases": ["Boundary", "Model Boundary Chart"],
+    "definition": "The conceptual line separating what is included in the model (endogenous and exogenous) from what is excluded.",
+    "relevance": "Choosing the boundary is one of the most important modeling decisions. Including too little omits critical feedback; including too much adds unnecessary complexity.",
+    "related": ["Endogenous", "Exogenous", "Mental Model"]
+  },
+  {
+    "term": "Endogenous",
+    "aliases": [],
+    "definition": "Variables whose behavior is determined within the model through feedback structure — they are computed, not assumed.",
+    "relevance": "A core principle of system dynamics is that behavior should arise endogenously from feedback structure, not be imposed by exogenous drivers.",
+    "related": ["Exogenous", "Model Boundary", "Feedback Loop"]
+  },
+  {
+    "term": "Exogenous",
+    "aliases": [],
+    "definition": "Variables whose values are specified as external inputs to the model, not influenced by feedback from within the model.",
+    "relevance": "Exogenous variables represent forces outside the modeler's scope of interest. Overuse of exogenous drivers limits a model's ability to explain behavior.",
+    "related": ["Endogenous", "Model Boundary", "Constant"]
+  },
+  {
+    "term": "Subsystem",
+    "aliases": ["Module", "Sector"],
+    "definition": "A logical grouping of related stocks, flows, and auxiliaries within a larger model, often represented as a module.",
+    "relevance": "Subsystems help organize complex models into understandable pieces, enabling team-based development and hierarchical model construction.",
+    "related": ["Module", "Model Boundary"]
+  },
+  {
+    "term": "Dimensional Consistency",
+    "aliases": ["Units Checking", "Dimensional Analysis"],
+    "definition": "The requirement that every equation in a model be valid in terms of physical units — both sides must have the same dimensions.",
+    "relevance": "Dimensional consistency is a powerful error-detection tool. Equations that fail units checking almost always contain a conceptual mistake.",
+    "related": ["Validation", "Extreme Condition Test"]
+  },
+  {
+    "term": "Extreme Condition Test",
+    "aliases": ["Extreme Value Test"],
+    "definition": "A validation test that sets parameters or stocks to extreme values (zero, very large) to check that the model produces physically reasonable results.",
+    "relevance": "Extreme condition tests catch structural errors that normal-range testing misses — a model should never produce negative populations or infinite prices.",
+    "related": ["Validation", "Behavior Reproduction Test"]
+  },
+  {
+    "term": "Behavior Reproduction Test",
+    "aliases": ["Historical Fit"],
+    "definition": "A validation test comparing model output to historical data to assess whether the model can replicate observed real-world behavior.",
+    "relevance": "Behavior reproduction builds confidence that the model captures the essential mechanisms driving observed dynamics.",
+    "related": ["Calibration", "Extreme Condition Test", "Reference Mode"]
+  },
+  {
+    "term": "Policy Analysis",
+    "aliases": ["Policy Design", "Strategy Testing"],
+    "definition": "Using a validated model to test proposed interventions, policies, or structural changes and compare their effects on system behavior.",
+    "relevance": "Policy analysis is the ultimate purpose of most SD models — understanding leverage points and evaluating which interventions produce lasting improvement.",
+    "related": ["Sensitivity Analysis", "Leverage Point", "Optimization"]
+  },
+  {
+    "term": "Leverage Point",
+    "aliases": [],
+    "definition": "A place in the system structure where a small change can produce a large, sustained shift in behavior.",
+    "relevance": "Identifying leverage points is a key insight from system dynamics. They are often counterintuitive — the most obvious intervention points are frequently the least effective.",
+    "related": ["Policy Analysis", "Feedback Loop", "Model Boundary"]
+  },
+  {
+    "term": "Loop Dominance",
+    "aliases": ["Dominant Loop"],
+    "definition": "The concept that at any point in time, one feedback loop exerts more influence on behavior than others, determining the current behavior mode.",
+    "relevance": "Behavior-mode shifts (e.g., from growth to stagnation) occur when loop dominance changes. Identifying which loop dominates explains why behavior changes character.",
+    "related": ["Feedback Loop", "Reinforcing Loop", "Balancing Loop"]
+  },
+  {
+    "term": "Carrying Capacity",
+    "aliases": [],
+    "definition": "The maximum population or quantity that an environment or system can sustain given available resources.",
+    "relevance": "Carrying capacity creates the balancing feedback that turns exponential growth into S-shaped growth or overshoot-and-collapse behavior.",
+    "related": ["S-Shaped Growth", "Overshoot", "Balancing Loop", "Equilibrium"]
+  },
+  {
+    "term": "Doubling Time",
+    "aliases": [],
+    "definition": "The time it takes for an exponentially growing quantity to double. For a growth rate r, doubling time ≈ 0.7/r.",
+    "relevance": "Doubling time is an intuitive measure of growth speed that helps modelers and stakeholders understand the pace of exponential processes.",
+    "related": ["Exponential Growth", "Reinforcing Loop"]
+  },
+  {
+    "term": "Half-Life",
+    "aliases": [],
+    "definition": "The time it takes for a decaying quantity to lose half its value. The decay analog of doubling time.",
+    "relevance": "Half-life characterizes exponential decay in stocks — radioactive decay, drug clearance, and memory loss all follow half-life dynamics.",
+    "related": ["Doubling Time", "Exponential Growth", "Goal-Seeking"]
+  },
+  {
+    "term": "Simulation",
+    "aliases": ["Model Simulation", "Run"],
+    "definition": "The process of numerically computing model behavior over time by iteratively updating stocks through their flows at each time step.",
+    "relevance": "Simulation is what makes SD models actionable — it reveals the dynamic consequences of structure and assumptions that cannot be computed mentally.",
+    "related": ["DT", "Integration", "Euler Integration", "Runge-Kutta"]
+  },
+  {
+    "term": "Monte Carlo Analysis",
+    "aliases": ["Monte Carlo Simulation", "Stochastic Simulation"],
+    "definition": "Running a model hundreds or thousands of times with randomly sampled parameter values to quantify uncertainty in model outputs.",
+    "relevance": "Monte Carlo analysis shows the range of possible outcomes given parameter uncertainty, moving beyond single-point forecasts to probabilistic understanding.",
+    "related": ["Sensitivity Analysis", "Parameter Sweep"]
+  },
+  {
+    "term": "Parameter Sweep",
+    "aliases": ["Parametric Analysis"],
+    "definition": "Systematically varying one parameter across a defined range while holding others constant, and comparing the resulting behavior across runs.",
+    "relevance": "Parameter sweeps reveal how sensitive model behavior is to specific assumptions and help identify critical thresholds or tipping points.",
+    "related": ["Sensitivity Analysis", "Monte Carlo Analysis"]
+  },
+  {
+    "term": "Calibration",
+    "aliases": ["Parameter Estimation"],
+    "definition": "The process of adjusting model parameters to minimize the difference between simulated and observed historical data.",
+    "relevance": "Calibration grounds a model in empirical data, providing parameter estimates that produce realistic behavior and enabling more credible scenario analysis.",
+    "related": ["Behavior Reproduction Test", "Optimization", "Reference Mode"]
+  },
+  {
+    "term": "Optimization",
+    "aliases": [],
+    "definition": "Finding parameter values or policy settings that maximize or minimize an objective function subject to model constraints.",
+    "relevance": "Optimization goes beyond asking 'what if' to asking 'what's best' — it systematically searches for the best policy or parameter configuration.",
+    "related": ["Calibration", "Sensitivity Analysis", "Policy Analysis"]
+  },
+  {
+    "term": "Validation",
+    "aliases": ["Model Validation", "Model Testing"],
+    "definition": "The process of building confidence that a model is useful for its intended purpose through a battery of structural and behavioral tests.",
+    "relevance": "Validation is not proof of correctness but a systematic process of challenging and testing the model to expose weaknesses and build confidence.",
+    "related": ["Dimensional Consistency", "Extreme Condition Test", "Behavior Reproduction Test"]
+  },
+  {
+    "term": "Jay Forrester",
+    "aliases": ["Jay W. Forrester"],
+    "definition": "Professor at MIT (1918–2016) who founded the field of system dynamics in the 1950s, applying feedback control theory to social and industrial systems.",
+    "relevance": "Forrester's books Industrial Dynamics (1961), Urban Dynamics (1969), and World Dynamics (1971) established system dynamics as a discipline.",
+    "related": ["Donella Meadows", "John Sterman"]
+  },
+  {
+    "term": "Donella Meadows",
+    "aliases": ["Dana Meadows"],
+    "definition": "Biophysicist and systems scientist (1941–2001), lead author of The Limits to Growth and author of Thinking in Systems: A Primer.",
+    "relevance": "Meadows made system dynamics accessible to a wide audience and identified leverage points as a framework for intervening in complex systems.",
+    "related": ["Jay Forrester", "John Sterman", "Leverage Point"]
+  },
+  {
+    "term": "John Sterman",
+    "aliases": [],
+    "definition": "Professor at MIT Sloan School of Management, author of Business Dynamics: Systems Thinking and Modeling for a Complex World (2000).",
+    "relevance": "Sterman's textbook is the standard reference for system dynamics education, covering modeling methodology, analysis techniques, and applications.",
+    "related": ["Jay Forrester", "Donella Meadows"]
+  }
+]

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/GlossaryPaneFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/GlossaryPaneFxTest.java
@@ -1,0 +1,188 @@
+package systems.courant.sd.app.canvas;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.TextFlow;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GlossaryPane (#1331)")
+@ExtendWith(ApplicationExtension.class)
+class GlossaryPaneFxTest {
+
+    private GlossaryPane glossaryPane;
+
+    @Start
+    void start(Stage stage) {
+        glossaryPane = new GlossaryPane();
+        stage.setScene(new Scene(new StackPane(glossaryPane), 600, 400));
+        stage.show();
+    }
+
+    @Test
+    @DisplayName("should have a search field")
+    void shouldHaveSearchField() {
+        TextField search = (TextField) glossaryPane.lookup("#glossarySearch");
+        assertThat(search).isNotNull();
+        assertThat(search.getPromptText()).contains("Search");
+    }
+
+    @Test
+    @DisplayName("should have a scroll pane with entries")
+    void shouldHaveScrollPane() {
+        ScrollPane scroll = (ScrollPane) glossaryPane.lookup("#glossaryScroll");
+        assertThat(scroll).isNotNull();
+        assertThat(scroll.getContent()).isInstanceOf(VBox.class);
+        VBox entriesBox = (VBox) scroll.getContent();
+        assertThat(entriesBox.getChildren()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("should display all glossary entries by default")
+    void shouldDisplayAllEntries() {
+        ScrollPane scroll = (ScrollPane) glossaryPane.lookup("#glossaryScroll");
+        VBox entriesBox = (VBox) scroll.getContent();
+        assertThat(entriesBox.getChildren().size())
+                .isEqualTo(Glossary.instance().entries().size());
+    }
+
+    @Test
+    @DisplayName("should filter entries when search text is typed")
+    void shouldFilterEntries() {
+        Platform.runLater(() -> {
+            TextField search = (TextField) glossaryPane.lookup("#glossarySearch");
+            search.setText("feedback");
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ScrollPane scroll = (ScrollPane) glossaryPane.lookup("#glossaryScroll");
+        VBox entriesBox = (VBox) scroll.getContent();
+        assertThat(entriesBox.getChildren().size())
+                .isLessThan(Glossary.instance().entries().size());
+        assertThat(entriesBox.getChildren().size()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("should restore all entries when search is cleared")
+    void shouldRestoreAllOnClear() {
+        Platform.runLater(() -> {
+            TextField search = (TextField) glossaryPane.lookup("#glossarySearch");
+            search.setText("xyz");
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        Platform.runLater(() -> {
+            TextField search = (TextField) glossaryPane.lookup("#glossarySearch");
+            search.clear();
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ScrollPane scroll = (ScrollPane) glossaryPane.lookup("#glossaryScroll");
+        VBox entriesBox = (VBox) scroll.getContent();
+        assertThat(entriesBox.getChildren().size())
+                .isEqualTo(Glossary.instance().entries().size());
+    }
+
+    @Test
+    @DisplayName("showTerm should scroll to and highlight the requested term")
+    void showTermShouldHighlight() {
+        Platform.runLater(() -> glossaryPane.showTerm("Feedback Loop"));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ScrollPane scroll = (ScrollPane) glossaryPane.lookup("#glossaryScroll");
+        VBox entriesBox = (VBox) scroll.getContent();
+
+        boolean found = false;
+        for (Node child : entriesBox.getChildren()) {
+            if (child instanceof VBox entryBox
+                    && "Feedback Loop".equals(entryBox.getUserData())) {
+                found = true;
+                assertThat(entryBox.getStyle()).contains("fff3cd");
+            }
+        }
+        assertThat(found).as("Feedback Loop entry should exist").isTrue();
+    }
+
+    @Test
+    @DisplayName("should invoke onTermNavigate callback when a related link is clicked")
+    void shouldInvokeNavigateCallback() {
+        AtomicReference<String> navigated = new AtomicReference<>();
+        Platform.runLater(() -> glossaryPane.setOnTermNavigate(navigated::set));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ScrollPane scroll = (ScrollPane) glossaryPane.lookup("#glossaryScroll");
+        VBox entriesBox = (VBox) scroll.getContent();
+
+        Platform.runLater(() -> {
+            for (Node child : entriesBox.getChildren()) {
+                if (child instanceof VBox entryBox) {
+                    for (Node inner : entryBox.getChildren()) {
+                        if (inner instanceof TextFlow tf) {
+                            for (Node n : tf.getChildren()) {
+                                if (n instanceof Hyperlink link) {
+                                    link.fire();
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(navigated.get()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("annotated help content should contain glossary hyperlinks")
+    void helpContentShouldContainGlossaryHyperlinks() {
+        AtomicReference<Node> result = new AtomicReference<>();
+        Platform.runLater(() -> result.set(
+                HelpContent.forTopic(HelpTopic.OVERVIEW, term -> {})));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ScrollPane scroll = (ScrollPane) result.get();
+        TextFlow flow = (TextFlow) scroll.getContent();
+
+        boolean hasHyperlink = flow.getChildren().stream()
+                .anyMatch(n -> n instanceof Hyperlink);
+        assertThat(hasHyperlink)
+                .as("Overview help content should contain glossary hyperlinks")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("unannotated help content should not contain hyperlinks")
+    void helpContentShouldNotContainHyperlinksWithoutCallback() {
+        AtomicReference<Node> result = new AtomicReference<>();
+        Platform.runLater(() -> result.set(
+                HelpContent.forTopic(HelpTopic.OVERVIEW)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ScrollPane scroll = (ScrollPane) result.get();
+        TextFlow flow = (TextFlow) scroll.getContent();
+
+        boolean hasHyperlink = flow.getChildren().stream()
+                .anyMatch(n -> n instanceof Hyperlink);
+        assertThat(hasHyperlink)
+                .as("Unannotated help content should not contain hyperlinks")
+                .isFalse();
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/GlossaryTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/GlossaryTest.java
@@ -1,0 +1,156 @@
+package systems.courant.sd.app.canvas;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Glossary (#1331)")
+class GlossaryTest {
+
+    @Nested
+    @DisplayName("Loading")
+    class Loading {
+
+        @Test
+        @DisplayName("should load entries from JSON resource")
+        void shouldLoadEntries() {
+            assertThat(Glossary.instance().entries()).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("entries should be sorted alphabetically by term")
+        void shouldBeSortedAlphabetically() {
+            List<Glossary.Entry> entries = Glossary.instance().entries();
+            for (int i = 1; i < entries.size(); i++) {
+                assertThat(entries.get(i).term().compareToIgnoreCase(entries.get(i - 1).term()))
+                        .as("'%s' should come after '%s'", entries.get(i).term(), entries.get(i - 1).term())
+                        .isGreaterThanOrEqualTo(0);
+            }
+        }
+
+        @Test
+        @DisplayName("every entry should have non-blank term, definition, and relevance")
+        void shouldHaveRequiredFields() {
+            for (Glossary.Entry entry : Glossary.instance().entries()) {
+                assertThat(entry.term()).as("term").isNotBlank();
+                assertThat(entry.definition()).as("definition for %s", entry.term()).isNotBlank();
+                assertThat(entry.relevance()).as("relevance for %s", entry.term()).isNotBlank();
+            }
+        }
+
+        @Test
+        @DisplayName("related terms should reference existing entries")
+        void shouldHaveValidRelatedTerms() {
+            Glossary glossary = Glossary.instance();
+            for (Glossary.Entry entry : glossary.entries()) {
+                for (String related : entry.related()) {
+                    assertThat(glossary.lookup(related))
+                            .as("related term '%s' from '%s'", related, entry.term())
+                            .isPresent();
+                }
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Lookup")
+    class Lookup {
+
+        @Test
+        @DisplayName("should find entry by exact term")
+        void shouldFindByExactTerm() {
+            Optional<Glossary.Entry> entry = Glossary.instance().lookup("Stock");
+            assertThat(entry).isPresent();
+            assertThat(entry.get().term()).isEqualTo("Stock");
+        }
+
+        @Test
+        @DisplayName("should find entry by alias")
+        void shouldFindByAlias() {
+            Optional<Glossary.Entry> entry = Glossary.instance().lookup("CLD");
+            assertThat(entry).isPresent();
+            assertThat(entry.get().term()).isEqualTo("Causal Loop Diagram");
+        }
+
+        @Test
+        @DisplayName("should be case-insensitive")
+        void shouldBeCaseInsensitive() {
+            assertThat(Glossary.instance().lookup("stock")).isPresent();
+            assertThat(Glossary.instance().lookup("STOCK")).isPresent();
+            assertThat(Glossary.instance().lookup("Stock")).isPresent();
+        }
+
+        @Test
+        @DisplayName("should return empty for unknown term")
+        void shouldReturnEmptyForUnknown() {
+            assertThat(Glossary.instance().lookup("nonexistent-xyz")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should return empty for null")
+        void shouldReturnEmptyForNull() {
+            assertThat(Glossary.instance().lookup(null)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Search")
+    class Search {
+
+        @Test
+        @DisplayName("should return all entries for blank query")
+        void shouldReturnAllForBlank() {
+            assertThat(Glossary.instance().search(""))
+                    .hasSize(Glossary.instance().entries().size());
+        }
+
+        @Test
+        @DisplayName("should return all entries for null query")
+        void shouldReturnAllForNull() {
+            assertThat(Glossary.instance().search(null))
+                    .hasSize(Glossary.instance().entries().size());
+        }
+
+        @Test
+        @DisplayName("should find entries by term substring")
+        void shouldFindByTermSubstring() {
+            List<Glossary.Entry> results = Glossary.instance().search("feedback");
+            assertThat(results).extracting(Glossary.Entry::term).contains("Feedback Loop");
+        }
+
+        @Test
+        @DisplayName("should find entries by alias")
+        void shouldFindByAlias() {
+            List<Glossary.Entry> results = Glossary.instance().search("SFD");
+            assertThat(results).extracting(Glossary.Entry::term).contains("Stock-and-Flow Diagram");
+        }
+
+        @Test
+        @DisplayName("should find entries by definition content")
+        void shouldFindByDefinition() {
+            List<Glossary.Entry> results = Glossary.instance().search("accumulates over time");
+            assertThat(results).extracting(Glossary.Entry::term).contains("Stock");
+        }
+
+        @Test
+        @DisplayName("should prioritize term matches over definition matches")
+        void shouldPrioritizeTermMatches() {
+            List<Glossary.Entry> results = Glossary.instance().search("stock");
+            assertThat(results).isNotEmpty();
+            assertThat(results.getFirst().term()).isEqualTo("Stock");
+        }
+
+        @Test
+        @DisplayName("should be case-insensitive")
+        void shouldBeCaseInsensitive() {
+            List<Glossary.Entry> lower = Glossary.instance().search("euler");
+            List<Glossary.Entry> upper = Glossary.instance().search("EULER");
+            assertThat(lower).isEqualTo(upper);
+        }
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/ContextHelpDialogFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/ContextHelpDialogFxTest.java
@@ -56,9 +56,10 @@ class ContextHelpDialogFxTest {
         @SuppressWarnings("unchecked")
         TreeView<HelpTopic> tree = (TreeView<HelpTopic>) root.getLeft();
 
-        // Count all leaf items (topic items, not category nodes)
+        // Count all leaf items (topic items + glossary, not category nodes)
         int leafCount = countLeaves(tree.getRoot());
-        assertThat(leafCount).isEqualTo(HelpTopic.values().length);
+        // +1 for the SD Terminology glossary leaf
+        assertThat(leafCount).isEqualTo(HelpTopic.values().length + 1);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add a 54-term System Dynamics glossary stored as JSON (`sd-glossary.json`), loaded by a new `Glossary` class with case-insensitive lookup, alias support, and ranked search
- New `GlossaryPane` UI with live search filtering, cross-reference hyperlinks, and scroll-to-term navigation
- Integrated into the help dialog sidebar under a "Glossary" category with an "SD Terminology" leaf
- `HelpContent.forTopic()` now accepts an optional navigation callback to auto-annotate plain text with glossary tooltips and hyperlinks (first occurrence only, styled, non-intrusive)
- New "SD Terminology" item in the Help menu for direct access
- 25 new tests covering JSON loading, lookup, search, FX pane structure, filtering, navigation, and annotation

Closes #1331

## Test plan
- [x] Full test suite passes (1933 tests, 0 failures)
- [x] SpotBugs clean
- [x] GlossaryTest validates all related terms reference existing entries
- [x] GlossaryPaneFxTest validates search filtering, term highlighting, and hyperlink callbacks
- [x] ContextHelpDialogFxTest updated for new glossary leaf