### PR TITLE
Fix fragile NC license check in DemoClassGenerator

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
@@ -75,7 +75,7 @@ public class DemoClassGenerator {
 
     private void emitLicenseHeader(StringBuilder sb, ModelMetadata metadata) {
         String license = metadata.license();
-        if (license != null && license.contains("NC")) {
+        if (license != null && license.contains("-NC")) {
             sb.append("/*\n");
             sb.append(" * Copyright (c) original author(s). See model metadata for attribution.\n");
             sb.append(" * Licensed under CC-BY-NC-SA-4.0. See THIRD-PARTY-LICENSES for details.\n");

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/DemoClassGeneratorTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/DemoClassGeneratorTest.java
@@ -249,6 +249,26 @@ class DemoClassGeneratorTest {
     }
 
     @Test
+    void shouldNotTreatNcsaLicenseAsNonCommercial() {
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("Test")
+                .stock("S", 100.0, "people")
+                .defaultSimulation("Day", 10.0, "Day")
+                .build();
+
+        ModelMetadata metadata = ModelMetadata.builder()
+                .license("NCSA")
+                .build();
+
+        String source = generator.generate(def, metadata, "TestDemo",
+                "systems.courant.sd.demo", "test.xmile",
+                List.of(), List.of());
+
+        assertThat(source).contains("Copyright (c) 2025 Courant Systems");
+        assertThat(source).doesNotContain("THIRD-PARTY-LICENSES");
+    }
+
+    @Test
     void shouldEmitCourantLicenseHeaderForNonNCLicense() {
         ModelDefinition def = new ModelDefinitionBuilder()
                 .name("Test")


### PR DESCRIPTION
## Summary
- Change `contains("NC")` to `contains("-NC")` in license detection so strings like "NCSA" are not falsely classified as Creative Commons Non-Commercial
- Add test for the NCSA edge case

Closes #1377