### PR TITLE
Add subscript bracket notation to autocomplete and validation

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationAutoComplete.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationAutoComplete.java
@@ -28,10 +28,17 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
 import systems.courant.sd.app.canvas.forms.TextFieldEquationField;
+import systems.courant.sd.model.def.FlowDef;
+import systems.courant.sd.model.def.StockDef;
+import systems.courant.sd.model.def.SubscriptDef;
+import systems.courant.sd.model.def.VariableDef;
 
 /**
  * Attaches autocomplete behaviour to equation fields.
@@ -197,9 +204,47 @@ public final class EquationAutoComplete {
         }
         int end = caret;
         int start = caret;
+
+        // Scan backward over ident chars (handles normal tokens and content after ']')
         while (start > 0 && isIdentChar(text.charAt(start - 1))) {
             start--;
         }
+
+        // Check if we're inside or just after bracket notation: Name[label...]
+        if (start > 0 && text.charAt(start - 1) == ']') {
+            // Caret is right after ']' — scan backward over bracket content and base name
+            start--; // skip ']'
+            while (start > 0 && text.charAt(start - 1) != '[') {
+                start--;
+            }
+            if (start > 0) {
+                start--; // skip '['
+                while (start > 0 && isIdentChar(text.charAt(start - 1))) {
+                    start--;
+                }
+            }
+        } else if (start > 0 && text.charAt(start - 1) == '[') {
+            // Caret is inside brackets — scan back over '[' and the base name
+            start--; // skip '['
+            while (start > 0 && isIdentChar(text.charAt(start - 1))) {
+                start--;
+            }
+        } else if (start < caret) {
+            // Check if we scanned over bracket content: "Name[lab|" where we
+            // stopped at ident chars but there's a '[' + base name before
+            int probe = start;
+            if (probe > 0 && text.charAt(probe - 1) == '[') {
+                probe--; // skip '['
+                int bracketPos = probe;
+                while (probe > 0 && isIdentChar(text.charAt(probe - 1))) {
+                    probe--;
+                }
+                if (probe < bracketPos) {
+                    start = probe; // include base name and bracket
+                }
+            }
+        }
+
         if (start == end) {
             return null;
         }
@@ -281,6 +326,9 @@ public final class EquationAutoComplete {
         addElementSuggestions(result, editor.getModules(), m -> m.instanceName(),
                 AutoCompleteSuggestion.Kind.MODULE, excludeUnderscore);
 
+        // Add expanded subscripted names (e.g., Population[North])
+        addSubscriptedSuggestions(result, editor, excludeUnderscore);
+
         result.sort(Comparator.comparing(AutoCompleteSuggestion::name));
 
         // Add functions after elements
@@ -352,6 +400,82 @@ public final class EquationAutoComplete {
             };
             dest.add(new AutoCompleteSuggestion(name, name, kindLabel, kind, false));
         }
+    }
+
+    private static void addSubscriptedSuggestions(
+            List<AutoCompleteSuggestion> dest, ModelEditor editor, String excludeUnderscore) {
+        Map<String, List<String>> dimLabels = new HashMap<>();
+        for (SubscriptDef def : editor.getSubscripts()) {
+            dimLabels.put(def.name(), def.labels());
+        }
+        if (dimLabels.isEmpty()) {
+            return;
+        }
+        addExpandedElementSuggestions(dest, editor.getStocks(), StockDef::name,
+                StockDef::subscripts, AutoCompleteSuggestion.Kind.STOCK,
+                excludeUnderscore, dimLabels);
+        addExpandedElementSuggestions(dest, editor.getFlows(), FlowDef::name,
+                FlowDef::subscripts, AutoCompleteSuggestion.Kind.FLOW,
+                excludeUnderscore, dimLabels);
+        addExpandedElementSuggestions(dest, editor.getVariables(), VariableDef::name,
+                VariableDef::subscripts, AutoCompleteSuggestion.Kind.AUX,
+                excludeUnderscore, dimLabels);
+    }
+
+    private static <T> void addExpandedElementSuggestions(
+            List<AutoCompleteSuggestion> dest, List<T> elements,
+            java.util.function.Function<T, String> nameExtractor,
+            java.util.function.Function<T, List<String>> subscriptExtractor,
+            AutoCompleteSuggestion.Kind kind, String excludeUnderscore,
+            Map<String, List<String>> dimLabels) {
+        for (T element : elements) {
+            List<String> subs = subscriptExtractor.apply(element);
+            if (subs == null || subs.isEmpty()) {
+                continue;
+            }
+            String baseName = nameExtractor.apply(element).replace(' ', '_');
+            if (baseName.equals(excludeUnderscore)) {
+                continue;
+            }
+            List<List<String>> labelLists = new ArrayList<>();
+            for (String dim : subs) {
+                List<String> labels = dimLabels.get(dim);
+                if (labels != null) {
+                    labelLists.add(labels);
+                }
+            }
+            if (labelLists.isEmpty()) {
+                continue;
+            }
+            String kindLabel = switch (kind) {
+                case STOCK -> "Stock";
+                case FLOW -> "Flow";
+                case AUX -> "Variable";
+                default -> "";
+            } + " (subscripted)";
+            for (List<String> combo : cartesianProduct(labelLists)) {
+                String expanded = baseName + "[" + String.join(",", combo) + "]";
+                dest.add(new AutoCompleteSuggestion(
+                        expanded, expanded, kindLabel, kind, false));
+            }
+        }
+    }
+
+    private static List<List<String>> cartesianProduct(List<List<String>> lists) {
+        List<List<String>> result = new ArrayList<>();
+        result.add(new ArrayList<>());
+        for (List<String> list : lists) {
+            List<List<String>> next = new ArrayList<>();
+            for (List<String> partial : result) {
+                for (String item : list) {
+                    List<String> combo = new ArrayList<>(partial);
+                    combo.add(item);
+                    next.add(combo);
+                }
+            }
+            result = next;
+        }
+        return result;
     }
 
     public static boolean isBuiltInFunction(String name) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationValidator.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationValidator.java
@@ -5,9 +5,16 @@ import systems.courant.sd.model.expr.ExprDependencies;
 import systems.courant.sd.model.expr.ExprParser;
 import systems.courant.sd.model.expr.ParseException;
 
+import systems.courant.sd.model.def.FlowDef;
+import systems.courant.sd.model.def.StockDef;
+import systems.courant.sd.model.def.SubscriptDef;
+import systems.courant.sd.model.def.VariableDef;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -27,9 +34,10 @@ public final class EquationValidator {
      *
      * @param valid   true if no errors were found
      * @param message error description, or null if valid
+     * @param warning optional warning text (may be non-null even when valid is true)
      */
