### PR TITLE
Fix severity merge downgrade in CanvasAnalysisFacade

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasAnalysisFacade.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasAnalysisFacade.java
@@ -264,7 +264,7 @@ public final class CanvasAnalysisFacade {
             if (issue.elementName() != null) {
                 issues.merge(issue.elementName(), issue.severity(),
                         (existing, incoming) ->
-                                existing == Severity.ERROR ? existing : incoming);
+                                existing.compareTo(incoming) <= 0 ? existing : incoming);
                 details.computeIfAbsent(issue.elementName(), k -> new ArrayList<>()).add(issue);
             }
         }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelCanvasInvalidateAnalysisFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/ModelCanvasInvalidateAnalysisFxTest.java
@@ -2,6 +2,8 @@ package systems.courant.sd.app.canvas;
 
 import systems.courant.sd.model.def.ElementType;
 import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.ValidationIssue.Severity;
+import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.ViewDef;
 
 import javafx.scene.Scene;
@@ -16,6 +18,7 @@ import org.testfx.framework.junit5.Start;
 
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -129,6 +132,26 @@ class ModelCanvasInvalidateAnalysisFxTest {
         // invalidateAnalysis should not throw
         assertThat(canvas.analysis().getLastValidationResult()).isNotNull();
         assertThat(canvas.analysis().getLastValidationResult().issues()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("severity merge should keep ERROR when WARNING arrives after (#1371)")
+    void shouldKeepErrorWhenWarningArrivesAfter() {
+        CountingModelEditor editor = new CountingModelEditor();
+        // Add a variable with an unparseable equation (ERROR) and no unit (WARNING)
+        editor.addVariableFrom(
+                new VariableDef("badVar", null, "###INVALID###", "", List.of()),
+                "###INVALID###");
+        CanvasState state = new CanvasState();
+        state.addElement("badVar", ElementType.AUX, 100, 200);
+        canvas.setModel(editor, state.toViewDef());
+
+        WaitForAsyncUtils.waitForFxEvents();
+
+        Severity severity = canvas.analysis().elementIssues().get("badVar");
+        assertThat(severity)
+                .as("element with both ERROR and WARNING should retain ERROR")
+                .isEqualTo(Severity.ERROR);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace hardcoded `existing == Severity.ERROR` check with `compareTo()` to always keep the most severe level, preventing WARNING from being replaced by a lower severity
- Add test verifying ERROR is retained when an element has both ERROR and WARNING issues

Closes #1371