### PR TITLE
Auto-fill unit from equation when blank

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/DimensionalAnalysisUI.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/DimensionalAnalysisUI.java
@@ -1,11 +1,19 @@
 package systems.courant.sd.app.canvas.forms;
 
 import systems.courant.sd.measure.CompositeUnit;
+import systems.courant.sd.measure.Dimension;
 import systems.courant.sd.measure.DimensionalAnalyzer;
+import systems.courant.sd.measure.TimeUnit;
 import systems.courant.sd.measure.UnitRegistry;
 import systems.courant.sd.model.expr.Expr;
 import systems.courant.sd.model.expr.ExprParser;
 import systems.courant.sd.model.expr.ParseException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
 
 import javafx.animation.PauseTransition;
 import javafx.scene.control.Label;
@@ -273,6 +281,178 @@ public class DimensionalAnalysisUI {
         }
 
         return null;
+    }
+
+    /**
+     * Infers the unit from the current equation text using dimensional analysis.
+     * Returns the inferred {@link CompositeUnit}, or null if the equation is empty,
+     * unparseable, or yields no dimensional information.
+     */
+    public CompositeUnit inferUnit(String equationText) {
+        if (equationText == null || equationText.isBlank()) {
+            return null;
+        }
+        try {
+            Expr expr = ExprParser.parse(equationText);
+            if (isPureConstant(expr)) {
+                return null;
+            }
+            EditorUnitContext unitContext = new EditorUnitContext(ctx.getEditor(), unitRegistry);
+            DimensionalAnalyzer analyzer = new DimensionalAnalyzer(unitContext);
+            DimensionalAnalyzer.AnalysisResult result = analyzer.analyze(expr);
+            if (result.inferredUnit() == null || !result.isConsistent()) {
+                return null;
+            }
+            return result.inferredUnit();
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Infers the material unit for a flow by dividing the equation's inferred unit
+     * by the flow's time unit. Returns a display string using the original declared
+     * unit names from referenced elements, or null if inference fails.
+     *
+     * @param equationText the flow equation
+     * @param timeUnitName the flow's declared time unit (e.g. "Day")
+     */
+    public String inferFlowMaterialUnit(String equationText, String timeUnitName) {
+        CompositeUnit inferred = inferUnit(equationText);
+        if (inferred == null || inferred.isDimensionless()) {
+            return null;
+        }
+        if (timeUnitName == null || timeUnitName.isBlank()) {
+            return null;
+        }
+        try {
+            TimeUnit timeUnit = unitRegistry.resolveTimeUnit(timeUnitName);
+            CompositeUnit timeComposite = CompositeUnit.of(timeUnit);
+            CompositeUnit material = inferred.multiply(timeComposite);
+            if (material.isDimensionless()) {
+                return null;
+            }
+            Expr expr = ExprParser.parse(equationText);
+            Map<Dimension, String> dimNames = buildDimensionNameMap(expr);
+            return renderWithOriginalNames(material, dimNames);
+        } catch (ParseException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Infers the unit for a variable from its equation. Returns a display string
+     * using the original declared unit names from referenced elements, or null if
+     * inference fails or the result is dimensionless.
+     */
+    public String inferVariableUnit(String equationText) {
+        CompositeUnit inferred = inferUnit(equationText);
+        if (inferred == null || inferred.isDimensionless()) {
+            return null;
+        }
+        try {
+            Expr expr = ExprParser.parse(equationText);
+            Map<Dimension, String> dimNames = buildDimensionNameMap(expr);
+            return renderWithOriginalNames(inferred, dimNames);
+        } catch (ParseException e) {
+            return inferred.displayString();
+        }
+    }
+
+    /**
+     * Walks the expression AST collecting element references, then maps each
+     * referenced element's declared unit dimension to its raw unit name.
+     */
+    private Map<Dimension, String> buildDimensionNameMap(Expr expr) {
+        List<String> refs = new ArrayList<>();
+        collectRefs(expr, refs);
+        Map<Dimension, String> map = new LinkedHashMap<>();
+        for (String ref : refs) {
+            String rawUnit = getRawUnitForElement(ref);
+            if (rawUnit != null && !rawUnit.isBlank()) {
+                CompositeUnit resolved = unitRegistry.resolveComposite(rawUnit);
+                for (Dimension dim : resolved.exponents().keySet()) {
+                    map.putIfAbsent(dim, rawUnit);
+                }
+            }
+        }
+        return map;
+    }
+
+    private void collectRefs(Expr expr, List<String> refs) {
+        if (expr instanceof Expr.Ref r) {
+            refs.add(r.name());
+        } else if (expr instanceof Expr.BinaryOp op) {
+            collectRefs(op.left(), refs);
+            collectRefs(op.right(), refs);
+        } else if (expr instanceof Expr.UnaryOp op) {
+            collectRefs(op.operand(), refs);
+        } else if (expr instanceof Expr.FunctionCall fc) {
+            fc.arguments().forEach(a -> collectRefs(a, refs));
+        } else if (expr instanceof Expr.Conditional c) {
+            collectRefs(c.condition(), refs);
+            collectRefs(c.thenExpr(), refs);
+            collectRefs(c.elseExpr(), refs);
+        }
+    }
+
+    /**
+     * Returns the raw declared unit string for an element, or null if unknown.
+     */
+    private String getRawUnitForElement(String name) {
+        String resolved = name.replace('_', ' ');
+        var stockOpt = ctx.getEditor().getStockByName(name);
+        if (stockOpt.isEmpty()) {
+            stockOpt = ctx.getEditor().getStockByName(resolved);
+        }
+        if (stockOpt.isPresent()) {
+            return stockOpt.get().unit();
+        }
+        var varOpt = ctx.getEditor().getVariableByName(name);
+        if (varOpt.isEmpty()) {
+            varOpt = ctx.getEditor().getVariableByName(resolved);
+        }
+        if (varOpt.isPresent()) {
+            return varOpt.get().unit();
+        }
+        var flowOpt = ctx.getEditor().getFlowByName(name);
+        if (flowOpt.isEmpty()) {
+            flowOpt = ctx.getEditor().getFlowByName(resolved);
+        }
+        if (flowOpt.isPresent()) {
+            return flowOpt.get().materialUnit();
+        }
+        return null;
+    }
+
+    /**
+     * Renders a CompositeUnit using raw unit names from the dimension map where available,
+     * falling back to the dimension's base unit name.
+     */
+    private String renderWithOriginalNames(CompositeUnit unit, Map<Dimension, String> dimNames) {
+        if (unit.isDimensionless()) {
+            return "Dimensionless";
+        }
+        StringJoiner numerator = new StringJoiner(" * ");
+        StringJoiner denominator = new StringJoiner(" * ");
+
+        for (Map.Entry<Dimension, Integer> e : unit.exponents().entrySet()) {
+            String name = dimNames.getOrDefault(e.getKey(), e.getKey().getBaseUnit().getName());
+            int exp = e.getValue();
+            if (exp > 0) {
+                numerator.add(exp == 1 ? name : name + "^" + exp);
+            } else {
+                int absExp = -exp;
+                denominator.add(absExp == 1 ? name : name + "^" + absExp);
+            }
+        }
+        if (numerator.length() == 0) {
+            numerator.add("1");
+        }
+        if (denominator.length() == 0) {
+            return numerator.toString();
+        }
+        return numerator + " / " + denominator;
     }
 
     private void clearEquationError(EquationField field, Label errorLabel) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FlowForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FlowForm.java
@@ -129,6 +129,24 @@ public class FlowForm implements ElementForm {
             return;
         }
         ctx.getCanvas().applyMutation(() -> ctx.getEditor().setFlowEquation(ctx.getElementName(), equation));
+        autoFillMaterialUnitIfBlank(equation);
+    }
+
+    private void autoFillMaterialUnitIfBlank(String equation) {
+        Optional<FlowDef> flowOpt = ctx.getEditor().getFlowByName(ctx.getElementName());
+        if (flowOpt.isEmpty()) {
+            return;
+        }
+        FlowDef flow = flowOpt.get();
+        if (flow.materialUnit() != null && !flow.materialUnit().isBlank()) {
+            return;
+        }
+        String inferred = dimAnalysis.inferFlowMaterialUnit(equation, flow.timeUnit());
+        if (inferred != null) {
+            ctx.getCanvas().applyMutation(
+                    () -> ctx.getEditor().setFlowMaterialUnit(ctx.getElementName(), inferred));
+            materialUnitBox.setValue(inferred);
+        }
     }
 
     private void commitMaterialUnit(ComboBox<String> box) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/VariableForm.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/VariableForm.java
@@ -108,6 +108,24 @@ public class VariableForm implements ElementForm {
             return;
         }
         ctx.getCanvas().applyMutation(() -> ctx.getEditor().setVariableEquation(ctx.getElementName(), equation));
+        autoFillUnitIfBlank(equation);
+    }
+
+    private void autoFillUnitIfBlank(String equation) {
+        Optional<VariableDef> varOpt = ctx.getEditor().getVariableByName(ctx.getElementName());
+        if (varOpt.isEmpty()) {
+            return;
+        }
+        String currentUnit = varOpt.get().unit();
+        if (currentUnit != null && !currentUnit.isBlank()) {
+            return;
+        }
+        String inferred = dimAnalysis.inferVariableUnit(equation);
+        if (inferred != null) {
+            ctx.getCanvas().applyMutation(
+                    () -> ctx.getEditor().setVariableUnit(ctx.getElementName(), inferred));
+            unitBox.setValue(inferred);
+        }
     }
 
     private void commitSubscripts(List<String> subscripts) {

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/forms/UnitAutoFillTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/forms/UnitAutoFillTest.java
@@ -1,0 +1,209 @@
+package systems.courant.sd.app.canvas.forms;
+
+import systems.courant.sd.measure.CompositeUnit;
+import systems.courant.sd.measure.DimensionalAnalyzer;
+import systems.courant.sd.measure.UnitRegistry;
+import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.ModelDefinitionBuilder;
+import systems.courant.sd.model.expr.ExprParser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Unit auto-fill from equation inference (#1317)")
+class UnitAutoFillTest {
+
+    private UnitRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new UnitRegistry();
+    }
+
+    @Nested
+    @DisplayName("Dimensional analysis inference")
+    class DimensionalInference {
+
+        @Test
+        @DisplayName("should infer non-dimensionless unit from typed stock reference")
+        void shouldInferFromStock() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Population", 100, "Person")
+                    .constant("Birth Rate", 0.03, "Dimensionless")
+                    .build();
+
+            var result = analyze(def, "Population * Birth_Rate");
+
+            assertThat(result.inferredUnit()).isNotNull();
+            assertThat(result.isConsistent()).isTrue();
+            assertThat(result.inferredUnit().isDimensionless()).isFalse();
+        }
+
+        @Test
+        @DisplayName("should return dimensionless for pure constant")
+        void shouldReturnDimensionlessForConstant() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .build();
+
+            var result = analyze(def, "42");
+
+            assertThat(result.inferredUnit()).isNotNull();
+            assertThat(result.inferredUnit().isDimensionless()).isTrue();
+        }
+
+        @Test
+        @DisplayName("should infer compound unit from division")
+        void shouldInferCompound() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Population", 1000, "Person")
+                    .stock("Area", 50, "Kilometer")
+                    .build();
+
+            var result = analyze(def, "Population / Area");
+
+            assertThat(result.inferredUnit()).isNotNull();
+            assertThat(result.isConsistent()).isTrue();
+            assertThat(result.inferredUnit().isDimensionless()).isFalse();
+        }
+
+        @Test
+        @DisplayName("should report inconsistency for mismatched addition")
+        void shouldReportInconsistentAddition() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Population", 100, "Person")
+                    .stock("Money", 500, "USD")
+                    .build();
+
+            var result = analyze(def, "Population + Money");
+
+            assertThat(result.isConsistent()).isFalse();
+        }
+
+        @Test
+        @DisplayName("should infer from nested expressions")
+        void shouldInferFromNested() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Population", 100, "Person")
+                    .constant("Rate", 0.05, "Dimensionless")
+                    .constant("Factor", 2, "Dimensionless")
+                    .build();
+
+            var result = analyze(def, "(Population * Rate) * Factor");
+
+            assertThat(result.inferredUnit()).isNotNull();
+            assertThat(result.isConsistent()).isTrue();
+            assertThat(result.inferredUnit().isDimensionless()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Flow material unit extraction")
+    class FlowMaterial {
+
+        @Test
+        @DisplayName("multiplying rate by time cancels the time dimension")
+        void shouldRecoverMaterial() {
+            var timeUnit = registry.resolveTimeUnit("Day");
+            var personUnit = registry.resolve("Person");
+            CompositeUnit rate = CompositeUnit.ofRate(personUnit, timeUnit);
+
+            CompositeUnit material = rate.multiply(CompositeUnit.of(timeUnit));
+
+            assertThat(material.isDimensionless()).isFalse();
+            // The dimension is ITEM^1, which is correct
+            assertThat(material.exponents()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("dimensionless rate times time yields just time (not useful)")
+        void shouldNotProduceMaterialFromDimensionless() {
+            CompositeUnit dimensionless = CompositeUnit.dimensionless();
+            var timeUnit = registry.resolveTimeUnit("Day");
+
+            CompositeUnit result = dimensionless.multiply(CompositeUnit.of(timeUnit));
+
+            // Dimensionless * Day = TIME^1 — not a useful material unit
+            assertThat(result.isDimensionless()).isFalse();
+        }
+
+        @Test
+        @DisplayName("compound rate correctly cancels time")
+        void shouldHandleCompoundRate() {
+            var timeUnit = registry.resolveTimeUnit("Year");
+            var usdUnit = registry.resolve("USD");
+            CompositeUnit rate = CompositeUnit.ofRate(usdUnit, timeUnit);
+
+            CompositeUnit material = rate.multiply(CompositeUnit.of(timeUnit));
+
+            assertThat(material.isDimensionless()).isFalse();
+            assertThat(material.exponents()).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("should handle TIME function in equation")
+        void shouldHandleTimeFunction() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Population", 100, "Person")
+                    .build();
+
+            var result = analyze(def, "Population * TIME");
+
+            assertThat(result.inferredUnit()).isNotNull();
+            assertThat(result.inferredUnit().isDimensionless()).isFalse();
+        }
+
+        @Test
+        @DisplayName("should handle unknown references gracefully")
+        void shouldHandleUnknownReferences() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .constant("X", 1, "")
+                    .build();
+
+            var result = analyze(def, "Unknown_Var * 2");
+
+            assertThat(result.inferredUnit()).isNotNull();
+        }
+    }
+
+    private DimensionalAnalyzer.AnalysisResult analyze(ModelDefinition def, String equation) {
+        DimensionalAnalyzer.UnitContext context = elementName -> {
+            String resolved = elementName.replace('_', ' ');
+            for (var stock : def.stocks()) {
+                if (stock.name().equals(elementName) || stock.name().equals(resolved)) {
+                    if (stock.unit() != null && !stock.unit().isBlank()) {
+                        return Optional.of(registry.resolveComposite(stock.unit()));
+                    }
+                    return Optional.of(CompositeUnit.dimensionless());
+                }
+            }
+            for (var v : def.variables()) {
+                if (v.name().equals(elementName) || v.name().equals(resolved)) {
+                    if (v.unit() != null && !v.unit().isBlank()) {
+                        return Optional.of(registry.resolveComposite(v.unit()));
+                    }
+                    return Optional.of(CompositeUnit.dimensionless());
+                }
+            }
+            return Optional.empty();
+        };
+        return new DimensionalAnalyzer(context).analyze(ExprParser.parse(equation));
+    }
+}


### PR DESCRIPTION
## Summary
- When an equation is committed on a variable or flow and the unit field is blank, dimensional analysis infers the unit and auto-fills it
- For variables: infers the full unit (e.g. "Person", "Person / Kilometer")
- For flows: infers the material unit by cancelling the time dimension from the rate
- Recovers original declared unit names from referenced elements by walking the expression AST, avoiding generic dimension names like "Thing"
- Non-blank unit mismatches continue to show the existing dimensional analysis warning — no silent overwrite

Closes #1317

## Test plan
- [x] Full test suite passes (1945 tests, 0 failures)
- [x] SpotBugs clean
- [x] UnitAutoFillTest covers: stock reference inference, pure constant, compound units, rate extraction, TIME function, unknown references, mismatched addition, nested expressions