### PR TITLE
Add UI support for subscript dimensions

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/MenuBarBuilder.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/MenuBarBuilder.java
@@ -133,10 +133,14 @@ final class MenuBarBuilder {
         MenuItem pasteItem = registry.toMenuItem("Paste");
         MenuItem selectAllItem = registry.toMenuItem("Select All");
 
+        MenuItem subscriptDimItem = registry.toMenuItem("Subscript Dimensions",
+                "Subscript Dimensions\u2026");
+
         editMenu.getItems().addAll(undoItem, redoItem, undoHistoryItem,
                 new SeparatorMenuItem(),
                 cutItem, copyItem, pasteItem,
-                new SeparatorMenuItem(), selectAllItem);
+                new SeparatorMenuItem(), selectAllItem,
+                new SeparatorMenuItem(), subscriptDimItem);
         editMenu.setDisable(true);
         editorOnlyItems.add(editMenu);
 

--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -25,6 +25,7 @@ import systems.courant.sd.app.canvas.dialogs.QuickstartDialog;
 import systems.courant.sd.app.canvas.dialogs.SdConceptsDialog;
 import systems.courant.sd.app.canvas.dialogs.SirTutorialDialog;
 import systems.courant.sd.app.canvas.dialogs.SupplyChainTutorialDialog;
+import systems.courant.sd.app.canvas.dialogs.SubscriptDefinitionDialog;
 import systems.courant.sd.app.canvas.dialogs.TutorialChooserDialog;
 import systems.courant.sd.app.canvas.StatusBar;
 import systems.courant.sd.app.canvas.UndoHistoryPopup;
@@ -33,6 +34,7 @@ import systems.courant.sd.app.canvas.dialogs.ValidationDialog;
 import systems.courant.sd.app.canvas.ZoomOverlay;
 import systems.courant.sd.model.def.ElementType;
 import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.SubscriptDef;
 import systems.courant.sd.model.def.ValidationResult;
 import systems.courant.sd.model.def.ViewDef;
 import systems.courant.sd.model.graph.AutoLayout;
@@ -547,6 +549,8 @@ public class ModelWindow {
                     canvas.elements().selectAll(); canvas.requestFocus(); },
                 new KeyCodeCombination(KeyCode.A,
                         KeyCombination.SHORTCUT_DOWN));
+        commandRegistry.add("Subscript Dimensions", "Edit",
+                this::openSubscriptDimensionsDialog);
 
         // -- Layout --
         commandRegistry.add("Align Top", "Layout",
@@ -669,6 +673,23 @@ public class ModelWindow {
                     "A visual System Dynamics modeling environment.\nVersion "
                             + AppVersion.get());
             about.showAndWait();
+        });
+    }
+
+    private void openSubscriptDimensionsDialog() {
+        var dialog = new SubscriptDefinitionDialog(editor.getSubscripts());
+        dialog.initOwner(stage);
+        dialog.showAndWait().ifPresent(result -> {
+            canvas.undo().saveUndoState("Edit subscript dimensions");
+            // Replace all subscript definitions
+            List<SubscriptDef> current = new ArrayList<>(editor.getSubscripts());
+            for (SubscriptDef old : current) {
+                editor.removeSubscript(old.name());
+            }
+            for (SubscriptDef def : result) {
+                editor.addSubscript(def);
+            }
+            canvas.requestFocus();
         });
     }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ElementFactory.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ElementFactory.java
@@ -109,7 +109,7 @@ final class ElementFactory {
             nextStockId = parseIdSuffix(name, "Stock ") + 1;
         }
         stocks.add(new StockDef(name, template.comment(), template.initialValue(),
-                template.unit(), template.negativeValuePolicy()));
+                template.unit(), template.negativeValuePolicy(), template.subscripts()));
         nameIndex.add(name);
         return name;
     }