-    public record Result(boolean valid, String message) {
-        static final Result OK = new Result(true, null);
+    public record Result(boolean valid, String message, String warning) {
+        static final Result OK = new Result(true, null, null);
     }
 
     /**
@@ -51,7 +59,7 @@ public final class EquationValidator {
         try {
             expr = ExprParser.parse(equation);
         } catch (ParseException e) {
-            return new Result(false, formatParseError(e));
+            return new Result(false, formatParseError(e), null);
         }
 
         // 2. Reference check
@@ -74,10 +82,16 @@ public final class EquationValidator {
                 if (suggestion != null) {
                     msg += " \u2014 did you mean '" + suggestion + "'?";
                 }
-                return new Result(false, msg);
+                return new Result(false, msg, null);
             }
             return new Result(false,
-                    "Unknown variables: " + String.join(", ", unknowns));
+                    "Unknown variables: " + String.join(", ", unknowns), null);
+        }
+
+        // 3. Subscript completeness check
+        String warning = checkSubscriptCompleteness(refs, editor, selfName);
+        if (warning != null) {
+            return new Result(true, null, warning);
         }
 
         return Result.OK;
@@ -105,7 +119,137 @@ public final class EquationValidator {
             names.addAll(m.outputBindings().values());
         });
         editor.getCldVariables().forEach(v -> names.add(v.name()));
+
+        // Add expanded subscripted names (e.g., Population[North])
+        Map<String, List<String>> dimLabels = buildDimensionLabelMap(editor);
+        if (!dimLabels.isEmpty()) {
+            addExpandedNames(names, editor.getStocks(), StockDef::name,
+                    StockDef::subscripts, dimLabels);
+            addExpandedNames(names, editor.getFlows(), FlowDef::name,
+                    FlowDef::subscripts, dimLabels);
+            addExpandedNames(names, editor.getVariables(), VariableDef::name,
+                    VariableDef::subscripts, dimLabels);
+        }
+
         return names;
+    }
+
+    private static Map<String, List<String>> buildDimensionLabelMap(ModelEditor editor) {
+        Map<String, List<String>> map = new HashMap<>();
+        for (SubscriptDef def : editor.getSubscripts()) {
+            map.put(def.name(), def.labels());
+        }
+        return map;
+    }
+
+    private static <T> void addExpandedNames(
+            Set<String> names, List<T> elements,
+            java.util.function.Function<T, String> nameExtractor,
+            java.util.function.Function<T, List<String>> subscriptExtractor,
+            Map<String, List<String>> dimLabels) {
+        for (T element : elements) {
+            List<String> subs = subscriptExtractor.apply(element);
+            if (subs == null || subs.isEmpty()) {
+                continue;
+            }
+            String baseName = nameExtractor.apply(element).replace(' ', '_');
+            List<List<String>> labelLists = new ArrayList<>();
+            for (String dim : subs) {
+                List<String> labels = dimLabels.get(dim);
+                if (labels != null) {
+                    labelLists.add(labels);
+                }
+            }
+            if (!labelLists.isEmpty()) {
+                for (List<String> combo : cartesianProduct(labelLists)) {
+                    names.add(baseName + "[" + String.join(",", combo) + "]");
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks whether any referenced element is subscripted but referenced
+     * without bracket notation from a non-subscripted context.
+     */
+    private static String checkSubscriptCompleteness(
+            Set<String> refs, ModelEditor editor, String selfName) {
+        Map<String, List<String>> elementSubscripts = buildElementSubscriptMap(editor);
+        List<String> selfSubs = selfName != null
+                ? elementSubscripts.getOrDefault(selfName, List.of()) : List.of();
+        // Also check underscore-resolved name
+        if (selfSubs.isEmpty() && selfName != null) {
+            selfSubs = elementSubscripts.getOrDefault(
+                    selfName.replace('_', ' '), List.of());
+        }
+
+        List<String> bareRefs = new ArrayList<>();
+        for (String ref : refs) {
+            // Skip bracket-notation references — those are already explicit
+            if (ref.contains("[")) {
+                continue;
+            }
+            String resolved = ref.replace('_', ' ');
+            List<String> refSubs = elementSubscripts.getOrDefault(ref, List.of());
+            if (refSubs.isEmpty()) {
+                refSubs = elementSubscripts.getOrDefault(resolved, List.of());
+            }
+            if (refSubs.isEmpty()) {
+                continue; // not subscripted, nothing to warn about
+            }
+            // The referenced element is subscripted. If this element shares
+            // all the same dimensions, the SubscriptExpander handles it — no warning.
+            if (!selfSubs.containsAll(refSubs)) {
+                bareRefs.add(ref);
+            }
+        }
+
+        if (bareRefs.isEmpty()) {
+            return null;
+        }
+        if (bareRefs.size() == 1) {
+            return "'" + bareRefs.getFirst() + "' is subscripted \u2014 "
+                    + "use bracket notation (e.g., " + bareRefs.getFirst() + "[label])";
+        }
+        return "Subscripted elements referenced without labels: "
+                + String.join(", ", bareRefs);
+    }
+
+    private static Map<String, List<String>> buildElementSubscriptMap(ModelEditor editor) {
+        Map<String, List<String>> map = new HashMap<>();
+        for (StockDef s : editor.getStocks()) {
+            if (!s.subscripts().isEmpty()) {
+                map.put(s.name(), s.subscripts());
+            }
+        }
+        for (FlowDef f : editor.getFlows()) {
+            if (!f.subscripts().isEmpty()) {
+                map.put(f.name(), f.subscripts());
+            }
+        }
+        for (VariableDef v : editor.getVariables()) {
+            if (!v.subscripts().isEmpty()) {
+                map.put(v.name(), v.subscripts());
+            }
+        }
+        return map;
+    }
+
+    private static List<List<String>> cartesianProduct(List<List<String>> lists) {
+        List<List<String>> result = new ArrayList<>();
+        result.add(new ArrayList<>());
+        for (List<String> list : lists) {
+            List<List<String>> next = new ArrayList<>();
+            for (List<String> partial : result) {
+                for (String item : list) {
+                    List<String> combo = new ArrayList<>(partial);
+                    combo.add(item);
+                    next.add(combo);
+                }
+            }
+            result = next;
+        }
+        return result;
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/Styles.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/Styles.java
@@ -72,6 +72,12 @@ public final class Styles {
     public static final String EQUATION_ERROR_LABEL =
             "-fx-text-fill: #E74C3C; -fx-font-size: 10px; -fx-wrap-text: true;";
 
+    // --- Equation validation (warning) ---
+    public static final String EQUATION_WARNING_BORDER =
+            "-fx-border-color: #E67E22; -fx-border-width: 1.5;";
+    public static final String EQUATION_WARNING_LABEL =
+            "-fx-text-fill: #E67E22; -fx-font-size: 10px; -fx-wrap-text: true;";
+
     // --- Dimensional analysis ---
     public static final String DIMENSION_LABEL =
             "-fx-text-fill: #6C757D; -fx-font-size: 10px;";

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/DimensionalAnalysisUI.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/DimensionalAnalysisUI.java
@@ -115,7 +115,15 @@ public class DimensionalAnalysisUI {
         EquationValidator.Result result =
                 EquationValidator.validate(text, ctx.getEditor(), ctx.getElementName());
         if (result.valid()) {
-            clearEquationError(field, errorLabel);
+            if (result.warning() != null) {
+                field.setFieldStyle(Styles.EQUATION_WARNING_BORDER);
+                errorLabel.setText(result.warning());
+                errorLabel.setStyle(Styles.EQUATION_WARNING_LABEL);
+                errorLabel.setVisible(true);
+                errorLabel.setManaged(true);
+            } else {
+                clearEquationError(field, errorLabel);
+            }
             runDimensionalAnalysis(text, dimensionLabel);
         } else {
             field.setFieldStyle(Styles.EQUATION_ERROR_BORDER);

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/EquationAutoCompleteTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/EquationAutoCompleteTest.java
@@ -2,6 +2,7 @@ package systems.courant.sd.app.canvas;
 
 import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.ModelDefinitionBuilder;
+import systems.courant.sd.model.def.SubscriptDef;
 
 import java.util.Arrays;
 import java.util.List;
@@ -353,6 +354,78 @@ class EquationAutoCompleteTest {
         @Test
         void shouldReturnFalseForNonBuiltIn() {
             assertThat(EquationAutoComplete.isBuiltInFunction("Population")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("extractToken with brackets")
+    class ExtractTokenBrackets {
+
+        @Test
+        void shouldExtractTokenInsideBrackets() {
+            var token = EquationAutoComplete.extractToken("Population[Nor", 14);
+            assertThat(token).isNotNull();
+            assertThat(token.prefix()).isEqualTo("Population[Nor");
+            assertThat(token.start()).isEqualTo(0);
+        }
+
+        @Test
+        void shouldExtractTokenAfterClosingBracket() {
+            var token = EquationAutoComplete.extractToken("Population[North]", 17);
+            assertThat(token).isNotNull();
+            assertThat(token.prefix()).isEqualTo("Population[North]");
+            assertThat(token.start()).isEqualTo(0);
+        }
+
+        @Test
+        void shouldExtractBracketTokenAfterOperator() {
+            var token = EquationAutoComplete.extractToken("A + Population[So", 17);
+            assertThat(token).isNotNull();
+            assertThat(token.prefix()).isEqualTo("Population[So");
+            assertThat(token.start()).isEqualTo(4);
+        }
+
+        @Test
+        void shouldExtractTokenWithOpenBracketOnly() {
+            var token = EquationAutoComplete.extractToken("Population[", 11);
+            assertThat(token).isNotNull();
+            assertThat(token.prefix()).isEqualTo("Population[");
+            assertThat(token.start()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("subscripted suggestions")
+    class SubscriptedSuggestions {
+
+        @Test
+        void shouldIncludeExpandedSubscriptedNames() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .subscript("Region", List.of("North", "South"))
+                    .stock("Population", 100, "Person", List.of("Region"))
+                    .variable("Rate", "0.05", "1/Year")
+                    .build();
+            ModelEditor ed = new ModelEditor();
+            ed.loadFrom(def);
+
+            List<String> names = EquationAutoComplete.getSuggestions(ed, null);
+            assertThat(names).contains("Population[North]", "Population[South]");
+            assertThat(names).contains("Population"); // base name still present
+        }
+
+        @Test
+        void shouldFilterBracketedSuggestions() {
+            List<AutoCompleteSuggestion> all = List.of(
+                    new AutoCompleteSuggestion("Population[North]", "Population[North]",
+                            "Stock", AutoCompleteSuggestion.Kind.STOCK, false),
+                    new AutoCompleteSuggestion("Population[South]", "Population[South]",
+                            "Stock", AutoCompleteSuggestion.Kind.STOCK, false));
+
+            List<AutoCompleteSuggestion> filtered =
+                    EquationAutoComplete.filterRichSuggestions(all, "Population[N");
+            assertThat(filtered).hasSize(1);
+            assertThat(filtered.getFirst().name()).isEqualTo("Population[North]");
         }
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/EquationValidatorTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/EquationValidatorTest.java
@@ -5,6 +5,9 @@ import systems.courant.sd.model.def.FlowDef;
 import systems.courant.sd.model.def.ModelDefinition;
 import systems.courant.sd.model.def.ModelDefinitionBuilder;
 import systems.courant.sd.model.def.StockDef;
+import systems.courant.sd.model.def.SubscriptDef;
+
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -164,6 +167,65 @@ class EquationValidatorTest {
         @DisplayName("empty vs non-empty")
         void emptyVsNonEmpty() {
             assertThat(EquationValidator.levenshtein("", "abc")).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("subscript validation")
+    class SubscriptValidation {
+
+        private ModelEditor subscriptEditor;
+
+        @BeforeEach
+        void setUp() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Subscript Test")
+                    .subscript("Region", List.of("North", "South"))
+                    .stock("Population", 100, "Person", List.of("Region"))
+                    .variable("Rate", "0.05", "1/Year")
+                    .flow("Migration", "Population * Rate", "Year",
+                            null, null, List.of("Region"))
+                    .build();
+            subscriptEditor = new ModelEditor();
+            subscriptEditor.loadFrom(def);
+        }
+
+        @Test
+        @DisplayName("bracket notation for subscripted element is accepted")
+        void bracketNotationAccepted() {
+            EquationValidator.Result result = EquationValidator.validate(
+                    "Population[North] * 0.1", subscriptEditor, "Migration");
+            assertThat(result.valid()).isTrue();
+            assertThat(result.warning()).isNull();
+        }
+
+        @Test
+        @DisplayName("bare subscripted ref from non-subscripted context warns")
+        void bareRefWarns() {
+            EquationValidator.Result result = EquationValidator.validate(
+                    "Population * 0.1", subscriptEditor, "Rate");
+            assertThat(result.valid()).isTrue();
+            assertThat(result.warning()).isNotNull();
+            assertThat(result.warning()).contains("Population");
+            assertThat(result.warning()).contains("subscripted");
+        }
+
+        @Test
+        @DisplayName("bare ref from same-dimension context does not warn")
+        void bareRefSameDimensionNoWarning() {
+            EquationValidator.Result result = EquationValidator.validate(
+                    "Population * Rate", subscriptEditor, "Migration");
+            assertThat(result.valid()).isTrue();
+            assertThat(result.warning()).isNull();
+        }
+
+        @Test
+        @DisplayName("unknown bracket label is rejected")
+        void unknownBracketLabel() {
+            EquationValidator.Result result = EquationValidator.validate(
+                    "Population[Nowhere] * 0.1", subscriptEditor, "Rate");
+            assertThat(result.valid()).isFalse();
+            assertThat(result.message()).contains("Unknown");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Extend equation autocomplete to recognize bracket notation tokens (`Population[Nor` extracts full token)
- Add expanded subscripted names to autocomplete suggestions (e.g., `Population[North]`, `Population[South]`)
- Add validation warning when subscripted elements are referenced bare from non-subscripted context
- Display warnings with orange styling distinct from red errors
- 10 new tests covering bracket extraction, subscripted suggestions, and validation

Closes #1346

## Test plan

- [x] All existing tests pass
- [x] 10 new unit tests for bracket tokens, subscripted suggestions, and validation warnings
- [x] SpotBugs clean
- [x] Full reactor clean compile