### PR TITLE
Preserve underscores in VensimExporter.denormalizeName

### DIFF
--- a/courant-app/src/test/java/systems/courant/sd/app/ModelWindowImportExportFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/ModelWindowImportExportFxTest.java
@@ -159,7 +159,7 @@ class ModelWindowImportExportFxTest {
         ImportResult reimported = new VensimImporter().importModel(mdlFile);
         assertThat(reimported.definition().stocks()).hasSize(1);
         assertThat(reimported.definition().stocks().getFirst().name())
-                .isEqualTo("Teacup Temperature");
+                .isEqualTo("Teacup_Temperature");
     }
 
     @Test

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -687,12 +687,10 @@ public final class VensimExporter {
     }
 
     /**
-     * Denormalizes a Courant name back to Vensim name format.
+     * Denormalizes a Courant display name back to Vensim name format.
      *
-     * <p>If the name already contains spaces (i.e. it came from VensimImporter's
-     * {@code normalizeDisplayName} which preserves spaces), underscores are treated
-     * as literal characters and preserved. Otherwise (XMILE import, native Courant
-     * names), underscores are treated as word separators and replaced with spaces.
+     * <p>Underscores are always preserved — names may originate from XMILE
+     * or user input where underscores are literal, not word separators.
      *
      * <p>Leading underscore digit-prefix escapes (e.g. {@code _2nd}) are always
      * removed regardless of format.
@@ -706,11 +704,6 @@ public final class VensimExporter {
         if (stripped.length() >= 2 && stripped.charAt(0) == '_'
                 && Character.isDigit(stripped.charAt(1))) {
             stripped = stripped.substring(1);
-        }
-        // If the name already contains spaces (Vensim display-name format),
-        // underscores are literal — preserve them. Otherwise replace with spaces.
-        if (!stripped.contains(" ")) {
-            return stripped.replace('_', ' ');
         }
         return stripped;
     }
@@ -738,7 +731,13 @@ public final class VensimExporter {
                     break;
                 }
                 String quotedName = expr.substring(i + 1, closeQuote);
-                String denormed = denormalizeName(quotedName);
+                // Quoted names in expressions are equation identifiers (normalized):
+                // underscores represent spaces and digit-prefix escapes need stripping
+                String denormed = quotedName.replace('_', ' ');
+                if (quotedName.length() >= 2 && quotedName.charAt(0) == '_'
+                        && Character.isDigit(quotedName.charAt(1))) {
+                    denormed = denormed.stripLeading();
+                }
                 result.append('"').append(denormed).append('"');
                 i = closeQuote + 1;
             } else if (Character.isLetter(c) || c == '_') {

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/VensimExporterTest.java
@@ -311,15 +311,10 @@ class VensimExporterTest {
     class NameDenormalization {
 
         @Test
-        void shouldReplaceUnderscoresWithSpacesForNonVensimNames() {
-            // Names without spaces (XMILE/native): underscores are word separators
+        void shouldPreserveUnderscoresInNames() {
+            // Underscores are always preserved (may originate from XMILE or user input)
             assertThat(VensimExporter.denormalizeName("Population_Growth"))
-                    .isEqualTo("Population Growth");
-        }
-
-        @Test
-        void shouldPreserveUnderscoresWhenNameHasSpaces() {
-            // Names with spaces (Vensim display-name format): underscores are literal
+                    .isEqualTo("Population_Growth");
             assertThat(VensimExporter.denormalizeName("Net_Flow Rate"))
                     .isEqualTo("Net_Flow Rate");
             assertThat(VensimExporter.denormalizeName("Population Growth"))
@@ -341,8 +336,7 @@ class VensimExporterTest {
         @Test
         void shouldStripLeadingUnderscoreFromDigitPrefixedNames() {
             assertThat(VensimExporter.denormalizeName("_2nd_Batch"))
-                    .isEqualTo("2nd Batch");
-            // Vensim display-name format preserves spaces
+                    .isEqualTo("2nd_Batch");
             assertThat(VensimExporter.denormalizeName("_2nd Batch"))
                     .isEqualTo("2nd Batch");
         }
@@ -350,7 +344,7 @@ class VensimExporterTest {
         @Test
         void shouldPreserveLeadingUnderscoreForNonDigitNames() {
             assertThat(VensimExporter.denormalizeName("_internal"))
-                    .isEqualTo(" internal");
+                    .isEqualTo("_internal");
         }
     }
 
@@ -453,7 +447,7 @@ class VensimExporterTest {
             String mdl = VensimExporter.toVensim(def);
 
             assertThat(mdl).contains("Population=\n\t0");
-            assertThat(mdl).contains("Birth Rate=\n\t0");
+            assertThat(mdl).contains("Birth_Rate=\n\t0");
             assertThat(mdl).contains("The total population");
             assertThat(mdl).contains("Rate of births");
         }
@@ -487,7 +481,7 @@ class VensimExporterTest {
             // Verify sketch section has element placements and connector
             assertThat(mdl).contains("*CLD");
             assertThat(mdl).contains("10,1,Population,200,200");
-            assertThat(mdl).contains("10,2,Birth Rate,100,100");
+            assertThat(mdl).contains("10,2,Birth_Rate,100,100");
             assertThat(mdl).contains("1,4,2,1");
 
             // Re-import — sketch with no flow valves + no stocks → CLD mode
@@ -730,7 +724,7 @@ class VensimExporterTest {
 
             String mdl = VensimExporter.toVensim(def);
 
-            assertThat(mdl).contains("growth rate[Region]=");
+            assertThat(mdl).contains("growth_rate[Region]=");
         }
 
         @Test
@@ -745,7 +739,7 @@ class VensimExporterTest {
 
             String mdl = VensimExporter.toVensim(def);
 
-            assertThat(mdl).contains("Population[Region,Age Group]= INTEG");
+            assertThat(mdl).contains("Population[Region,Age_Group]= INTEG");
         }
     }
 
@@ -883,9 +877,9 @@ class VensimExporterTest {
             String mdl = VensimExporter.toVensim(def);
 
             // The LOOKUP call should be inlined as table-call syntax
-            assertThat(mdl).contains("effect table(Time) * factor");
+            assertThat(mdl).contains("effect_table(Time) * factor");
             // The lookup table should still be emitted as a standalone block
-            assertThat(mdl).contains("effect table(");
+            assertThat(mdl).contains("effect_table(");
             assertThat(mdl).contains("(0,0)");
         }
 


### PR DESCRIPTION
## Summary
- Stops `denormalizeName()` from blindly replacing underscores with spaces in element names
- Names from XMILE or user input use underscores literally, not as word separators
- Quoted names in expressions still correctly convert underscores to spaces (separate code path)
- Updates all affected test expectations for the new behavior

Closes #1382

## Test plan
- [x] Name denormalization unit tests updated and pass
- [x] CLD export, subscript export, lookup export tests updated
- [x] XMILE→Vensim round-trip test updated and passes
- [x] Full reactor tests pass
- [x] SpotBugs clean