### PR TITLE
Resolve symlinks in VensimImporter path traversal check

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
@@ -603,6 +603,20 @@ public class VensimImporter implements ModelImporter {
                 if (!Files.isRegularFile(csvPath)) {
                     continue;
                 }
+                // Resolve symlinks to prevent symlink-based path traversal
+                try {
+                    Path realCsvPath = csvPath.toRealPath();
+                    Path realBaseDir = baseDir.toRealPath();
+                    if (!realCsvPath.startsWith(realBaseDir)) {
+                        warnings.add("Rejected companion CSV path '" + filePath
+                                + "': resolves outside model directory via symlink");
+                        continue;
+                    }
+                } catch (IOException e) {
+                    warnings.add("Failed to resolve companion CSV path '" + filePath
+                            + "': " + e.getMessage());
+                    continue;
+                }
                 try {
                     ReferenceDataset dataset = ReferenceDataCsvReader.read(csvPath, filePath);
                     builder.referenceDataset(dataset);

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimImporterTest.java
@@ -3063,6 +3063,64 @@ class VensimImporterTest {
             java.nio.file.Files.deleteIfExists(modelDir);
             java.nio.file.Files.deleteIfExists(tempDir);
         }
+
+        @Test
+        void shouldRejectSymlinkBasedPathTraversal() throws IOException {
+            var tempDir = java.nio.file.Files.createTempDirectory("vensim-test");
+            var modelDir = tempDir.resolve("model");
+            java.nio.file.Files.createDirectories(modelDir);
+            var secretFile = tempDir.resolve("secret.csv");
+            java.nio.file.Files.writeString(secretFile, "time,value\n0,1\n");
+
+            // Create a symlink inside modelDir pointing to the secret file outside
+            var symlink = modelDir.resolve("link.csv");
+            try {
+                java.nio.file.Files.createSymbolicLink(symlink, secretFile);
+            } catch (UnsupportedOperationException | IOException e) {
+                // Symlinks may not be supported or require elevated privileges
+                java.nio.file.Files.deleteIfExists(secretFile);
+                java.nio.file.Files.deleteIfExists(modelDir);
+                java.nio.file.Files.deleteIfExists(tempDir);
+                return; // Skip test on platforms that don't support symlinks
+            }
+
+            String mdl = """
+                    x = GET DIRECT DATA('link.csv', 'Sheet', 'A', 'B')
+                    \t~\t
+                    \t~\t
+                    \t|
+
+                    INITIAL TIME = 0
+                    \t~\tYear
+                    \t~\t
+                    \t|
+
+                    FINAL TIME = 10
+                    \t~\tYear
+                    \t~\t
+                    \t|
+
+                    TIME STEP = 1
+                    \t~\tYear
+                    \t~\t
+                    \t|
+                    """;
+
+            var mdlPath = modelDir.resolve("test.mdl");
+            java.nio.file.Files.writeString(mdlPath, mdl);
+
+            ImportResult result = importer.importModel(mdlPath);
+
+            // Should warn about the symlink-based traversal
+            assertThat(result.warnings()).anyMatch(w -> w.contains("outside model directory"));
+
+            // Cleanup
+            java.nio.file.Files.deleteIfExists(symlink);
+            java.nio.file.Files.deleteIfExists(secretFile);
+            java.nio.file.Files.deleteIfExists(mdlPath);
+            java.nio.file.Files.deleteIfExists(modelDir);
+            java.nio.file.Files.deleteIfExists(tempDir);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Adds `toRealPath()` symlink resolution after the existing `normalize()` path traversal check in `VensimImporter.resolveCompanionCsvFiles()`
- Prevents symlink-based directory traversal when loading companion CSV files from `.mdl` models
- Adds test for symlink-based traversal (gracefully skips on platforms without symlink support)

Closes #1384

## Test plan
- [x] Existing path traversal test still passes
- [x] New symlink traversal test passes (or skips gracefully on restricted platforms)
- [x] Full reactor tests pass
- [x] SpotBugs clean