### PR TITLE
Add tutorial progress tracking (#881 Phase 2)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/TutorialProgressStore.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/TutorialProgressStore.java
@@ -1,0 +1,128 @@
+package systems.courant.sd.app;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.prefs.Preferences;
+
+/**
+ * Persists tutorial completion and resume state across sessions using
+ * Java Preferences. Mirrors the pattern established by {@link LastDirectoryStore}.
+ *
+ * <p>Completion is stored as a comma-separated set of tutorial IDs.
+ * The resume point records the user's last-viewed tutorial and step index
+ * so the dialog can reopen at the same position.
+ */
+public final class TutorialProgressStore {
+
+    private static final Preferences DEFAULT_PREFS =
+            Preferences.userNodeForPackage(TutorialProgressStore.class);
+
+    private static Preferences prefs = DEFAULT_PREFS;
+
+    private static final String KEY_COMPLETED = "completedTutorials";
+    private static final String KEY_RESUME_TUTORIAL = "resumeTutorialId";
+    private static final String KEY_RESUME_STEP = "resumeStepIndex";
+
+    private TutorialProgressStore() {
+    }
+
+    /**
+     * A snapshot of the user's position within a tutorial.
+     */
+    public record ResumePoint(String tutorialId, int stepIndex) {
+    }
+
+    /**
+     * Marks a tutorial as completed. Duplicate calls are idempotent.
+     */
+    public static void markCompleted(String tutorialId) {
+        Set<String> completed = new LinkedHashSet<>(getCompleted());
+        completed.add(tutorialId);
+        prefs.put(KEY_COMPLETED, String.join(",", completed));
+    }
+
+    /**
+     * Returns whether the given tutorial has been completed.
+     */
+    public static boolean isCompleted(String tutorialId) {
+        return getCompleted().contains(tutorialId);
+    }
+
+    /**
+     * Returns all completed tutorial IDs in the order they were completed.
+     */
+    public static Set<String> getCompleted() {
+        String raw = prefs.get(KEY_COMPLETED, "");
+        if (raw.isEmpty()) {
+            return Set.of();
+        }
+        return Collections.unmodifiableSet(
+                new LinkedHashSet<>(Arrays.asList(raw.split(","))));
+    }
+
+    /**
+     * Counts how many of the given tutorial IDs have been completed.
+     * Callers (e.g., the curriculum browser) pass in a tier's tutorial
+     * IDs to compute tier-level progress.
+     */
+    public static int getCompletedCount(Iterable<String> tutorialIds) {
+        Set<String> completed = getCompleted();
+        int count = 0;
+        for (String id : tutorialIds) {
+            if (completed.contains(id)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Returns the user's last resume point, if any.
+     */
+    public static Optional<ResumePoint> getResumePoint() {
+        String tutorialId = prefs.get(KEY_RESUME_TUTORIAL, "");
+        if (tutorialId.isEmpty()) {
+            return Optional.empty();
+        }
+        int stepIndex = prefs.getInt(KEY_RESUME_STEP, 0);
+        return Optional.of(new ResumePoint(tutorialId, stepIndex));
+    }
+
+    /**
+     * Records the user's current position within a tutorial for later resume.
+     */
+    public static void setResumePoint(String tutorialId, int stepIndex) {
+        prefs.put(KEY_RESUME_TUTORIAL, tutorialId);
+        prefs.putInt(KEY_RESUME_STEP, stepIndex);
+    }
+
+    /**
+     * Clears the resume point (e.g., when a tutorial is completed).
+     */
+    public static void clearResumePoint() {
+        prefs.remove(KEY_RESUME_TUTORIAL);
+        prefs.remove(KEY_RESUME_STEP);
+    }
+
+    /**
+     * Resets all progress — completions and resume point.
+     */
+    public static void resetProgress() {
+        prefs.remove(KEY_COMPLETED);
+        prefs.remove(KEY_RESUME_TUTORIAL);
+        prefs.remove(KEY_RESUME_STEP);
+    }
+
+    /** Replaces the Preferences backing store. Package-private for testing. */
+    static void setPreferences(Preferences testPrefs) {
+        prefs = testPrefs;
+    }
+
+    /** Restores the production Preferences node. Package-private for testing. */
+    static void restoreDefaultPreferences() {
+        prefs = DEFAULT_PREFS;
+    }
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/AbstractTutorialDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/AbstractTutorialDialog.java
@@ -8,12 +8,19 @@ import javafx.scene.control.TabPane;
 import javafx.scene.text.TextFlow;
 import javafx.stage.Stage;
 
+import systems.courant.sd.app.TutorialProgressStore;
+
 import java.util.List;
 
 /**
  * Base class for tabbed tutorial and reference dialogs. Provides the common
- * TabPane scaffolding and a {@link #createTab(String, TextFlow)} helper so
- * subclasses only need to supply tab content.
+ * TabPane scaffolding, a {@link #createTab(String, TextFlow)} helper so
+ * subclasses only need to supply tab content, and progress tracking via
+ * {@link TutorialProgressStore}.
+ *
+ * <p>Subclasses that override {@link #getTutorialId()} participate in
+ * progress tracking: the tutorial is marked complete when the user reaches
+ * the last tab, and the user's position is saved for later resume.
  */
 public abstract class AbstractTutorialDialog extends Stage {
 
@@ -33,8 +40,19 @@ public abstract class AbstractTutorialDialog extends Stage {
         TabPane tabPane = new TabPane();
         tabPane.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
         tabPane.getTabs().addAll(buildTabs());
+        installProgressTracking(tabPane);
 
         setScene(new Scene(tabPane, width, height));
+    }
+
+    /**
+     * Returns the unique tutorial identifier for progress tracking, or
+     * {@code null} if this dialog does not participate in tracking.
+     * Subclasses should override to return a stable, kebab-case ID
+     * (e.g., {@code "first-model"}, {@code "sir-epidemic"}).
+     */
+    protected String getTutorialId() {
+        return null;
     }
 
     /**
@@ -54,5 +72,35 @@ public abstract class AbstractTutorialDialog extends Stage {
         scroll.setFitToWidth(true);
 
         return new Tab(title, scroll);
+    }
+
+    private void installProgressTracking(TabPane tabPane) {
+        String tutorialId = getTutorialId();
+        if (tutorialId == null) {
+            return;
+        }
+
+        int tabCount = tabPane.getTabs().size();
+
+        tabPane.getSelectionModel().selectedIndexProperty().addListener(
+                (obs, oldIdx, newIdx) -> {
+                    int idx = newIdx.intValue();
+                    if (idx == tabCount - 1) {
+                        TutorialProgressStore.markCompleted(tutorialId);
+                        TutorialProgressStore.clearResumePoint();
+                    } else {
+                        TutorialProgressStore.setResumePoint(tutorialId, idx);
+                    }
+                });
+
+        // Resume at the last-viewed step if the user is returning to this tutorial
+        TutorialProgressStore.getResumePoint()
+                .filter(rp -> rp.tutorialId().equals(tutorialId))
+                .ifPresent(rp -> {
+                    int target = Math.min(rp.stepIndex(), tabCount - 1);
+                    if (target > 0) {
+                        tabPane.getSelectionModel().select(target);
+                    }
+                });
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CldTutorialDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/CldTutorialDialog.java
@@ -20,6 +20,11 @@ public class CldTutorialDialog extends AbstractTutorialDialog {
     }
 
     @Override
+    protected String getTutorialId() {
+        return "cld-basics";
+    }
+
+    @Override
     protected List<Tab> buildTabs() {
         return List.of(
                 createTab("1. The Idea", ideaTab()),

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/QuickstartDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/QuickstartDialog.java
@@ -19,6 +19,11 @@ public class QuickstartDialog extends AbstractTutorialDialog {
     }
 
     @Override
+    protected String getTutorialId() {
+        return "first-model";
+    }
+
+    @Override
     protected List<Tab> buildTabs() {
         return List.of(
                 createTab("1. The Idea", ideaTab()),

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SirTutorialDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SirTutorialDialog.java
@@ -19,6 +19,11 @@ public class SirTutorialDialog extends AbstractTutorialDialog {
     }
 
     @Override
+    protected String getTutorialId() {
+        return "sir-epidemic";
+    }
+
+    @Override
     protected List<Tab> buildTabs() {
         return List.of(
                 createTab("1. The Idea", ideaTab()),

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SupplyChainTutorialDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SupplyChainTutorialDialog.java
@@ -19,6 +19,11 @@ public class SupplyChainTutorialDialog extends AbstractTutorialDialog {
     }
 
     @Override
+    protected String getTutorialId() {
+        return "supply-chain";
+    }
+
+    @Override
     protected List<Tab> buildTabs() {
         return List.of(
                 createTab("1. The Idea", ideaTab()),

--- a/courant-app/src/test/java/systems/courant/sd/app/TutorialProgressStoreTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/TutorialProgressStoreTest.java
@@ -1,0 +1,200 @@
+package systems.courant.sd.app;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TutorialProgressStore")
+class TutorialProgressStoreTest {
+
+    private Preferences testPrefs;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        testPrefs = Preferences.userRoot().node("/test/courant/tutorial-progress");
+        testPrefs.clear();
+        TutorialProgressStore.setPreferences(testPrefs);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        testPrefs.removeNode();
+        TutorialProgressStore.restoreDefaultPreferences();
+    }
+
+    @Nested
+    @DisplayName("Completion tracking")
+    class Completion {
+
+        @Test
+        @DisplayName("should return false when tutorial not completed")
+        void shouldReturnFalseWhenNotCompleted() {
+            assertThat(TutorialProgressStore.isCompleted("first-model")).isFalse();
+        }
+
+        @Test
+        @DisplayName("should mark tutorial as completed")
+        void shouldMarkTutorialCompleted() {
+            TutorialProgressStore.markCompleted("first-model");
+
+            assertThat(TutorialProgressStore.isCompleted("first-model")).isTrue();
+        }
+
+        @Test
+        @DisplayName("should track multiple completions independently")
+        void shouldTrackMultipleCompletions() {
+            TutorialProgressStore.markCompleted("first-model");
+            TutorialProgressStore.markCompleted("sir-epidemic");
+
+            assertThat(TutorialProgressStore.isCompleted("first-model")).isTrue();
+            assertThat(TutorialProgressStore.isCompleted("sir-epidemic")).isTrue();
+            assertThat(TutorialProgressStore.isCompleted("supply-chain")).isFalse();
+        }
+
+        @Test
+        @DisplayName("should handle duplicate completions idempotently")
+        void shouldHandleDuplicateCompletions() {
+            TutorialProgressStore.markCompleted("first-model");
+            TutorialProgressStore.markCompleted("first-model");
+
+            Set<String> completed = TutorialProgressStore.getCompleted();
+            assertThat(completed).containsExactly("first-model");
+        }
+
+        @Test
+        @DisplayName("should return all completed tutorial IDs")
+        void shouldReturnAllCompleted() {
+            TutorialProgressStore.markCompleted("first-model");
+            TutorialProgressStore.markCompleted("sir-epidemic");
+            TutorialProgressStore.markCompleted("cld-basics");
+
+            assertThat(TutorialProgressStore.getCompleted())
+                    .containsExactly("first-model", "sir-epidemic", "cld-basics");
+        }
+
+        @Test
+        @DisplayName("should return empty set when nothing completed")
+        void shouldReturnEmptySetWhenNothingCompleted() {
+            assertThat(TutorialProgressStore.getCompleted()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should count completed tutorials from a given set")
+        void shouldReturnCompletedCountForGivenIds() {
+            TutorialProgressStore.markCompleted("first-model");
+            TutorialProgressStore.markCompleted("sir-epidemic");
+
+            List<String> tierTutorials = List.of(
+                    "first-model", "sir-epidemic", "cld-basics", "supply-chain");
+
+            assertThat(TutorialProgressStore.getCompletedCount(tierTutorials))
+                    .isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("should return zero count when none in tier completed")
+        void shouldReturnZeroCountWhenNoneCompleted() {
+            TutorialProgressStore.markCompleted("first-model");
+
+            List<String> otherTier = List.of("sir-epidemic", "cld-basics");
+
+            assertThat(TutorialProgressStore.getCompletedCount(otherTier))
+                    .isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("Resume point")
+    class Resume {
+
+        @Test
+        @DisplayName("should return empty when no resume point set")
+        void shouldReturnEmptyWhenNoResumePoint() {
+            assertThat(TutorialProgressStore.getResumePoint()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should set and get resume point")
+        void shouldSetAndGetResumePoint() {
+            TutorialProgressStore.setResumePoint("sir-epidemic", 3);
+
+            Optional<TutorialProgressStore.ResumePoint> rp =
+                    TutorialProgressStore.getResumePoint();
+
+            assertThat(rp).isPresent();
+            assertThat(rp.get().tutorialId()).isEqualTo("sir-epidemic");
+            assertThat(rp.get().stepIndex()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("should overwrite previous resume point")
+        void shouldOverwritePreviousResumePoint() {
+            TutorialProgressStore.setResumePoint("sir-epidemic", 2);
+            TutorialProgressStore.setResumePoint("supply-chain", 5);
+
+            Optional<TutorialProgressStore.ResumePoint> rp =
+                    TutorialProgressStore.getResumePoint();
+
+            assertThat(rp).isPresent();
+            assertThat(rp.get().tutorialId()).isEqualTo("supply-chain");
+            assertThat(rp.get().stepIndex()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("should clear resume point")
+        void shouldClearResumePoint() {
+            TutorialProgressStore.setResumePoint("sir-epidemic", 3);
+            TutorialProgressStore.clearResumePoint();
+
+            assertThat(TutorialProgressStore.getResumePoint()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should handle resume point at step zero")
+        void shouldHandleResumePointAtStepZero() {
+            TutorialProgressStore.setResumePoint("first-model", 0);
+
+            Optional<TutorialProgressStore.ResumePoint> rp =
+                    TutorialProgressStore.getResumePoint();
+
+            assertThat(rp).isPresent();
+            assertThat(rp.get().stepIndex()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("Reset")
+    class ResetProgress {
+
+        @Test
+        @DisplayName("should clear all completions and resume point")
+        void shouldResetAllProgress() {
+            TutorialProgressStore.markCompleted("first-model");
+            TutorialProgressStore.markCompleted("sir-epidemic");
+            TutorialProgressStore.setResumePoint("supply-chain", 4);
+
+            TutorialProgressStore.resetProgress();
+
+            assertThat(TutorialProgressStore.getCompleted()).isEmpty();
+            assertThat(TutorialProgressStore.getResumePoint()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should be safe to call when already empty")
+        void shouldBeSafeWhenAlreadyEmpty() {
+            TutorialProgressStore.resetProgress();
+
+            assertThat(TutorialProgressStore.getCompleted()).isEmpty();
+            assertThat(TutorialProgressStore.getResumePoint()).isEmpty();
+        }
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/TutorialProgressTrackingFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/TutorialProgressTrackingFxTest.java
@@ -1,0 +1,207 @@
+package systems.courant.sd.app;
+
+import javafx.scene.Scene;
+import javafx.scene.control.TabPane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import systems.courant.sd.app.canvas.dialogs.CldTutorialDialog;
+import systems.courant.sd.app.canvas.dialogs.QuickstartDialog;
+import systems.courant.sd.app.canvas.dialogs.SirTutorialDialog;
+import systems.courant.sd.app.canvas.dialogs.SupplyChainTutorialDialog;
+
+import java.util.prefs.Preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests verifying that tutorial dialogs interact correctly
+ * with {@link TutorialProgressStore} for completion tracking and resume.
+ */
+@DisplayName("Tutorial Progress Tracking (TestFX)")
+@ExtendWith(ApplicationExtension.class)
+class TutorialProgressTrackingFxTest {
+
+    private Preferences testPrefs;
+
+    @Start
+    void start(Stage stage) {
+        stage.setScene(new Scene(new StackPane(), 100, 100));
+        stage.show();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        testPrefs = Preferences.userRoot().node("/test/courant/tutorial-progress-fx");
+        testPrefs.clear();
+        TutorialProgressStore.setPreferences(testPrefs);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        TutorialProgressStore.resetProgress();
+        testPrefs.removeNode();
+        TutorialProgressStore.restoreDefaultPreferences();
+    }
+
+    @Nested
+    @DisplayName("Completion")
+    class Completion {
+
+        @Test
+        @DisplayName("reaching the last tab marks tutorial completed")
+        void shouldMarkCompletedOnLastTab(FxRobot robot) {
+            robot.interact(() -> {
+                SirTutorialDialog dialog = new SirTutorialDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                tabPane.getSelectionModel().selectLast();
+            });
+
+            assertThat(TutorialProgressStore.isCompleted("sir-epidemic")).isTrue();
+        }
+
+        @Test
+        @DisplayName("middle tab does not mark completed")
+        void shouldNotMarkCompletedOnMiddleTab(FxRobot robot) {
+            robot.interact(() -> {
+                SirTutorialDialog dialog = new SirTutorialDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                tabPane.getSelectionModel().select(3);
+            });
+
+            assertThat(TutorialProgressStore.isCompleted("sir-epidemic")).isFalse();
+        }
+
+        @Test
+        @DisplayName("QuickstartDialog completes as 'first-model'")
+        void quickstartCompletesAsFirstModel(FxRobot robot) {
+            robot.interact(() -> {
+                QuickstartDialog dialog = new QuickstartDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                tabPane.getSelectionModel().selectLast();
+            });
+
+            assertThat(TutorialProgressStore.isCompleted("first-model")).isTrue();
+        }
+
+        @Test
+        @DisplayName("SupplyChainTutorialDialog completes as 'supply-chain'")
+        void supplyChainCompletesAsSupplyChain(FxRobot robot) {
+            robot.interact(() -> {
+                SupplyChainTutorialDialog dialog = new SupplyChainTutorialDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                tabPane.getSelectionModel().selectLast();
+            });
+
+            assertThat(TutorialProgressStore.isCompleted("supply-chain")).isTrue();
+        }
+
+        @Test
+        @DisplayName("CldTutorialDialog completes as 'cld-basics'")
+        void cldCompletesAsCldBasics(FxRobot robot) {
+            robot.interact(() -> {
+                CldTutorialDialog dialog = new CldTutorialDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                tabPane.getSelectionModel().selectLast();
+            });
+
+            assertThat(TutorialProgressStore.isCompleted("cld-basics")).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Resume point")
+    class Resume {
+
+        @Test
+        @DisplayName("selecting a middle tab sets resume point")
+        void shouldSetResumePointOnMiddleTab(FxRobot robot) {
+            robot.interact(() -> {
+                SirTutorialDialog dialog = new SirTutorialDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                tabPane.getSelectionModel().select(3);
+            });
+
+            var rp = TutorialProgressStore.getResumePoint();
+            assertThat(rp).isPresent();
+            assertThat(rp.get().tutorialId()).isEqualTo("sir-epidemic");
+            assertThat(rp.get().stepIndex()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("completing a tutorial clears the resume point")
+        void shouldClearResumePointOnCompletion(FxRobot robot) {
+            robot.interact(() -> {
+                SirTutorialDialog dialog = new SirTutorialDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                // Navigate to a middle tab first
+                tabPane.getSelectionModel().select(3);
+            });
+            assertThat(TutorialProgressStore.getResumePoint()).isPresent();
+
+            robot.interact(() -> {
+                SirTutorialDialog dialog = new SirTutorialDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                tabPane.getSelectionModel().selectLast();
+            });
+
+            assertThat(TutorialProgressStore.getResumePoint()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("dialog resumes at the saved step")
+        void shouldResumeAtSavedStep(FxRobot robot) {
+            TutorialProgressStore.setResumePoint("sir-epidemic", 4);
+
+            int[] selectedIndex = {-1};
+            robot.interact(() -> {
+                SirTutorialDialog dialog = new SirTutorialDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                selectedIndex[0] = tabPane.getSelectionModel().getSelectedIndex();
+            });
+
+            assertThat(selectedIndex[0]).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("resume point for different tutorial is ignored")
+        void shouldIgnoreResumePointForDifferentTutorial(FxRobot robot) {
+            TutorialProgressStore.setResumePoint("supply-chain", 3);
+
+            int[] selectedIndex = {-1};
+            robot.interact(() -> {
+                SirTutorialDialog dialog = new SirTutorialDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                selectedIndex[0] = tabPane.getSelectionModel().getSelectedIndex();
+            });
+
+            assertThat(selectedIndex[0]).isZero();
+        }
+
+        @Test
+        @DisplayName("resume point beyond tab count is clamped")
+        void shouldClampResumePointBeyondTabCount(FxRobot robot) {
+            TutorialProgressStore.setResumePoint("sir-epidemic", 99);
+
+            int[] selectedIndex = {-1};
+            robot.interact(() -> {
+                SirTutorialDialog dialog = new SirTutorialDialog();
+                TabPane tabPane = (TabPane) dialog.getScene().getRoot();
+                selectedIndex[0] = tabPane.getSelectionModel().getSelectedIndex();
+            });
+
+            // SIR has 7 tabs (0-6), so clamped to 6 (the last tab)
+            assertThat(selectedIndex[0]).isEqualTo(6);
+        }
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/TutorialDialogFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/TutorialDialogFxTest.java
@@ -19,12 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(ApplicationExtension.class)
 class TutorialDialogFxTest {
 
+    private QuickstartDialog quickstartDialog;
     private SirTutorialDialog sirDialog;
     private SupplyChainTutorialDialog supplyChainDialog;
     private CldTutorialDialog cldDialog;
 
     @Start
     void start(Stage stage) {
+        quickstartDialog = new QuickstartDialog();
         sirDialog = new SirTutorialDialog();
         supplyChainDialog = new SupplyChainTutorialDialog();
         cldDialog = new CldTutorialDialog();
@@ -119,8 +121,25 @@ class TutorialDialogFxTest {
     }
 
     @Test
+    @DisplayName("Quickstart tutorial has 6 tabs")
+    void quickstartDialogHasSixTabs(FxRobot robot) {
+        TabPane tabs = (TabPane) quickstartDialog.getScene().getRoot();
+        assertThat(tabs.getTabs()).hasSize(6);
+    }
+
+    @Test
+    @DisplayName("Quickstart tutorial has correct window title")
+    void quickstartDialogTitle(FxRobot robot) {
+        assertThat(quickstartDialog.getTitle()).contains("Getting Started");
+    }
+
+    @Test
     @DisplayName("Tabs are not closeable")
     void tabsNotCloseable(FxRobot robot) {
+        TabPane qsTabs = (TabPane) quickstartDialog.getScene().getRoot();
+        assertThat(qsTabs.getTabClosingPolicy())
+                .isEqualTo(TabPane.TabClosingPolicy.UNAVAILABLE);
+
         TabPane sirTabs = (TabPane) sirDialog.getScene().getRoot();
         assertThat(sirTabs.getTabClosingPolicy())
                 .isEqualTo(TabPane.TabClosingPolicy.UNAVAILABLE);
@@ -132,5 +151,14 @@ class TutorialDialogFxTest {
         TabPane cldTabs = (TabPane) cldDialog.getScene().getRoot();
         assertThat(cldTabs.getTabClosingPolicy())
                 .isEqualTo(TabPane.TabClosingPolicy.UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("All tutorial dialogs provide a tutorial ID for progress tracking")
+    void allDialogsProvideTutorialId(FxRobot robot) {
+        assertThat(quickstartDialog.getTutorialId()).isEqualTo("first-model");
+        assertThat(sirDialog.getTutorialId()).isEqualTo("sir-epidemic");
+        assertThat(supplyChainDialog.getTutorialId()).isEqualTo("supply-chain");
+        assertThat(cldDialog.getTutorialId()).isEqualTo("cld-basics");
     }
 }


### PR DESCRIPTION
## Summary
- Add `TutorialProgressStore` for persisting completion and resume state via `java.util.prefs.Preferences`
- Wire progress tracking into `AbstractTutorialDialog` — last tab marks complete, mid-tutorial position saved for resume
- All four tutorial dialogs (`QuickstartDialog`, `SirTutorialDialog`, `SupplyChainTutorialDialog`, `CldTutorialDialog`) participate in tracking

## Test plan
- 14 unit tests for `TutorialProgressStore` (completion, resume, reset, edge cases)
- 8 TestFX integration tests for dialog-level progress tracking (completion on last tab, resume at saved step, cross-tutorial isolation, clamping)
- Structural tests for tutorial IDs added to existing `TutorialDialogFxTest`