### PR TITLE
Add canvas subscript badges and sidebar grouping for arrayed elements

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ChartUtils.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ChartUtils.java
@@ -160,4 +160,20 @@ public final class ChartUtils {
         }
         return String.format(Locale.US, "%.4f", value);
     }
+
+    /**
+     * Extracts the base element name from a possibly bracketed subscript name.
+     * Returns "Population" for "Population[North]", or the input unchanged if no brackets.
+     */
+    public static String baseElementName(String columnName) {
+        int bracket = columnName.indexOf('[');
+        return bracket >= 0 ? columnName.substring(0, bracket) : columnName;
+    }
+
+    /**
+     * Returns true if the column name contains a subscript bracket suffix.
+     */
+    public static boolean isSubscriptedColumn(String columnName) {
+        return columnName.indexOf('[') >= 0;
+    }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ColorPalette.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ColorPalette.java
@@ -74,6 +74,9 @@ public final class ColorPalette {
     // Delay indicator badge
     public static final Color DELAY_BADGE = Color.web("#8E44AD");
 
+    /** Teal accent for subscript dimension badge on arrayed elements. */
+    public static final Color SUBSCRIPT_BADGE = Color.web("#2980B9");
+
     // Maturity indicators (#89)
     /** Amber accent stripe on elements missing equations. */
     public static final Color MATURITY_ACCENT = Color.web("#F39C12", 0.8);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
@@ -773,6 +773,7 @@ public class ModelEditor {
     public Optional<String> getFlowEquation(String name) { return queryFacade.getFlowEquation(name); }
     public Optional<String> getVariableEquation(String name) { return queryFacade.getVariableEquation(name); }
     public int getModuleIndex(String name) { return queryFacade.getModuleIndex(name); }
+    public List<String> getElementSubscripts(String name) { return queryFacade.getElementSubscripts(name); }
     public ModelDefinition toModelDefinition() { return toModelDefinition(null); }
     public ModelDefinition toModelDefinition(ViewDef view) { return queryFacade.toModelDefinition(view); }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelQueryFacade.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelQueryFacade.java
@@ -121,6 +121,26 @@ final class ModelQueryFacade {
         return null;
     }
 
+    /**
+     * Returns the subscript dimension names for the given element, or an empty list
+     * if the element is scalar or not found.
+     */
+    List<String> getElementSubscripts(String name) {
+        Optional<StockDef> stock = getStockByName(name);
+        if (stock.isPresent()) {
+            return stock.get().subscripts();
+        }
+        Optional<FlowDef> flow = getFlowByName(name);
+        if (flow.isPresent()) {
+            return flow.get().subscripts();
+        }
+        Optional<VariableDef> variable = getVariableByName(name);
+        if (variable.isPresent()) {
+            return variable.get().subscripts();
+        }
+        return List.of();
+    }
+
     // === Derived queries ===
 
     boolean hasElement(String name) { return nameIndex.contains(name); }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SimulationResultPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/charts/SimulationResultPane.java
@@ -466,24 +466,14 @@ public class SimulationResultPane extends BorderPane {
                 && currentSeries.stream().anyMatch(s -> !stockNames.contains(s.getName()));
         if (hasGrouping) {
             addSectionHeader(sidebar, "Stocks");
-            for (int i = 0; i < currentSeries.size(); i++) {
-                if (isStock.get(i)) {
-                    addSeriesRow(sidebar, currentSeries.get(i), i,
-                            behaviorModes.get(i), seriesCheckBoxes, rescaleYAxis);
-                }
-            }
+            addGroupedSeriesRows(sidebar, currentSeries, behaviorModes, isStock,
+                    true, seriesCheckBoxes, rescaleYAxis);
             addSectionHeader(sidebar, "Variables");
-            for (int i = 0; i < currentSeries.size(); i++) {
-                if (!isStock.get(i)) {
-                    addSeriesRow(sidebar, currentSeries.get(i), i,
-                            behaviorModes.get(i), seriesCheckBoxes, rescaleYAxis);
-                }
-            }
+            addGroupedSeriesRows(sidebar, currentSeries, behaviorModes, isStock,
+                    false, seriesCheckBoxes, rescaleYAxis);
         } else {
-            for (int i = 0; i < currentSeries.size(); i++) {
-                addSeriesRow(sidebar, currentSeries.get(i), i,
-                        behaviorModes.get(i), seriesCheckBoxes, rescaleYAxis);
-            }
+            addGroupedSeriesRows(sidebar, currentSeries, behaviorModes, null,
+                    true, seriesCheckBoxes, rescaleYAxis);
         }
 
         if (!netFlowSeries.isEmpty()) {
@@ -683,6 +673,66 @@ public class SimulationResultPane extends BorderPane {
     public DoubleProperty cursorTimeStepProperty() {
         return timeCursor != null ? timeCursor.cursorTimeStepProperty()
                 : new SimpleDoubleProperty(Double.NaN);
+    }
+
+    /**
+     * Adds series rows to the sidebar, grouping subscripted elements under their
+     * base name with a master toggle checkbox. Scalar series are ungrouped.
+     *
+     * @param filterStock  if non-null, only include series where isStock matches this value;
+     *                     if null, include all series
+     * @param matchStock   the value to match against (true = stocks, false = variables)
+     */
+    private void addGroupedSeriesRows(
+            VBox sidebar, List<XYChart.Series<Number, Number>> currentSeries,
+            List<String> behaviorModes, List<Boolean> isStock,
+            boolean matchStock, List<CheckBox> seriesCheckBoxes, Runnable rescaleYAxis) {
+        // Build ordered groups: baseName → list of series indices
+        java.util.LinkedHashMap<String, List<Integer>> groups = new java.util.LinkedHashMap<>();
+        for (int i = 0; i < currentSeries.size(); i++) {
+            if (isStock != null && isStock.get(i) != matchStock) {
+                continue;
+            }
+            String baseName = ChartUtils.baseElementName(currentSeries.get(i).getName());
+            groups.computeIfAbsent(baseName, k -> new ArrayList<>()).add(i);
+        }
+        for (var entry : groups.entrySet()) {
+            List<Integer> indices = entry.getValue();
+            if (indices.size() > 1) {
+                // Group header with master toggle
+                addArrayGroupHeader(sidebar, entry.getKey(), indices,
+                        seriesCheckBoxes, rescaleYAxis);
+                for (int idx : indices) {
+                    addSeriesRow(sidebar, currentSeries.get(idx), idx,
+                            behaviorModes.get(idx), seriesCheckBoxes, rescaleYAxis);
+                }
+            } else {
+                addSeriesRow(sidebar, currentSeries.get(indices.getFirst()), indices.getFirst(),
+                        behaviorModes.get(indices.getFirst()), seriesCheckBoxes, rescaleYAxis);
+            }
+        }
+    }
+
+    private void addArrayGroupHeader(VBox sidebar, String baseName,
+                                      List<Integer> seriesIndices,
+                                      List<CheckBox> seriesCheckBoxes,
+                                      Runnable rescaleYAxis) {
+        CheckBox groupCb = new CheckBox();
+        groupCb.setSelected(true);
+        groupCb.selectedProperty().addListener((obs, wasSelected, isSelected) -> {
+            for (int idx : seriesIndices) {
+                if (idx < seriesCheckBoxes.size()) {
+                    seriesCheckBoxes.get(idx).setSelected(isSelected);
+                }
+            }
+        });
+
+        Label groupLabel = new Label(baseName);
+        groupLabel.setStyle(Styles.FIELD_LABEL + " -fx-text-fill: #444;");
+
+        HBox row = new HBox(4, groupCb, groupLabel);
+        row.setAlignment(Pos.CENTER_LEFT);
+        sidebar.getChildren().add(row);
     }
 
     private void addSectionHeader(VBox sidebar, String title) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/AuxRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/AuxRenderer.java
@@ -8,6 +8,8 @@ import systems.courant.sd.app.canvas.ModelEditor;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.expr.DelayDetector;
 
+import java.util.List;
+
 /**
  * Renders auxiliary/constant elements: rounded rectangle with badge, name, and
  * optional delay indicator.
@@ -24,7 +26,8 @@ final class AuxRenderer implements ElementTypeRenderer {
         String equation = editor.getVariableEquation(name).orElse(null);
         boolean hasDelay = showDelay
                 && DelayDetector.equationContainsDelay(equation);
-        ElementRenderer.drawAux(gc, name, isLiteral, equation, hasDelay,
+        List<String> subscripts = editor.getElementSubscripts(name);
+        ElementRenderer.drawAux(gc, name, isLiteral, equation, hasDelay, subscripts,
                 cx - w / 2, cy - h / 2, w, h);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
@@ -27,14 +27,44 @@ public final class ElementRenderer {
     public static final String BADGE_MODULE = "Module";
     /** Badge label for elements containing delay functions. */
     public static final String BADGE_DELAY = "D";
+    /** Badge prefix for subscript dimension indicators. */
+    public static final String BADGE_SUBSCRIPT_PREFIX = "\u2193";
 
     private ElementRenderer() {
     }
 
     /**
-     * Draws a stock: heavy rounded rectangle with centered name and unit badge.
+     * Draws a subscript dimension badge at the bottom-right of an element.
+     * Shows dimension names joined by " x " (e.g., "Region" or "Region x Age").
+     * Does nothing if the subscript list is empty.
+     */
+    public static void drawSubscriptBadge(GraphicsContext gc, List<String> subscripts,
+                                           double x, double y, double width, double height) {
+        if (subscripts == null || subscripts.isEmpty()) {
+            return;
+        }
+        String label = String.join(" \u00d7 ", subscripts);
+        gc.setFill(ColorPalette.SUBSCRIPT_BADGE);
+        gc.setFont(LayoutMetrics.BADGE_FONT);
+        gc.setTextAlign(TextAlignment.RIGHT);
+        gc.setTextBaseline(VPos.BOTTOM);
+        gc.fillText(label, x + width - 4, y + height - 3);
+    }
+
+    /**
+     * Draws a stock (scalar, no subscript badge).
      */
     public static void drawStock(GraphicsContext gc, String name, String unit,
+                                 double x, double y, double width, double height) {
+        drawStock(gc, name, unit, List.of(), x, y, width, height);
+    }
+
+    /**
+     * Draws a stock: heavy rounded rectangle with centered name, unit badge,
+     * and optional subscript badge.
+     */
+    public static void drawStock(GraphicsContext gc, String name, String unit,
+                                 List<String> subscripts,
                                  double x, double y, double width, double height) {
         double r = LayoutMetrics.STOCK_CORNER_RADIUS;
 
@@ -64,6 +94,9 @@ public final class ElementRenderer {
             gc.setTextBaseline(VPos.BOTTOM);
             gc.fillText("[" + unit + "]", x + width / 2, y + height - 3);
         }
+
+        // Subscript badge bottom-right
+        drawSubscriptBadge(gc, subscripts, x, y, width, height);
     }
 
     /**
@@ -75,6 +108,12 @@ public final class ElementRenderer {
      * @param height   bounding box height
      */
     public static void drawFlow(GraphicsContext gc, String name, boolean hasDelay,
+                                double x, double y, double width, double height) {
+        drawFlow(gc, name, hasDelay, List.of(), x, y, width, height);
+    }
+
+    public static void drawFlow(GraphicsContext gc, String name, boolean hasDelay,
+                                List<String> subscripts,
                                 double x, double y, double width, double height) {
         double cx = x + width / 2;
         double cy = y + height / 2;
@@ -107,6 +146,17 @@ public final class ElementRenderer {
             gc.setTextBaseline(VPos.BOTTOM);
             gc.fillText(BADGE_DELAY, cx + half + 2, cy - half + 4);
         }
+
+        // Subscript badge right of name
+        if (subscripts != null && !subscripts.isEmpty()) {
+            String label = String.join(" \u00d7 ", subscripts);
+            gc.setFill(ColorPalette.SUBSCRIPT_BADGE);
+            gc.setFont(LayoutMetrics.BADGE_FONT);
+            gc.setTextAlign(TextAlignment.CENTER);
+            gc.setTextBaseline(VPos.TOP);
+            double nameY = cy + half + LayoutMetrics.FLOW_NAME_GAP;
+            gc.fillText(label, cx, nameY + 12);
+        }
     }
 
     /**
@@ -121,7 +171,13 @@ public final class ElementRenderer {
     public static void drawAux(GraphicsContext gc, String name, boolean isLiteral, String equation,
                                boolean hasDelay,
                                double x, double y, double width, double height) {
-        drawAux(gc, name, isLiteral, equation, hasDelay, x, y, width, height, false);
+        drawAux(gc, name, isLiteral, equation, hasDelay, List.of(), x, y, width, height, false);
+    }
+
+    public static void drawAux(GraphicsContext gc, String name, boolean isLiteral, String equation,
+                               boolean hasDelay, List<String> subscripts,
+                               double x, double y, double width, double height) {
+        drawAux(gc, name, isLiteral, equation, hasDelay, subscripts, x, y, width, height, false);
     }
 
     /**
@@ -129,7 +185,8 @@ public final class ElementRenderer {
      * When hovered, uses a stronger fill to provide visual feedback.
      */
     public static void drawAux(GraphicsContext gc, String name, boolean isLiteral, String equation,
-                               boolean hasDelay, double x, double y, double width, double height,
+                               boolean hasDelay, List<String> subscripts,
+                               double x, double y, double width, double height,
                                boolean hovered) {
         double r = LayoutMetrics.AUX_CORNER_RADIUS;
 
@@ -168,6 +225,9 @@ public final class ElementRenderer {
             gc.setTextBaseline(VPos.TOP);
             gc.fillText(BADGE_DELAY, x + width - 5, y + 3);
         }
+
+        // Subscript badge bottom-right
+        drawSubscriptBadge(gc, subscripts, x, y, width, height);
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/FlowRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/FlowRenderer.java
@@ -7,6 +7,8 @@ import systems.courant.sd.app.canvas.LayoutMetrics;
 import systems.courant.sd.app.canvas.ModelEditor;
 import systems.courant.sd.model.expr.DelayDetector;
 
+import java.util.List;
+
 /**
  * Renders flow elements: diamond indicator with name label and optional delay badge.
  */
@@ -18,8 +20,9 @@ final class FlowRenderer implements ElementTypeRenderer {
         boolean hasDelay = showDelay
                 && editor.getFlowEquation(name)
                         .map(DelayDetector::equationContainsDelay).orElse(false);
+        List<String> subscripts = editor.getElementSubscripts(name);
         double size = LayoutMetrics.FLOW_INDICATOR_SIZE;
-        ElementRenderer.drawFlow(gc, name, hasDelay,
+        ElementRenderer.drawFlow(gc, name, hasDelay, subscripts,
                 cx - size / 2, cy - size / 2, size, size);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/InteractionOverlayPass.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/InteractionOverlayPass.java
@@ -208,7 +208,8 @@ final class InteractionOverlayPass implements RenderPass {
             String eq = ed.getVariableEquation(hoveredElement).orElse(null);
             boolean hasDel = ctx.showDelayBadges()
                     && DelayDetector.equationContainsDelay(eq);
-            ElementRenderer.drawAux(gc, hoveredElement, isLit, eq, hasDel,
+            java.util.List<String> subs = ed.getElementSubscripts(hoveredElement);
+            ElementRenderer.drawAux(gc, hoveredElement, isLit, eq, hasDel, subs,
                     hx, hy, hw, hh, true);
         } else if (hoverType == ElementType.LOOKUP) {
             double hw = LayoutMetrics.effectiveWidth(canvasState, hoveredElement);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/StockRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/StockRenderer.java
@@ -6,6 +6,8 @@ import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.LayoutMetrics;
 import systems.courant.sd.app.canvas.ModelEditor;
 
+import java.util.List;
+
 /**
  * Renders stock elements: heavy bordered rectangle with name and unit badge.
  */
@@ -17,6 +19,7 @@ final class StockRenderer implements ElementTypeRenderer {
         double w = LayoutMetrics.effectiveWidth(canvasState, name);
         double h = LayoutMetrics.effectiveHeight(canvasState, name);
         String unit = editor.getStockUnit(name).orElse(null);
-        ElementRenderer.drawStock(gc, name, unit, cx - w / 2, cy - h / 2, w, h);
+        List<String> subscripts = editor.getElementSubscripts(name);
+        ElementRenderer.drawStock(gc, name, unit, subscripts, cx - w / 2, cy - h / 2, w, h);
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ChartUtilsTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ChartUtilsTest.java
@@ -185,4 +185,26 @@ class ChartUtilsTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("subscript column helpers")
+    class SubscriptColumnHelpers {
+
+        @Test
+        void shouldExtractBaseNameFromBracketedColumn() {
+            assertThat(ChartUtils.baseElementName("Population[North]")).isEqualTo("Population");
+            assertThat(ChartUtils.baseElementName("Population[North,Young]")).isEqualTo("Population");
+        }
+
+        @Test
+        void shouldReturnNameUnchangedForScalarColumn() {
+            assertThat(ChartUtils.baseElementName("Population")).isEqualTo("Population");
+        }
+
+        @Test
+        void shouldDetectSubscriptedColumn() {
+            assertThat(ChartUtils.isSubscriptedColumn("Population[North]")).isTrue();
+            assertThat(ChartUtils.isSubscriptedColumn("Population")).isFalse();
+        }
+    }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelEditorTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelEditorTest.java
@@ -2616,4 +2616,51 @@ class ModelEditorTest {
             assertThat(copy.subscripts()).containsExactly("Region");
         }
     }
+
+    @Nested
+    @DisplayName("getElementSubscripts")
+    class GetElementSubscripts {
+
+        @Test
+        void shouldReturnSubscriptsForSubscriptedStock() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .subscript("Region", List.of("N", "S"))
+                    .stock("Pop", 100, "Person", List.of("Region"))
+                    .build();
+            editor.loadFrom(def);
+
+            assertThat(editor.getElementSubscripts("Pop")).containsExactly("Region");
+        }
+
+        @Test
+        void shouldReturnSubscriptsForSubscriptedFlow() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .subscript("Region", List.of("N", "S"))
+                    .flow("Migration", "0", "Year", null, null, List.of("Region"))
+                    .build();
+            editor.loadFrom(def);
+
+            assertThat(editor.getElementSubscripts("Migration")).containsExactly("Region");
+        }
+
+        @Test
+        void shouldReturnEmptyListForScalarElement() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("S", 0, "units")
+                    .build();
+            editor.loadFrom(def);
+
+            assertThat(editor.getElementSubscripts("S")).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyListForUnknownElement() {
+            editor.loadFrom(new ModelDefinitionBuilder().name("Test").build());
+
+            assertThat(editor.getElementSubscripts("Missing")).isEmpty();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Draw subscript dimension names as a teal badge on stocks (bottom-right), variables (bottom-right), and flows (below name) when the element is arrayed
- Group expanded subscript series (e.g., Population[North], Population[South]) under a collapsible base-name header with master toggle checkbox in the simulation results sidebar
- Add `getElementSubscripts()` query to ModelEditor/ModelQueryFacade
- Add `baseElementName()` and `isSubscriptedColumn()` utilities to ChartUtils
- 7 new tests covering element subscript queries and chart utilities

Closes #1347

## Test plan

- [x] All existing tests pass
- [x] 7 new unit tests
- [x] SpotBugs clean
- [x] Full reactor clean compile