### PR TITLE
Fix capitalizeFirst preserving mixed-case unit abbreviations

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileImporter.java
@@ -699,6 +699,6 @@ public class XmileImporter implements ModelImporter {
             return s;
         }
         return s.substring(0, 1).toUpperCase(Locale.ROOT)
-                + s.substring(1).toLowerCase(Locale.ROOT);
+                + s.substring(1);
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileImporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileImporterTest.java
@@ -338,6 +338,27 @@ class XmileImporterTest {
         }
 
         @Test
+        void shouldPreserveMixedCaseTimeUnits() {
+            String xmile = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <xmile xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0" version="1.0">
+                      <header><name>Test</name></header>
+                      <sim_specs time_units="kWh">
+                        <start>0</start><stop>10</stop><dt>1</dt>
+                      </sim_specs>
+                      <model><variables>
+                        <aux name="x"><eqn>1</eqn></aux>
+                      </variables></model>
+                    </xmile>
+                    """;
+
+            ImportResult result = importer.importModel(xmile, "Test");
+            var sim = result.definition().defaultSimulation();
+            assertThat(sim.timeStep()).isEqualTo("KWh");
+            assertThat(sim.durationUnit()).isEqualTo("KWh");
+        }
+
+        @Test
         void shouldPreserveNonZeroInitialTime() {
             String xmile = """
                     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- Removes erroneous `.toLowerCase()` call on the substring after the first character in `XmileImporter.capitalizeFirst()`
- Mixed-case unit abbreviations like `kWh` are now correctly capitalized as `KWh` instead of being flattened to `Kwh`
- Adds test verifying mixed-case preservation

Closes #1383

## Test plan
- [x] New test `shouldPreserveMixedCaseTimeUnits` passes
- [x] Full reactor tests pass
- [x] SpotBugs clean