### PR TITLE
Reopen Multi-Parameter Sweep dialog with previous settings

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/SimulationController.java
@@ -61,6 +61,7 @@ final class SimulationController {
     private final Consumer<Consumer<ModelEditListener>> fireLogEvent;
     private ParameterSweepDialog.Config lastSweepConfig;
     private MonteCarloDialog.Config lastMonteCarloConfig;
+    private MultiParameterSweepDialog.Config lastMultiSweepConfig;
 
     SimulationController(ModelCanvas canvas,
                          AnalysisRunner analysisRunner,
@@ -193,13 +194,15 @@ final class SimulationController {
             return;
         }
 
-        MultiParameterSweepDialog dialog = new MultiParameterSweepDialog(parameterNames);
+        MultiParameterSweepDialog dialog = new MultiParameterSweepDialog(
+                parameterNames, lastMultiSweepConfig);
         Optional<MultiParameterSweepDialog.Config> configOpt = dialog.showAndWait();
         if (configOpt.isEmpty()) {
             return;
         }
 
         MultiParameterSweepDialog.Config config = configOpt.get();
+        lastMultiSweepConfig = config;
         ModelDefinition def = canvas.navigation().toModelDefinition();
         SimulationSettings finalSettings = settings;
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/MultiParameterSweepDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/MultiParameterSweepDialog.java
@@ -47,6 +47,10 @@ public class MultiParameterSweepDialog extends Dialog<MultiParameterSweepDialog.
     private final Label combinationCountLabel;
 
     public MultiParameterSweepDialog(List<String> constantNames) {
+        this(constantNames, null);
+    }
+
+    public MultiParameterSweepDialog(List<String> constantNames, Config previousConfig) {
         HelpContextResolver.addHelpButton(this);
         setTitle("Multi-Parameter Sweep");
         setHeaderText("Configure parameters to sweep (at least 2)");
@@ -69,12 +73,24 @@ public class MultiParameterSweepDialog extends Dialog<MultiParameterSweepDialog.
 
         paramBox.getChildren().addAll(combinationCountLabel, addButton);
 
-        // Add two default rows
-        for (int i = 0; i < 2; i++) {
-            String defaultName = constantNames.size() > i ? constantNames.get(i) : null;
-            ParameterRow row = new ParameterRow(constantNames, paramBox, defaultName);
-            parameterRows.add(row);
-            paramBox.getChildren().add(paramBox.getChildren().size() - 2, row.getPane());
+        // Restore previous parameter rows, or add two defaults
+        if (previousConfig != null && !previousConfig.parameters().isEmpty()) {
+            for (ParamConfig pc : previousConfig.parameters()) {
+                if (constantNames.contains(pc.name())) {
+                    ParameterRow row = new ParameterRow(constantNames, paramBox, pc.name());
+                    row.restoreFrom(pc);
+                    parameterRows.add(row);
+                    paramBox.getChildren().add(paramBox.getChildren().size() - 2, row.getPane());
+                }
+            }
+        }
+        if (parameterRows.isEmpty()) {
+            for (int i = 0; i < 2; i++) {
+                String defaultName = constantNames.size() > i ? constantNames.get(i) : null;
+                ParameterRow row = new ParameterRow(constantNames, paramBox, defaultName);
+                parameterRows.add(row);
+                paramBox.getChildren().add(paramBox.getChildren().size() - 2, row.getPane());
+            }
         }
         updateCombinationCount();
 
@@ -233,6 +249,13 @@ public class MultiParameterSweepDialog extends Dialog<MultiParameterSweepDialog.
             } catch (NumberFormatException e) {
                 return false;
             }
+        }
+
+        void restoreFrom(ParamConfig pc) {
+            nameCombo.setValue(pc.name());
+            startField.setText(String.valueOf(pc.start()));
+            endField.setText(String.valueOf(pc.end()));
+            stepField.setText(String.valueOf(pc.step()));
         }
 
         ParamConfig toConfig() {


### PR DESCRIPTION
## Summary
- Restore previous parameter rows (name, start, end, step) when reopening Multi-Parameter Sweep dialog
- Follow same pattern as ParameterSweepDialog and MonteCarloDialog previousConfig

Closes #1352

## Test plan
- [x] All existing tests pass
- [x] SpotBugs clean