### PR TITLE
Fix review issues in loop naming feature

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
@@ -255,13 +255,16 @@ public class CanvasState {
         this.cldLoopInfo = loopInfo;
     }
 
-    /** Returns the mutable loop names map (loop label → custom name). */
+    /** Returns an unmodifiable view of loop names (loop label → custom name). */
     public Map<String, String> getLoopNames() {
-        return loopNames;
+        return Collections.unmodifiableMap(loopNames);
     }
 
     /** Sets a custom name for a loop, or removes it if the name is blank. */
     public void setLoopName(String loopLabel, String customName) {
+        if (loopLabel == null) {
+            return;
+        }
         if (customName == null || customName.isBlank()) {
             loopNames.remove(loopLabel);
         } else {
@@ -351,8 +354,7 @@ public class CanvasState {
                 placements.add(new ElementPlacement(name, type, pos.x(), pos.y()));
             }
         }
-        return new ViewDef(viewName, placements, List.of(), List.of(),
-                Map.copyOf(loopNames));
+        return new ViewDef(viewName, placements, List.of(), List.of(), loopNames);
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/LoopNavigatorBar.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/LoopNavigatorBar.java
@@ -8,6 +8,7 @@ import javafx.geometry.Pos;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
@@ -19,8 +20,6 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.util.Duration;
-
-import javafx.scene.control.TextField;
 
 import java.util.List;
 import java.util.Map;
@@ -359,6 +358,7 @@ public class LoopNavigatorBar extends HBox {
             filterRBtn.setDisable(true);
             filterBBtn.setDisable(true);
             elementsButton.setDisable(true);
+            hideNameField();
             closePopup();
             return;
         }


### PR DESCRIPTION
## Summary
- Fix ghost name field visible when loopCount == 0
- Return unmodifiable map from getLoopNames() for consistency
- Add null-guard on loopLabel in setLoopName()
- Fix import ordering, remove redundant Map.copyOf()

## Test plan
- [x] All tests pass
- [x] SpotBugs clean