### PR TITLE
Warn when macro expansion exceeds 10-pass limit

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/MacroExpander.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/MacroExpander.java
@@ -54,9 +54,10 @@ public final class MacroExpander {
         Map<String, Integer> instantiationCounters = new HashMap<>();
 
         int maxPasses = 10;
+        boolean anyExpanded = false;
         for (int pass = 0; pass < maxPasses; pass++) {
             List<MdlEquation> nextResult = new ArrayList<>();
-            boolean anyExpanded = false;
+            anyExpanded = false;
 
             for (MdlEquation eq : result) {
                 if (eq.expression().isEmpty()) {
@@ -89,6 +90,11 @@ public final class MacroExpander {
             if (!anyExpanded) {
                 break;
             }
+        }
+
+        if (anyExpanded) {
+            warnings.add("Macro expansion incomplete after " + maxPasses
+                    + " passes — some macro calls may remain unexpanded");
         }
 
         return new ExpansionResult(result, warnings);

--- a/courant-engine/src/test/java/systems/courant/sd/io/vensim/MacroExpanderTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/vensim/MacroExpanderTest.java
@@ -298,6 +298,28 @@ class MacroExpanderTest {
         }
 
         @Test
+        void shouldWarnWhenExpansionExceedsMaxPasses() {
+            // A simple identity macro whose body has no nested calls,
+            // but deeply nested invocations require >10 passes to fully expand
+            MacroDef wrap = new MacroDef(
+                    "WRAP",
+                    List.of("x"),
+                    List.of("output"),
+                    List.of(eq("output", "x"))
+            );
+
+            // 11 levels of nesting: WRAP(WRAP(WRAP(...WRAP(42)...)))
+            String expr = "42";
+            for (int i = 0; i < 11; i++) {
+                expr = "WRAP(" + expr + ")";
+            }
+            List<MdlEquation> equations = List.of(eq("y", expr));
+            MacroExpander.ExpansionResult result = MacroExpander.expand(equations, List.of(wrap));
+
+            assertThat(result.warnings()).anyMatch(w -> w.contains("incomplete after 10 passes"));
+        }
+
+        @Test
         void shouldHandleNoMatchingCalls() {
             MacroDef macro = new MacroDef(
                     "UNUSED",


### PR DESCRIPTION
## Summary
- Adds a warning when the MacroExpander's 10-pass expansion loop exits without fully expanding all macro calls
- Previously, deeply nested macros silently produced partially-expanded equations
- Adds test with 11-level nested macro calls to verify the warning

Closes #1368

## Test plan
- [x] New test `shouldWarnWhenExpansionExceedsMaxPasses` passes
- [x] Full reactor tests pass
- [x] SpotBugs clean