### PR TITLE
Extend module output bindings to support stocks and flows

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ModelCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ModelCompiler.java
@@ -4,6 +4,7 @@ import systems.courant.sd.measure.Quantity;
 import systems.courant.sd.measure.TimeUnit;
 import systems.courant.sd.measure.Unit;
 import systems.courant.sd.measure.UnitRegistry;
+import systems.courant.sd.measure.Units;
 import systems.courant.sd.model.Flow;
 import systems.courant.sd.model.LookupTable;
 import systems.courant.sd.model.Model;
@@ -233,24 +234,44 @@ public class ModelCompiler {
 
         compileFormulas(innerDef, moduleContext, resettables, auxHolders, flowHolders);
 
-        // Output bindings
+        // Output bindings — resolve from variables, stocks, or flows
         for (Map.Entry<String, String> binding : mDef.outputBindings().entrySet()) {
             String portName = binding.getKey();
             String alias = binding.getValue();
-            Variable moduleVar = moduleContext.getVariables().get(portName);
-            if (moduleVar == null) {
-                throw new CompilationException(
-                        "Module '" + mDef.instanceName()
-                                + "' output binding references unknown port: " + portName,
-                        portName);
-            }
-            Variable aliasVar = new Variable(alias, moduleVar.getUnit(),
-                    moduleVar::getValue);
+            Variable aliasVar = resolveOutputBinding(
+                    mDef.instanceName(), portName, alias, moduleContext);
             parentContext.addVariable(alias, aliasVar);
             parentModel.addVariable(aliasVar);
         }
 
         parentModel.addModule(module);
+    }
+
+    /**
+     * Resolves an output binding port name to a Variable wrapper.
+     * Checks variables, then stocks, then flows in the module context.
+     */
+    private Variable resolveOutputBinding(String moduleName, String portName,
+                                          String alias, CompilationContext moduleContext) {
+        Variable moduleVar = moduleContext.getVariables().get(portName);
+        if (moduleVar != null) {
+            return new Variable(alias, moduleVar.getUnit(), moduleVar::getValue);
+        }
+        Stock stock = moduleContext.getStocks().get(portName);
+        if (stock != null) {
+            return new Variable(alias, stock.getUnit(), stock::getValue);
+        }
+        Flow flow = moduleContext.getFlows().get(portName);
+        if (flow != null) {
+            Unit flowUnit = flow.getMaterialUnit() != null
+                    ? flow.getMaterialUnit() : Units.DIMENSIONLESS;
+            return new Variable(alias, flowUnit,
+                    () -> flow.flowPerTimeUnit(flow.getTimeUnit()).getValue());
+        }
+        throw new CompilationException(
+                "Module '" + moduleName
+                        + "' output binding references unknown port: " + portName,
+                portName);
     }
 
     private void injectSimulationConstants(ModelDefinition def, CompilationContext context) {

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ModelCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ModelCompilerTest.java
@@ -463,6 +463,50 @@ class ModelCompilerTest {
         }
 
         @Test
+        void shouldCompileStockOutputBinding() {
+            ModelDefinition innerModule = new ModelDefinitionBuilder()
+                    .name("Tank")
+                    .stock("Level", 75, "Gallon")
+                    .build();
+
+            ModelDefinition outer = new ModelDefinitionBuilder()
+                    .name("Monitor")
+                    .module("tank", innerModule,
+                            java.util.Map.of(),
+                            java.util.Map.of("Level", "TankLevel"))
+                    .defaultSimulation("Day", 1, "Day")
+                    .build();
+
+            CompiledModel compiled = compiler.compile(outer);
+            assertThat(compiled.getModel().getVariable("TankLevel")).isPresent();
+            Variable level = compiled.getModel().getVariable("TankLevel").orElseThrow();
+            assertThat(level.getValue()).isCloseTo(75.0, within(0.01));
+        }
+
+        @Test
+        void shouldCompileFlowOutputBinding() {
+            ModelDefinition innerModule = new ModelDefinitionBuilder()
+                    .name("Pipe")
+                    .stock("Tank", 100, "Gallon")
+                    .variable("rate", "10", "Gallon")
+                    .flow("Drain", "rate", "Day", "Tank", null)
+                    .build();
+
+            ModelDefinition outer = new ModelDefinitionBuilder()
+                    .name("Monitor")
+                    .module("pipe", innerModule,
+                            java.util.Map.of(),
+                            java.util.Map.of("Drain", "DrainRate"))
+                    .defaultSimulation("Day", 1, "Day")
+                    .build();
+
+            CompiledModel compiled = compiler.compile(outer);
+            assertThat(compiled.getModel().getVariable("DrainRate")).isPresent();
+            Variable drain = compiled.getModel().getVariable("DrainRate").orElseThrow();
+            assertThat(drain.getValue()).isCloseTo(10.0, within(0.01));
+        }
+
+        @Test
         void shouldThrowForBadOutputBinding() {
             ModelDefinition innerModule = new ModelDefinitionBuilder()
                     .name("Inner")


### PR DESCRIPTION
## Summary
- Extract `resolveOutputBinding` method that checks variables, then stocks, then flows
- Module output bindings can now expose any element type, not just variables
- Add tests for stock and flow output binding compilation

Closes #1374