### PR TITLE
Increase undo decompress timeout from 100ms to 5s

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/UndoManager.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/UndoManager.java
@@ -342,19 +342,21 @@ public class UndoManager implements AutoCloseable {
         if (raw != null) {
             return raw;
         }
-        // Block on the future with a bounded timeout instead of spin-waiting.
-        // The raw snapshot fast-path above handles most cases; this covers
-        // entries whose raw snapshot was already consumed.
+        // Block on the future until compression completes. Most calls are
+        // served by the raw snapshot fast-path above; this covers entries
+        // whose raw snapshot was already consumed. Use a generous timeout
+        // (5 seconds) so that large models can finish compressing rather than
+        // crashing, while still preventing indefinite hangs.
         CompressedData data;
         try {
-            data = entry.future().get(100, TimeUnit.MILLISECONDS);
+            data = entry.future().get(5, TimeUnit.SECONDS);
         } catch (ExecutionException e) {
             throw new IllegalStateException("Undo compression failed", e.getCause());
         } catch (java.util.concurrent.CancellationException e) {
             throw new IllegalStateException("Undo entry was cancelled", e);
         } catch (TimeoutException e) {
             throw new IllegalStateException(
-                    "Undo decompression timed out — compression did not complete within 100 ms");
+                    "Undo decompression timed out — compression did not complete within 5 s", e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Undo decompression interrupted", e);

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/UndoManagerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/UndoManagerTest.java
@@ -385,21 +385,18 @@ class UndoManagerTest {
         }
 
         @Test
-        void shouldTimeoutWithinMillisecondsNotSeconds() {
+        void shouldTimeoutGracefullyOnStuckCompression() {
             // Inject an entry whose future never completes and raw snapshot is null.
-            // The old code would block for 5 seconds; the new code times out in ~100ms.
+            // The 5-second timeout allows large models to finish compressing but
+            // still prevents indefinite hangs.
             CompletableFuture<UndoManager.CompressedData> neverComplete = new CompletableFuture<>();
             UndoManager.UndoEntry entry = new UndoManager.UndoEntry(
                     neverComplete, "Stuck", null);
             manager.pushEntry(entry);
 
-            long start = System.nanoTime();
             assertThatThrownBy(() -> manager.undo(snapshot("Current")))
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("100 ms");
-            long elapsed = (System.nanoTime() - start) / 1_000_000;
-
-            assertThat(elapsed).isLessThan(500); // well under 5 seconds
+                    .hasMessageContaining("5 s");
             neverComplete.cancel(false);
         }
 


### PR DESCRIPTION
## Summary
- Increase `UndoManager.decompress()` timeout from 100ms to 5 seconds
- Prevents crash on large models where compressor can't keep up
- Undo operation now degrades gracefully (brief pause) instead of throwing

Closes #1372

## Test plan
- Updated `shouldTimeoutGracefullyOnStuckCompression` test to verify 5s timeout message
- All existing UndoManager compression/decompression tests pass