### PR TITLE
Fix capitalizeFirst preserving original casing after first character

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileImporter.java
@@ -694,11 +694,11 @@ public class XmileImporter implements ModelImporter {
         return result;
     }
 
-    private static String capitalizeFirst(String s) {
+    static String capitalizeFirst(String s) {
         if (s == null || s.isEmpty()) {
             return s;
         }
         return s.substring(0, 1).toUpperCase(Locale.ROOT)
-                + s.substring(1).toLowerCase(Locale.ROOT);
+                + s.substring(1);
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileImporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/xmile/XmileImporterTest.java
@@ -1009,4 +1009,45 @@ class XmileImporterTest {
             assertThat(result.definition().stocks().get(0).name()).isEqualTo("Temp\u00e9rature");
         }
     }
+
+    @Nested
+    @DisplayName("capitalizeFirst")
+    class CapitalizeFirst {
+
+        @Test
+        @DisplayName("should capitalize first letter and preserve rest")
+        void shouldCapitalizeFirstAndPreserveRest() {
+            assertThat(XmileImporter.capitalizeFirst("day")).isEqualTo("Day");
+        }
+
+        @Test
+        @DisplayName("should preserve mixed case after first character")
+        void shouldPreserveMixedCase() {
+            assertThat(XmileImporter.capitalizeFirst("kWh")).isEqualTo("KWh");
+        }
+
+        @Test
+        @DisplayName("should handle single character")
+        void shouldHandleSingleCharacter() {
+            assertThat(XmileImporter.capitalizeFirst("d")).isEqualTo("D");
+        }
+
+        @Test
+        @DisplayName("should return null for null input")
+        void shouldReturnNullForNull() {
+            assertThat(XmileImporter.capitalizeFirst(null)).isNull();
+        }
+
+        @Test
+        @DisplayName("should return empty for empty input")
+        void shouldReturnEmptyForEmpty() {
+            assertThat(XmileImporter.capitalizeFirst("")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should handle already capitalized input")
+        void shouldHandleAlreadyCapitalized() {
+            assertThat(XmileImporter.capitalizeFirst("Month")).isEqualTo("Month");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Remove `.toLowerCase()` on the substring after the first character in `XmileImporter.capitalizeFirst`
- Preserves mixed-case unit abbreviations like `kWh` → `KWh` instead of `Kwh`

Closes #1383

## Test plan
- 6 new tests for `capitalizeFirst`: mixed case, single char, null, empty, already capitalized