@@ -122,7 +122,7 @@ final class ElementFactory {
         String matUnit = template.materialUnit() != null
                 ? template.materialUnit() : inferMaterialUnit(source, sink);
         flows.add(new FlowDef(name, template.comment(), template.equation(),
-                template.timeUnit(), matUnit, source, sink, List.of()));
+                template.timeUnit(), matUnit, source, sink, template.subscripts()));
         nameIndex.add(name);
         return name;
     }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
@@ -422,7 +422,7 @@ public class ModelEditor {
         checkFxThread();
         return updateInList(stocks, name, StockDef::name,
                 s -> new StockDef(name, s.comment(), value,
-                        s.unit(), s.negativeValuePolicy()));
+                        s.unit(), s.negativeValuePolicy(), s.subscripts()));
     }
 
     /** @return true if the stock was found and updated */
@@ -433,7 +433,7 @@ public class ModelEditor {
         }
         return updateInList(stocks, name, StockDef::name,
                 s -> new StockDef(name, s.comment(), s.initialValue(),
-                        unit, s.negativeValuePolicy()));
+                        unit, s.negativeValuePolicy(), s.subscripts()));
     }
 
     /** @return true if the stock was found and updated */
@@ -441,7 +441,7 @@ public class ModelEditor {
         checkFxThread();
         return updateInList(stocks, name, StockDef::name,
                 s -> new StockDef(name, s.comment(), s.initialValue(),
-                        s.unit(), policy));
+                        s.unit(), policy, s.subscripts()));
     }
 
     /** @return true if the flow was found and updated */
@@ -478,7 +478,7 @@ public class ModelEditor {
         checkFxThread();
         return updateInList(stocks, name, StockDef::name,
                 s -> new StockDef(name, comment, s.initialValue(),
-                        s.unit(), s.negativeValuePolicy()));
+                        s.unit(), s.negativeValuePolicy(), s.subscripts()));
     }
 
     /** @return true if the flow was found and updated */
