### PR TITLE
Fix VensimSubscriptExpander to accept non-numeric comma-separated values

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimSubscriptExpander.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimSubscriptExpander.java
@@ -3,7 +3,6 @@ package systems.courant.sd.io.vensim;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 /**
  * Expands subscripted Vensim variables into per-label scalar variables.
@@ -17,9 +16,6 @@ import java.util.regex.Pattern;
  * ~250 lines of subscript expansion logic into a single-responsibility unit.
  */
 final class VensimSubscriptExpander {
-
-    private static final Pattern NUMERIC_PATTERN = Pattern.compile(
-            "^[+-]?(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?$");
 
     private VensimSubscriptExpander() {
     }

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimSubscriptExpanderTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimSubscriptExpanderTest.java
@@ -63,8 +63,11 @@ class VensimSubscriptExpanderTest {
         @Test
         @DisplayName("should not split commas inside parentheses")
         void shouldNotSplitCommasInsideParens() {
-            assertThat(VensimSubscriptExpander.splitSubscriptValues(
-                    "IF(a>b, 1, 0)", 3)).isNull();
+            // With expectedCount=1, verifies the whole expression is returned as one part
+            // (i.e., commas inside parens are not treated as top-level separators)
+            List<String> result = VensimSubscriptExpander.splitSubscriptValues(
+                    "IF(a>b, 1, 0)", 1);
+            assertThat(result).containsExactly("IF(a>b, 1, 0)");
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Remove the `allNumeric` restriction in `splitSubscriptValues` so non-numeric comma-separated values (variable references, expressions) are correctly assigned per-label
- Add `VensimSubscriptExpanderTest` with comprehensive coverage
- Remove dead `NUMERIC_PATTERN` field

Closes #1378