### PR TITLE
Fix subscript bracket corruption with whitespace in clearDanglingReferences

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CopyPasteController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CopyPasteController.java
@@ -392,9 +392,14 @@ public final class CopyPasteController {
 
             // Consume subscript brackets as part of the reference (e.g. Stock[Region])
             // so that subscript names are not independently checked and replaced.
+            // Skip optional whitespace before the bracket (e.g. "Stock [Region]").
             String suffix = "";
-            if (i < len && equation.charAt(i) == '[') {
-                int close = equation.indexOf(']', i);
+            int bracketPos = i;
+            while (bracketPos < len && Character.isWhitespace(equation.charAt(bracketPos))) {
+                bracketPos++;
+            }
+            if (bracketPos < len && equation.charAt(bracketPos) == '[') {
+                int close = equation.indexOf(']', bracketPos);
                 if (close >= 0) {
                     suffix = equation.substring(i, close + 1);
                     i = close + 1;

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/CopyPasteControllerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/CopyPasteControllerTest.java
@@ -326,6 +326,19 @@ class CopyPasteControllerTest {
                     "Population[Region, Age]", editor).equation();
             assertThat(result).isEqualTo("Population[Region, Age]");
         }
+
+        @Test
+        void shouldHandleWhitespaceBetweenTokenAndSubscriptBracket() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Test")
+                    .stock("Stock", 100, null)
+                    .build();
+            editor.loadFrom(def);
+
+            String result = CopyPasteController.clearDanglingReferences(
+                    "Stock [Region] * Rate", editor).equation();
+            assertThat(result).isEqualTo("Stock [Region] * 0");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Skip optional whitespace before `[` when consuming subscript brackets in `clearDanglingReferences`
- Prevents subscript index names from being treated as independent identifiers and replaced with `0`
- Matches the existing whitespace-skip logic already used for function call parens

Closes #1386

## Test plan
- New test: `shouldHandleWhitespaceBetweenTokenAndSubscriptBracket` verifies `Stock [Region] * Rate` is handled correctly