### PR TITLE
Fix SubscriptExpander regex matching variable name substrings with spaces

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/SubscriptExpander.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/SubscriptExpander.java
@@ -46,7 +46,8 @@ public class SubscriptExpander {
         }
 
         Map<String, Integer> dimensionCounts = collectDimensionCounts(def);
-        Pattern namePattern = buildNamePattern(subscriptedNames);
+        Set<String> allNames = collectAllNames(def);
+        Pattern namePattern = buildNamePattern(allNames);
 
         return def.toBuilder()
                 .clearStocks().clearFlows().clearVariables()
@@ -102,6 +103,20 @@ public class SubscriptExpander {
             }
         }
         return counts;
+    }
+
+    private static Set<String> collectAllNames(ModelDefinition def) {
+        Set<String> names = new HashSet<>();
+        for (StockDef s : def.stocks()) {
+            names.add(s.name());
+        }
+        for (FlowDef f : def.flows()) {
+            names.add(f.name());
+        }
+        for (VariableDef v : def.variables()) {
+            names.add(v.name());
+        }
+        return names;
     }
 
     private static List<StockDef> expandStocks(ModelDefinition def,

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/SubscriptExpanderTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/SubscriptExpanderTest.java
@@ -139,6 +139,29 @@ class SubscriptExpanderTest {
         }
 
         @Test
+        void shouldNotMatchSubscriptedNameInsideLongerNonSubscriptedName() {
+            // "birth rate" is subscripted; "adjusted birth rate" is not.
+            // The regex must not match "birth rate" inside "adjusted birth rate".
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Substring Bug")
+                    .subscript("Region", List.of("North", "South"))
+                    .stock("Pop", 100, "Person", List.of("Region"))
+                    .variable("birth rate", "0.02", "1/Year", List.of("Region"))
+                    .constant("adjusted birth rate", 0.03, "1/Year")
+                    .flow("inflow", "Pop * adjusted birth rate", "Year",
+                            null, "Pop", List.of("Region"))
+                    .build();
+
+            ModelDefinition expanded = SubscriptExpander.expand(def);
+
+            // "adjusted birth rate" is not subscripted, so it must NOT be rewritten
+            assertThat(expanded.flows().get(0).equation())
+                    .isEqualTo("Pop[North] * adjusted birth rate");
+            assertThat(expanded.flows().get(1).equation())
+                    .isEqualTo("Pop[South] * adjusted birth rate");
+        }
+
+        @Test
         void shouldNotRewriteBuiltinFunctionCallMatchingSubscriptedName() {
             // "SIN" is both a subscripted element and a built-in function name.
             // The function call SIN(angle) must not be rewritten to SIN[A](angle).


### PR DESCRIPTION
## Summary
- Include all element names in the regex pattern (not just subscripted ones) so longer names are matched first, preventing subscripted names from incorrectly matching as substrings of non-subscripted multi-word names
- Added test for subscripted "birth rate" inside non-subscripted "adjusted birth rate"

Closes #1375

## Test plan
- [x] New test `shouldNotMatchSubscriptedNameInsideLongerNonSubscriptedName` verifies the fix
- [x] All 158 tests pass
- [x] SpotBugs clean