### PR TITLE
Propagate IOException from CsvSubscriber.close()

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/CsvSubscriber.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/CsvSubscriber.java
@@ -134,25 +134,33 @@ public class CsvSubscriber implements EventHandler, Closeable {
      */
     @Override
     public void handleSimulationEndEvent(SimulationEndEvent event) {
-        close();
+        try {
+            close();
+        } catch (IOException e) {
+            throw new CsvOutputException("Failed to flush CSV output on simulation end", e);
+        }
         logger.info("Ending simulation");
     }
 
     /**
      * Closes the underlying CSV writer, flushing any buffered data.
+     *
+     * @throws IOException if flushing or closing the writer fails
      */
     @Override
-    public void close() {
+    public void close() throws IOException {
         synchronized (lock) {
             closed = true;
             if (csvWriter != null) {
                 try {
                     csvWriter.flush();
-                    csvWriter.close();
-                } catch (IOException e) {
-                    logger.error("Failed to close CSV writer", e);
+                } finally {
+                    try {
+                        csvWriter.close();
+                    } finally {
+                        csvWriter = null;
+                    }
                 }
-                csvWriter = null;
             }
         }
     }


### PR DESCRIPTION
## Summary
- `close()` now declares `throws IOException` instead of silently swallowing flush/close errors
- `handleSimulationEndEvent` wraps the IOException in `CsvOutputException` so the simulation framework surfaces data loss errors
- Uses try-finally to ensure `csvWriter.close()` is always called even if `flush()` fails

Closes #1367

## Test plan
- [x] Existing close/double-close tests still pass
- [x] Concurrent close test still passes
- [x] Full reactor engine/demos tests pass
- [x] SpotBugs clean