@@ -494,6 +494,54 @@ public class ModelEditor {
         checkFxThread();
         return updateInList(variables, name, VariableDef::name,
                 a -> new VariableDef(a.name(), comment, a.equation(), a.unit(), a.subscripts()));
+    }
+
+    // ── Subscript assignment ─────────────────────────────────────────────
+
+    /** @return true if the stock was found and updated */
+    public boolean setStockSubscripts(String name, List<String> newSubscripts) {
+        checkFxThread();
+        return updateInList(stocks, name, StockDef::name,
+                s -> new StockDef(name, s.comment(), s.initialValue(),
+                        s.unit(), s.negativeValuePolicy(), newSubscripts));
+    }
+
+    /** @return true if the flow was found and updated */
+    public boolean setFlowSubscripts(String name, List<String> newSubscripts) {
+        checkFxThread();
+        return updateInList(flows, name, FlowDef::name,
+                f -> new FlowDef(f.name(), f.comment(), f.equation(),
+                        f.timeUnit(), f.materialUnit(), f.source(), f.sink(), newSubscripts));
+    }
+
+    /** @return true if the variable was found and updated */
+    public boolean setVariableSubscripts(String name, List<String> newSubscripts) {
+        checkFxThread();
+        return updateInList(variables, name, VariableDef::name,
+                a -> new VariableDef(a.name(), a.comment(), a.equation(), a.unit(), newSubscripts));
+    }
+
+    // ── Subscript definition management ─────────────────────────────────
+
+    public void addSubscript(SubscriptDef def) {
+        checkFxThread();
+        subscripts.add(def);
+    }
+
+    public boolean updateSubscript(String oldName, SubscriptDef updated) {
+        checkFxThread();
+        for (int i = 0; i < subscripts.size(); i++) {
+            if (subscripts.get(i).name().equals(oldName)) {
+                subscripts.set(i, updated);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean removeSubscript(String name) {
+        checkFxThread();
+        return subscripts.removeIf(s -> s.name().equals(name));
     }
 
     /** @return true if the lookup table was found and updated */

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SubscriptDefinitionDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SubscriptDefinitionDialog.java
@@ -1,0 +1,162 @@
+package systems.courant.sd.app.canvas.dialogs;
+
+import systems.courant.sd.app.canvas.HelpContextResolver;
+import systems.courant.sd.app.canvas.Styles;
+import systems.courant.sd.model.def.SubscriptDef;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Dialog for defining subscript dimensions (name + ordered label list).
+ * Each dimension row has a name field, a comma-separated labels field,
+ * and a remove button. New dimensions can be added dynamically.
+ */
+public class SubscriptDefinitionDialog extends Dialog<List<SubscriptDef>> {
+
+    private final VBox rowsBox = new VBox(6);
+    private final List<DimensionRow> rows = new ArrayList<>();
+
+    private record DimensionRow(TextField nameField, TextField labelsField, HBox container) {}
+
+    public SubscriptDefinitionDialog(List<SubscriptDef> existing) {
+        HelpContextResolver.addHelpButton(this);
+        setTitle("Subscript Dimensions");
+        setHeaderText("Define subscript dimensions for arrayed elements");
+        setResizable(true);
+
+        VBox content = new VBox(12);
+        content.setPadding(new Insets(10));
+        content.setPrefWidth(480);
+
+        Label help = new Label(
+                "Each dimension has a name and a comma-separated list of labels. "
+                + "Assign dimensions to elements in the properties panel.");
+        help.setStyle(Styles.MUTED_TEXT);
+        help.setWrapText(true);
+
+        GridPane columnHeaders = createColumnHeaders();
+
+        Button addButton = new Button("+ Add Dimension");
+        addButton.setId("addDimensionButton");
+        addButton.setOnAction(e -> addRow("", ""));
+
+        content.getChildren().addAll(help, columnHeaders, rowsBox, addButton);
+
+        if (existing != null) {
+            for (SubscriptDef def : existing) {
+                addRow(def.name(), String.join(", ", def.labels()));
+            }
+        }
+
+        ScrollPane scrollPane = new ScrollPane(content);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        scrollPane.setMaxHeight(400);
+        VBox.setVgrow(scrollPane, Priority.ALWAYS);
+
+        getDialogPane().setContent(scrollPane);
+        getDialogPane().setPrefHeight(350);
+
+        ButtonType okButton = new ButtonType("OK", ButtonBar.ButtonData.OK_DONE);
+        getDialogPane().getButtonTypes().addAll(okButton, ButtonType.CANCEL);
+
+        setResultConverter(button -> {
+            if (button == okButton) {
+                return collectDimensions();
+            }
+            return null;
+        });
+    }
+
+    private GridPane createColumnHeaders() {
+        GridPane headers = new GridPane();
+        headers.setHgap(10);
+
+        Label nameHeader = new Label("Name");
+        nameHeader.setStyle(Styles.BOLD_TEXT);
+        nameHeader.setPrefWidth(140);
+        headers.add(nameHeader, 0, 0);
+
+        Label labelsHeader = new Label("Labels");
+        labelsHeader.setStyle(Styles.BOLD_TEXT);
+        labelsHeader.setPrefWidth(260);
+        headers.add(labelsHeader, 1, 0);
+
+        return headers;
+    }
+
+    private void addRow(String name, String labels) {
+        TextField nameField = new TextField(name);
+        nameField.setPrefWidth(140);
+        nameField.setPromptText("e.g., Region");
+
+        TextField labelsField = new TextField(labels);
+        labelsField.setPrefWidth(260);
+        labelsField.setPromptText("e.g., North, South, East, West");
+        Tooltip.install(labelsField, new Tooltip("Comma-separated list of labels"));
+        HBox.setHgrow(labelsField, Priority.ALWAYS);
+
+        Button removeButton = new Button("\u2715");
+        removeButton.setStyle("-fx-font-size: 10px; -fx-padding: 2 6 2 6;");
+
+        HBox row = new HBox(10, nameField, labelsField, removeButton);
+        row.setAlignment(Pos.CENTER_LEFT);
+
+        DimensionRow dimRow = new DimensionRow(nameField, labelsField, row);
+        rows.add(dimRow);
+        rowsBox.getChildren().add(row);
+
+        removeButton.setOnAction(e -> {
+            rows.remove(dimRow);
+            rowsBox.getChildren().remove(row);
+        });
+    }
+
+    private List<SubscriptDef> collectDimensions() {
+        List<SubscriptDef> result = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        for (DimensionRow row : rows) {
+            String name = row.nameField().getText();
+            if (name == null || name.isBlank()) {
+                continue;
+            }
+            String trimmedName = name.trim();
+            if (!seen.add(trimmedName)) {
+                continue; // skip duplicate names
+            }
+            String labelsText = row.labelsField().getText();
+            if (labelsText == null || labelsText.isBlank()) {
+                continue;
+            }
+            List<String> labels = Arrays.stream(labelsText.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .toList();
+            if (labels.isEmpty()) {
+                continue;
+            }
+            result.add(new SubscriptDef(trimmedName, labels));
+        }
+        return result;
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FlowForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FlowForm.java
@@ -7,6 +7,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import systems.courant.sd.app.canvas.EquationAutoComplete;
@@ -78,6 +79,9 @@ public class FlowForm implements ElementForm {
         fields.addReadOnlyRow(row++, "Sink", sinkLabel,
                 "The stock this flow fills. (cloud) = unlimited external sink.");
 
+        row = fields.addSubscriptRow(row, ctx.getEditor().getSubscripts(),
+                flow.subscripts(), this::commitSubscripts);
+
         return row;
     }
 
@@ -136,6 +140,15 @@ public class FlowForm implements ElementForm {
         }
         ctx.getCanvas().applyMutation(
                 () -> ctx.getEditor().setFlowMaterialUnit(ctx.getElementName(), resolved));
+    }
+
+    private void commitSubscripts(List<String> subscripts) {
+        Optional<FlowDef> flowOpt = ctx.getEditor().getFlowByName(ctx.getElementName());
+        if (flowOpt.isEmpty() || flowOpt.get().subscripts().equals(subscripts)) {
+            return;
+        }
+        ctx.getCanvas().applyMutation(
+                () -> ctx.getEditor().setFlowSubscripts(ctx.getElementName(), subscripts));
     }
 
     private void commitTimeUnit(ComboBox<String> box) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormFieldBuilder.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormFieldBuilder.java
@@ -21,6 +21,7 @@ import javafx.util.Duration;
 
 import javafx.collections.FXCollections;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -28,6 +29,7 @@ import systems.courant.sd.app.canvas.EquationField;
 import systems.courant.sd.app.canvas.EquationTemplates;
 import systems.courant.sd.app.canvas.ModelEditor;
 import systems.courant.sd.app.canvas.Styles;
+import systems.courant.sd.model.def.SubscriptDef;
 
 /**
  * UI builder utility that creates and arranges form fields in the property grid.
@@ -274,6 +276,46 @@ public class FormFieldBuilder {
         box.setMaxWidth(Double.MAX_VALUE);
         GridPane.setHgrow(box, Priority.ALWAYS);
         return box;
+    }
+
+    /**
+     * Adds a subscript assignment row with one checkbox per defined dimension.
+     * If no subscript dimensions are defined in the model, nothing is added and
+     * {@code startRow} is returned unchanged — keeping the form free of subscript
+     * UI for users who don't use this feature.
+     *
+     * @return the next available row index
+     */
+    public int addSubscriptRow(int startRow, List<SubscriptDef> modelSubscripts,
+                               List<String> currentSubscripts,
+                               Consumer<List<String>> onChanged) {
+        if (modelSubscripts == null || modelSubscripts.isEmpty()) {
+            return startRow;
+        }
+        javafx.scene.layout.FlowPane checkboxPane = new javafx.scene.layout.FlowPane(8, 4);
+        for (SubscriptDef dim : modelSubscripts) {
+            javafx.scene.control.CheckBox cb = new javafx.scene.control.CheckBox(dim.name());
+            cb.setSelected(currentSubscripts != null && currentSubscripts.contains(dim.name()));
+            cb.setStyle("-fx-font-size: 11px;");
+            cb.selectedProperty().addListener((obs, wasSelected, isSelected) -> {
+                if (!ctx.isUpdatingFields()) {
+                    List<String> checked = new ArrayList<>();
+                    for (var node : checkboxPane.getChildren()) {
+                        if (node instanceof javafx.scene.control.CheckBox box
+                                && box.isSelected()) {
+                            checked.add(box.getText());
+                        }
+                    }
+                    onChanged.accept(checked);
+                }
+            });
+            checkboxPane.getChildren().add(cb);
+        }
+        checkboxPane.setMaxWidth(Double.MAX_VALUE);
+        GridPane.setHgrow(checkboxPane, Priority.ALWAYS);
+        addFieldRow(startRow, "Subscripts", checkboxPane,
+                "Dimensions this element is arrayed over");
+        return startRow + 1;
     }
 
     public void addComboCommitHandlers(ComboBox<String> box, Consumer<ComboBox<String>> handler) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/StockForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/StockForm.java
@@ -6,6 +6,7 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import systems.courant.sd.app.canvas.renderers.ElementRenderer;
@@ -71,6 +72,9 @@ public class StockForm implements ElementForm {
                 + "'Clamp to Zero' prevents negative values (common for physical "
                 + "quantities like population or inventory).\n"
                 + "'Allow' permits negatives (e.g., bank balances, temperature deltas).");
+
+        row = fields.addSubscriptRow(row, ctx.getEditor().getSubscripts(),
+                stock.subscripts(), this::commitSubscripts);
 
         return row;
     }
@@ -140,6 +144,15 @@ public class StockForm implements ElementForm {
      * Maps the stored policy string to a display value.
      * Null and "CLAMP_TO_ZERO" both display as "Clamp to Zero" (the engine default).
      */
+    private void commitSubscripts(List<String> subscripts) {
+        Optional<StockDef> stockOpt = ctx.getEditor().getStockByName(ctx.getElementName());
+        if (stockOpt.isEmpty() || stockOpt.get().subscripts().equals(subscripts)) {
+            return;
+        }
+        ctx.getCanvas().applyMutation(
+                () -> ctx.getEditor().setStockSubscripts(ctx.getElementName(), subscripts));
+    }
+
     private static String policyDisplayValue(String policy) {
         if ("ALLOW".equals(policy)) {
             return "Allow";

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/VariableForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/VariableForm.java
@@ -6,6 +6,7 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import systems.courant.sd.app.canvas.EquationAutoComplete;
@@ -60,6 +61,9 @@ public class VariableForm implements ElementForm {
         fields.addFieldRow(row++, "Unit", unitBox,
                 "The unit of measurement");
 
+        row = fields.addSubscriptRow(row, ctx.getEditor().getSubscripts(),
+                v.subscripts(), this::commitSubscripts);
+
         return row;
     }
 
@@ -104,6 +108,15 @@ public class VariableForm implements ElementForm {
             return;
         }
         ctx.getCanvas().applyMutation(() -> ctx.getEditor().setVariableEquation(ctx.getElementName(), equation));
+    }
+
+    private void commitSubscripts(List<String> subscripts) {
+        Optional<VariableDef> varOpt = ctx.getEditor().getVariableByName(ctx.getElementName());
+        if (varOpt.isEmpty() || varOpt.get().subscripts().equals(subscripts)) {
+            return;
+        }
+        ctx.getCanvas().applyMutation(
+                () -> ctx.getEditor().setVariableSubscripts(ctx.getElementName(), subscripts));
     }
 
     private void commitUnit(ComboBox<String> box) {

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelEditorTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelEditorTest.java
@@ -2386,4 +2386,234 @@ class ModelEditorTest {
             assertThat(events).isEmpty();
         }
     }
+
+    @Nested
+    @DisplayName("subscript preservation on stock setters")
+    class StockSubscriptPreservation {
+
+        @Test
+        void shouldPreserveSubscriptsOnSetInitialValue() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .subscript("Region", List.of("North", "South"))
+                    .stock("Pop", 100, "Person", List.of("Region"))
+                    .build();
+            editor.loadFrom(def);
+
+            editor.setStockInitialValue("Pop", 200);
+
+            StockDef updated = editor.getStockByName("Pop").orElseThrow();
+            assertThat(updated.initialValue()).isEqualTo(200);
+            assertThat(updated.subscripts()).containsExactly("Region");
+        }
+
+        @Test
+        void shouldPreserveSubscriptsOnSetUnit() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .subscript("Region", List.of("North", "South"))
+                    .stock("Pop", 100, "Person", List.of("Region"))
+                    .build();
+            editor.loadFrom(def);
+
+            editor.setStockUnit("Pop", "Animal");
+
+            StockDef updated = editor.getStockByName("Pop").orElseThrow();
+            assertThat(updated.unit()).isEqualTo("Animal");
+            assertThat(updated.subscripts()).containsExactly("Region");
+        }
+
+        @Test
+        void shouldPreserveSubscriptsOnSetNegativeValuePolicy() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .subscript("Region", List.of("North", "South"))
+                    .stock("Pop", 100, "Person", List.of("Region"))
+                    .build();
+            editor.loadFrom(def);
+
+            editor.setStockNegativeValuePolicy("Pop", "ALLOW");
+
+            StockDef updated = editor.getStockByName("Pop").orElseThrow();
+            assertThat(updated.negativeValuePolicy()).isEqualTo("ALLOW");
+            assertThat(updated.subscripts()).containsExactly("Region");
+        }
+
+        @Test
+        void shouldPreserveSubscriptsOnSetComment() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .subscript("Region", List.of("North", "South"))
+                    .stock("Pop", 100, "Person", List.of("Region"))
+                    .build();
+            editor.loadFrom(def);
+
+            editor.setStockComment("Pop", "A comment");
+
+            StockDef updated = editor.getStockByName("Pop").orElseThrow();
+            assertThat(updated.comment()).isEqualTo("A comment");
+            assertThat(updated.subscripts()).containsExactly("Region");
+        }
+    }
+
+    @Nested
+    @DisplayName("subscript assignment setters")
+    class SubscriptAssignment {
+
+        @Test
+        void shouldSetStockSubscripts() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("S", 0, "units")
+                    .build();
+            editor.loadFrom(def);
+
+            boolean updated = editor.setStockSubscripts("S", List.of("Region"));
+
+            assertThat(updated).isTrue();
+            assertThat(editor.getStockByName("S").orElseThrow().subscripts())
+                    .containsExactly("Region");
+        }
+
+        @Test
+        void shouldSetFlowSubscripts() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .flow("F", "0", "Day", null, null)
+                    .build();
+            editor.loadFrom(def);
+
+            boolean updated = editor.setFlowSubscripts("F", List.of("Age"));
+
+            assertThat(updated).isTrue();
+            assertThat(editor.getFlowByName("F").orElseThrow().subscripts())
+                    .containsExactly("Age");
+        }
+
+        @Test
+        void shouldSetVariableSubscripts() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .variable("V", "0", "units")
+                    .build();
+            editor.loadFrom(def);
+
+            boolean updated = editor.setVariableSubscripts("V", List.of("Region", "Age"));
+
+            assertThat(updated).isTrue();
+            assertThat(editor.getVariableByName("V").orElseThrow().subscripts())
+                    .containsExactly("Region", "Age");
+        }
+
+        @Test
+        void shouldReturnFalseForNonexistentElement() {
+            editor.loadFrom(new ModelDefinitionBuilder().name("Test").build());
+
+            assertThat(editor.setStockSubscripts("Missing", List.of("X"))).isFalse();
+            assertThat(editor.setFlowSubscripts("Missing", List.of("X"))).isFalse();
+            assertThat(editor.setVariableSubscripts("Missing", List.of("X"))).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("subscript definition management")
+    class SubscriptDefinitionManagement {
+
+        @Test
+        void shouldAddSubscriptDef() {
+            editor.loadFrom(new ModelDefinitionBuilder().name("Test").build());
+
+            editor.addSubscript(new SubscriptDef("Region", List.of("N", "S")));
+
+            assertThat(editor.getSubscripts()).hasSize(1);
+            assertThat(editor.getSubscripts().get(0).name()).isEqualTo("Region");
+            assertThat(editor.getSubscripts().get(0).labels()).containsExactly("N", "S");
+        }
+
+        @Test
+        void shouldUpdateSubscriptDef() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .subscript("Region", List.of("N", "S"))
+                    .build();
+            editor.loadFrom(def);
+
+            boolean updated = editor.updateSubscript("Region",
+                    new SubscriptDef("Region", List.of("N", "S", "E", "W")));
+
+            assertThat(updated).isTrue();
+            assertThat(editor.getSubscripts().get(0).labels())
+                    .containsExactly("N", "S", "E", "W");
+        }
+
+        @Test
+        void shouldRemoveSubscriptDef() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .subscript("Region", List.of("N", "S"))
+                    .build();
+            editor.loadFrom(def);
+
+            boolean removed = editor.removeSubscript("Region");
+
+            assertThat(removed).isTrue();
+            assertThat(editor.getSubscripts()).isEmpty();
+        }
+
+        @Test
+        void shouldReturnFalseWhenRemovingNonexistentSubscript() {
+            editor.loadFrom(new ModelDefinitionBuilder().name("Test").build());
+
+            assertThat(editor.removeSubscript("Missing")).isFalse();
+        }
+
+        @Test
+        void shouldReturnFalseWhenUpdatingNonexistentSubscript() {
+            editor.loadFrom(new ModelDefinitionBuilder().name("Test").build());
+
+            assertThat(editor.updateSubscript("Missing",
+                    new SubscriptDef("Missing", List.of("A")))).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("copy-paste preserves subscripts")
+    class CopyPasteSubscripts {
+
+        @Test
+        void shouldPreserveSubscriptsOnAddStockFrom() {
+            editor.loadFrom(new ModelDefinitionBuilder().name("Test").build());
+            StockDef template = new StockDef("Pop", null, 100, "Person",
+                    null, List.of("Region"));
+
+            String name = editor.addStockFrom(template);
+
+            StockDef copy = editor.getStockByName(name).orElseThrow();
+            assertThat(copy.subscripts()).containsExactly("Region");
+        }
+
+        @Test
+        void shouldPreserveSubscriptsOnAddFlowFrom() {
+            editor.loadFrom(new ModelDefinitionBuilder().name("Test").build());
+            FlowDef template = new FlowDef("Migration", null, "0.1",
+                    "Year", "Person", null, null, List.of("Region"));
+
+            String name = editor.addFlowFrom(template, null, null);
+
+            FlowDef copy = editor.getFlowByName(name).orElseThrow();
+            assertThat(copy.subscripts()).containsExactly("Region");
+        }
+
+        @Test
+        void shouldPreserveSubscriptsOnAddVariableFrom() {
+            editor.loadFrom(new ModelDefinitionBuilder().name("Test").build());
+            VariableDef template = new VariableDef("Rate", null, "0.5",
+                    "1/Year", List.of("Region"));
+
+            String name = editor.addVariableFrom(template, template.equation());
+
+            VariableDef copy = editor.getVariableByName(name).orElseThrow();
+            assertThat(copy.subscripts()).containsExactly("Region");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Fix data-loss bugs where stock setters and copy-paste silently dropped subscript assignments
- Add subscript definition dialog (Edit > Subscript Dimensions...) for managing dimension names and labels
- Add conditional subscript checkboxes in property forms for stocks, flows, and variables (hidden when no dimensions defined)
- Add ModelEditor API for subscript assignment and definition management
- 17 new tests covering preservation, assignment, management, and copy-paste

Closes #1339 Phase 1

## Test plan

- [x] All 158+ existing tests pass
- [x] 17 new unit tests for subscript preservation, assignment, definition management, and copy-paste
- [x] SpotBugs clean
- [x] Full reactor clean compile