### PR TITLE
Fix SubscriptExpander spaced-name substring matching

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/SubscriptExpander.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/SubscriptExpander.java
@@ -360,12 +360,15 @@ public class SubscriptExpander {
                 sb.append('|');
             }
             String quoted = Pattern.quote(sorted.get(i));
-            // Match backtick-quoted form first, then unquoted with word boundaries
+            // Match backtick-quoted form first, then unquoted with word boundaries.
+            // Use (?<!\w)(?<!\w ) and (?!\w)(?! \w) to prevent matching variable
+            // name substrings when names contain spaces (e.g. "birth rate" inside
+            // "adjusted birth rate").
             sb.append("`").append(quoted).append("`");
             sb.append("|");
-            sb.append("(?<![\\w])");
+            sb.append("(?<![\\w])(?<!\\w )");
             sb.append(quoted);
-            sb.append("(?![\\w])");
+            sb.append("(?![\\w])(?! \\w)");
         }
         return Pattern.compile(sb.toString());
     }

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/SubscriptExpanderTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/SubscriptExpanderTest.java
@@ -345,6 +345,63 @@ class SubscriptExpanderTest {
         }
     }
 
+    @Nested
+    @DisplayName("Spaced name substring matching (#1375)")
+    class SpacedNameSubstringMatching {
+
+        @Test
+        @DisplayName("should not match 'birth rate' inside 'adjusted birth rate'")
+        void shouldNotMatchShorterNameInsideLongerSpacedName() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Spaced Substring")
+                    .subscript("Region", List.of("A", "B"))
+                    .stock("birth rate", 100, "Person/Year", List.of("Region"))
+                    .variable("net", "adjusted birth rate + birth rate", "Person/Year",
+                            List.of("Region"))
+                    .build();
+
+            ModelDefinition expanded = SubscriptExpander.expand(def);
+
+            // "birth rate" should be expanded but "adjusted birth rate" should NOT be
+            assertThat(expanded.variables().get(0).equation())
+                    .isEqualTo("adjusted birth rate + birth rate[A]");
+        }
+
+        @Test
+        @DisplayName("should not match 'birth rate' inside 'birth rate adjustment'")
+        void shouldNotMatchShorterNameAtStartOfLongerName() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Suffix Match")
+                    .subscript("Region", List.of("X"))
+                    .stock("birth rate", 50, "Person/Year", List.of("Region"))
+                    .variable("net", "birth rate adjustment + birth rate", "Person/Year",
+                            List.of("Region"))
+                    .build();
+
+            ModelDefinition expanded = SubscriptExpander.expand(def);
+
+            assertThat(expanded.variables().get(0).equation())
+                    .isEqualTo("birth rate adjustment + birth rate[X]");
+        }
+
+        @Test
+        @DisplayName("should still match standalone spaced name in expression")
+        void shouldMatchStandaloneSpacedName() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Standalone")
+                    .subscript("Region", List.of("A"))
+                    .stock("birth rate", 100, "Person/Year", List.of("Region"))
+                    .variable("total", "birth rate * 2", "Person/Year",
+                            List.of("Region"))
+                    .build();
+
+            ModelDefinition expanded = SubscriptExpander.expand(def);
+
+            assertThat(expanded.variables().get(0).equation())
+                    .isEqualTo("birth rate[A] * 2");
+        }
+    }
+
     @Test
     void shouldThrowOnUnknownSubscriptDimension() {
         ModelDefinition def = new ModelDefinitionBuilder()


### PR DESCRIPTION
## Summary
- Extend regex boundary assertions in `buildNamePattern` to prevent matching spaced variable names as substrings of longer names (e.g., "birth rate" inside "adjusted birth rate")
- Uses `(?<!\w )` lookbehind and `(?! \w)` lookahead to detect adjacent words separated by a single space, which indicates the match is part of a longer Vensim identifier

Closes #1375

## Test plan
- [x] New test: "birth rate" not matched inside "adjusted birth rate"
- [x] New test: "birth rate" not matched inside "birth rate adjustment"
- [x] New test: standalone "birth rate" still matched correctly
- [x] All existing SubscriptExpander tests pass unchanged
- [x] Full test suite passes
- [x] SpotBugs clean