### PR TITLE
Enable custom naming of feedback loops in the loop navigator

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -269,6 +269,10 @@ public class ModelWindow {
             updateLoopNavigator();
             canvas.requestFocus();
         });
+        loopNavigatorBar.setOnLoopRenamed((loopLabel, customName) -> {
+            canvas.canvasState().setLoopName(loopLabel, customName);
+            fileController.markDirty();
+        });
         toolBar.setOnLoopToggleChanged(active -> {
             canvas.analysis().setLoopHighlightActive(active);
             loopNavigatorBar.setVisible(active);
@@ -923,6 +927,7 @@ public class ModelWindow {
         if (loopNavigatorBar == null) {
             return;
         }
+        loopNavigatorBar.setLoopNames(canvas.canvasState().getLoopNames());
         loopNavigatorBar.update(canvas.analysis().getLoopAnalysis(), canvas.analysis().getActiveLoopIndex(),
                 canvas.analysis().getLoopTypeFilter(), canvas.analysis().getFilteredLoopCount());
     }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
@@ -44,6 +44,7 @@ public class CanvasState {
     private List<String> drawOrderCache;
     private String viewName = DEFAULT_VIEW_NAME;
     private CldLoopInfo cldLoopInfo;
+    private final Map<String, String> loopNames = new LinkedHashMap<>();
 
     /**
      * Loads element positions and types from a ViewDef, clearing any previous state.
@@ -54,6 +55,8 @@ public class CanvasState {
         sizes.clear();
         selection.clear();
         cldLoopInfo = null;
+        loopNames.clear();
+        loopNames.putAll(view.loopNames());
         viewName = view.name();
 
         synchronized (drawOrderLock) {
@@ -252,6 +255,20 @@ public class CanvasState {
         this.cldLoopInfo = loopInfo;
     }
 
+    /** Returns the mutable loop names map (loop label → custom name). */
+    public Map<String, String> getLoopNames() {
+        return loopNames;
+    }
+
+    /** Sets a custom name for a loop, or removes it if the name is blank. */
+    public void setLoopName(String loopLabel, String customName) {
+        if (customName == null || customName.isBlank()) {
+            loopNames.remove(loopLabel);
+        } else {
+            loopNames.put(loopLabel, customName);
+        }
+    }
+
     /**
      * Returns true if positions map contains the named element.
      */
@@ -334,7 +351,8 @@ public class CanvasState {
                 placements.add(new ElementPlacement(name, type, pos.x(), pos.y()));
             }
         }
-        return new ViewDef(viewName, placements, List.of(), List.of());
+        return new ViewDef(viewName, placements, List.of(), List.of(),
+                Map.copyOf(loopNames));
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/LoopNavigatorBar.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/LoopNavigatorBar.java
@@ -20,7 +20,11 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.util.Duration;
 
+import javafx.scene.control.TextField;
+
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
@@ -49,11 +53,16 @@ public class LoopNavigatorBar extends HBox {
     private final Button helpIcon = new Button("?");
     private final Button elementsButton = new Button("Elements");
 
+    private final TextField nameField = new TextField();
+
     private Runnable onPrev;
     private Runnable onNext;
     private Runnable onShowAll;
     private Consumer<LoopType> onFilterChanged;
+    private BiConsumer<String, String> onLoopRenamed;
     private Stage elementsPopup;
+    private Map<String, String> loopNames = Map.of();
+    private String activeLoopLabel;
 
     public LoopNavigatorBar() {
         setId("loopNavigatorBar");
@@ -100,6 +109,21 @@ public class LoopNavigatorBar extends HBox {
 
         loopLabel.setId("loopNavigatorLabel");
         loopLabel.setStyle("-fx-font-size: 12px;");
+
+        nameField.setId("loopNameField");
+        nameField.setStyle("-fx-font-size: 11px;");
+        nameField.setPrefWidth(150);
+        nameField.setMaxWidth(200);
+        nameField.setPromptText("Name this loop");
+        nameField.setVisible(false);
+        nameField.setManaged(false);
+        nameField.setFocusTraversable(false);
+        nameField.setOnAction(e -> commitLoopName());
+        nameField.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
+            if (!isFocused) {
+                commitLoopName();
+            }
+        });
     }
 
     private void configureFilterButtons() {
@@ -246,7 +270,7 @@ public class LoopNavigatorBar extends HBox {
         Region spacer2 = new Region();
         spacer2.setPrefWidth(8);
 
-        getChildren().addAll(prevButton, nextButton, loopLabel, allButton,
+        getChildren().addAll(prevButton, nextButton, loopLabel, nameField, allButton,
                 elementsButton,
                 spacer, filterLabel, filterAllBtn, filterRBtn, filterBBtn,
                 spacer2, helpIcon);
@@ -285,6 +309,21 @@ public class LoopNavigatorBar extends HBox {
     }
 
     /**
+     * Sets the callback invoked when the user names a loop.
+     * Parameters: (loopLabel, customName) — customName may be empty to clear.
+     */
+    public void setOnLoopRenamed(BiConsumer<String, String> callback) {
+        this.onLoopRenamed = callback;
+    }
+
+    /**
+     * Sets the loop names map (typically from ViewDef). Call before update().
+     */
+    public void setLoopNames(Map<String, String> names) {
+        this.loopNames = names != null ? names : Map.of();
+    }
+
+    /**
      * Updates the navigator display based on the current loop analysis, active index,
      * and type filter.
      *
@@ -296,6 +335,7 @@ public class LoopNavigatorBar extends HBox {
     public void update(FeedbackAnalysis analysis, int activeIndex,
                        LoopType typeFilter, int filteredCount) {
         boolean popupWasShowing = elementsPopup != null && elementsPopup.isShowing();
+        activeLoopLabel = null;
 
         if (analysis == null) {
             loopLabel.setText("Loop analysis not available");
@@ -306,6 +346,7 @@ public class LoopNavigatorBar extends HBox {
             filterRBtn.setDisable(true);
             filterBBtn.setDisable(true);
             elementsButton.setDisable(true);
+            hideNameField();
             closePopup();
             return;
         }
@@ -339,6 +380,7 @@ public class LoopNavigatorBar extends HBox {
             String filterDesc = typeFilter == LoopType.REINFORCING ? "reinforcing" : "balancing";
             loopLabel.setText("No " + filterDesc + " loops");
             loopLabel.setTooltip(null);
+            hideNameField();
             closePopup();
         } else if (activeIndex < 0) {
             String suffix = typeFilter != null
@@ -347,6 +389,7 @@ public class LoopNavigatorBar extends HBox {
             loopLabel.setText(displayCount + (displayCount == 1 ? " loop" : " loops")
                     + suffix + " \u2014 click \u25B6 to step");
             loopLabel.setTooltip(null);
+            hideNameField();
             closePopup();
         } else {
             FeedbackAnalysis.CausalLoop activeLoop = analysis.causalLoops().get(activeIndex);
@@ -377,6 +420,9 @@ public class LoopNavigatorBar extends HBox {
                 tip.setWrapText(true);
                 tip.setMaxWidth(400);
                 loopLabel.setTooltip(tip);
+
+                activeLoopLabel = info.label();
+                showNameField(info.label());
             });
             elementsButton.setDisable(false);
             elementsButton.setOnAction(e -> showElementsPopup(activeLoop));
@@ -393,6 +439,29 @@ public class LoopNavigatorBar extends HBox {
         if (elementsPopup != null) {
             elementsPopup.close();
             elementsPopup = null;
+        }
+    }
+
+    private void showNameField(String loopLabel) {
+        String customName = loopNames.getOrDefault(loopLabel, "");
+        nameField.setText(customName);
+        nameField.setVisible(true);
+        nameField.setManaged(true);
+    }
+
+    private void hideNameField() {
+        nameField.setVisible(false);
+        nameField.setManaged(false);
+    }
+
+    private void commitLoopName() {
+        if (activeLoopLabel == null || onLoopRenamed == null) {
+            return;
+        }
+        String name = nameField.getText().trim();
+        String existing = loopNames.getOrDefault(activeLoopLabel, "");
+        if (!name.equals(existing)) {
+            onLoopRenamed.accept(activeLoopLabel, name);
         }
     }
 

--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -373,6 +373,13 @@ public class ModelDefinitionSerializer {
                 }
                 node.set("flowRoutes", flowRoutes);
             }
+            if (!v.loopNames().isEmpty()) {
+                ObjectNode loopNamesNode = mapper.createObjectNode();
+                for (Map.Entry<String, String> entry : v.loopNames().entrySet()) {
+                    loopNamesNode.put(entry.getKey(), entry.getValue());
+                }
+                node.set("loopNames", loopNamesNode);
+            }
             arr.add(node);
         }
         return arr;
@@ -829,7 +836,13 @@ public class ModelDefinitionSerializer {
                 flowRoutes.add(new FlowRoute(requiredText(fr, "flowName"), points));
             }
         }
-        return new ViewDef(name, elements, connectors, flowRoutes);
+        Map<String, String> loopNames = new HashMap<>();
+        if (n.has("loopNames")) {
+            JsonNode loopNamesNode = n.get("loopNames");
+            loopNamesNode.fieldNames().forEachRemaining(key ->
+                    loopNames.put(key, loopNamesNode.get(key).asText()));
+        }
+        return new ViewDef(name, elements, connectors, flowRoutes, loopNames);
     }
 
     private ModuleInterface deserializeModuleInterface(JsonNode node) {

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/ViewDef.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/ViewDef.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.model.def;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Definition of a graphical view of a model (or a page within a multi-page view).
@@ -9,13 +10,21 @@ import java.util.List;
  * @param elements element placements (positions of stocks, flows, etc.)
  * @param connectors influence connectors (dependency arrows)
  * @param flowRoutes flow pipe routes
+ * @param loopNames user-assigned names for feedback loops, keyed by auto-generated label (e.g., "R1")
  */
 public record ViewDef(
         String name,
         List<ElementPlacement> elements,
         List<ConnectorRoute> connectors,
-        List<FlowRoute> flowRoutes
+        List<FlowRoute> flowRoutes,
+        Map<String, String> loopNames
 ) {
+
+    /** Backward-compatible constructor without loopNames. */
+    public ViewDef(String name, List<ElementPlacement> elements,
+                   List<ConnectorRoute> connectors, List<FlowRoute> flowRoutes) {
+        this(name, elements, connectors, flowRoutes, Map.of());
+    }
 
     public ViewDef {
         if (name == null || name.isBlank()) {
@@ -24,5 +33,6 @@ public record ViewDef(
         elements = elements == null ? List.of() : List.copyOf(elements);
         connectors = connectors == null ? List.of() : List.copyOf(connectors);
         flowRoutes = flowRoutes == null ? List.of() : List.copyOf(flowRoutes);
+        loopNames = loopNames == null ? Map.of() : Map.copyOf(loopNames);
     }
 }


### PR DESCRIPTION
## Summary

- Add inline name field to loop navigator bar for custom loop names
- Store loop names in ViewDef as a loopNames map (loop label -> custom name)
- Persist via JSON serialization with backward compatibility
- Wire rename callback through ModelWindow to mark model dirty

Closes #1349

## Test plan

- [x] All existing tests pass
- [x] SpotBugs clean
- [x] Full reactor clean compile