### PR TITLE
Fix closePopout not restoring dashboard panel to tab

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/DashboardDockManager.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/DashboardDockManager.java
@@ -99,12 +99,8 @@ final class DashboardDockManager {
         }
     }
 
-    /** Close the floating dashboard stage if currently popped out. */
+    /** Close the floating dashboard stage if currently popped out, restoring the panel to its tab. */
     void closePopout() {
-        if (dashboardStage != null) {
-            dashboardStage.setOnHidden(null);
-            dashboardStage.close();
-            dashboardStage = null;
-        }
+        dock();
     }
 }

--- a/courant-app/src/test/java/systems/courant/sd/app/DashboardDockManagerFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/DashboardDockManagerFxTest.java
@@ -1,0 +1,75 @@
+package systems.courant.sd.app;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import systems.courant.sd.app.canvas.DashboardPanel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DashboardDockManager (#1366)")
+@ExtendWith(ApplicationExtension.class)
+class DashboardDockManagerFxTest {
+
+    private DashboardDockManager manager;
+    private DashboardPanel dashboardPanel;
+    private Tab dashboardTab;
+    private TabPane rightTabPane;
+
+    @Start
+    void start(Stage stage) {
+        dashboardPanel = new DashboardPanel();
+        dashboardTab = new Tab("Dashboard", dashboardPanel);
+        rightTabPane = new TabPane(dashboardTab);
+
+        MenuItem popOutItem = new MenuItem("Pop Out Dashboard");
+
+        manager = new DashboardDockManager(
+                dashboardPanel, dashboardTab, rightTabPane, popOutItem, stage);
+
+        stage.setScene(new Scene(new StackPane(rightTabPane), 400, 300));
+        stage.show();
+    }
+
+    @Test
+    @DisplayName("closePopout should restore dashboard panel to tab")
+    void closePopoutShouldRestorePanel() {
+        Platform.runLater(() -> manager.popOut("Test Model"));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(manager.isPoppedOut()).isTrue();
+        assertThat(rightTabPane.getTabs()).doesNotContain(dashboardTab);
+
+        Platform.runLater(() -> manager.closePopout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(manager.isPoppedOut()).isFalse();
+        assertThat(rightTabPane.getTabs()).contains(dashboardTab);
+        assertThat(dashboardTab.getContent()).isEqualTo(dashboardPanel);
+    }
+
+    @Test
+    @DisplayName("closePopout when already docked should be a no-op")
+    void closePopoutWhenDockedShouldBeNoop() {
+        assertThat(manager.isPoppedOut()).isFalse();
+
+        Platform.runLater(() -> manager.closePopout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(manager.isPoppedOut()).isFalse();
+        assertThat(rightTabPane.getTabs()).contains(dashboardTab);
+        assertThat(dashboardTab.getContent()).isEqualTo(dashboardPanel);
+    }
+}


### PR DESCRIPTION
## Summary
- `DashboardDockManager.closePopout()` closed the floating stage but left the dashboard panel orphaned — not re-attached to its tab
- Fix: delegate to `dock()` which already handles detach, restore, and re-add correctly

Closes #1366

## Test plan
- [x] Full test suite passes
- [x] SpotBugs clean
- [x] New `DashboardDockManagerFxTest` verifies panel is restored to tab after closePopout