### PR TITLE
Fix stale stepHolder when savePer > 1

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/Simulation.java
+++ b/courant-engine/src/main/java/systems/courant/sd/Simulation.java
@@ -82,6 +82,7 @@ public class Simulation {
 
     private final List<EventHandler> eventHandlers = new ArrayList<>();
 
+    private final List<Runnable> preStepCallbacks = new ArrayList<>();
 
     public Simulation(Model model, TimeUnit timeStep, Quantity duration) {
         this(model, timeStep, duration, LocalDateTime.now());
@@ -114,6 +115,18 @@ public class Simulation {
 
     public void removeEventHandler(EventHandler handler) {
         eventHandlers.remove(handler);
+    }
+
+    /**
+     * Adds a callback that runs at the start of every simulation step, regardless of
+     * {@link #setSavePer(long) savePer}. Use this for computation-critical sync that must
+     * happen on every step, not just recorded steps.
+     *
+     * @param callback the callback to invoke before each step's calculations
+     */
+    public void addPreStepCallback(Runnable callback) {
+        Preconditions.checkNotNull(callback, "callback must not be null");
+        preStepCallbacks.add(callback);
     }
 
     /**
@@ -252,6 +265,10 @@ public class Simulation {
                 }
 
                 flowMap.clear();
+
+                for (Runnable cb : preStepCallbacks) {
+                    cb.run();
+                }
 
                 boolean shouldRecord = currentStep % savePer == 0
                         || currentStep == totalSteps;

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/CompiledModel.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/CompiledModel.java
@@ -1,8 +1,6 @@
 package systems.courant.sd.model.compile;
 
 import systems.courant.sd.Simulation;
-import systems.courant.sd.event.EventHandler;
-import systems.courant.sd.event.TimeStepEvent;
 import systems.courant.sd.measure.Quantity;
 import systems.courant.sd.measure.TimeUnit;
 import systems.courant.sd.measure.UnitRegistry;
@@ -231,24 +229,6 @@ public class CompiledModel {
     }
 
     private void installStepSync(Simulation sim) {
-        sim.addEventHandler(new StepSyncHandler(stepHolder, sim));
-    }
-
-    /**
-     * Event handler that synchronizes the compiled model's step counter with the simulation.
-     */
-    private static class StepSyncHandler implements EventHandler {
-        private final long[] stepHolder;
-        private final Simulation sim;
-
-        StepSyncHandler(long[] stepHolder, Simulation sim) {
-            this.stepHolder = stepHolder;
-            this.sim = sim;
-        }
-
-        @Override
-        public void handleTimeStepEvent(TimeStepEvent event) {
-            stepHolder[0] = sim.getCurrentStep();
-        }
+        sim.addPreStepCallback(() -> stepHolder[0] = sim.getCurrentStep());
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ModelCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ModelCompilerTest.java
@@ -779,6 +779,39 @@ class ModelCompilerTest {
     }
 
     @Nested
+    @DisplayName("savePer does not affect numerical accuracy (issue #1363)")
+    class SavePerAccuracy {
+
+        @Test
+        void shouldProduceSameResultsRegardlessOfSavePer() {
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("SavePer SMOOTH")
+                    .stock("Level", 100, "Thing")
+                    .variable("SmoothedLevel", "SMOOTH(Level, 5)", "Thing")
+                    .flow("Drain", "SmoothedLevel * 0.1", "Day", "Level", null)
+                    .defaultSimulation("Day", 20, "Day")
+                    .build();
+
+            // Run with savePer=1
+            CompiledModel compiled = compiler.compile(def);
+            Simulation sim1 = compiled.createSimulation();
+            sim1.execute();
+            double finalLevel1 = findStock(compiled.getModel(), "Level").getValue();
+
+            // Reset and run with savePer=5
+            compiled.reset();
+            Simulation sim2 = compiled.createSimulation();
+            sim2.setSavePer(5);
+            sim2.execute();
+            double finalLevel2 = findStock(compiled.getModel(), "Level").getValue();
+
+            assertThat(finalLevel2)
+                    .as("savePer should only affect recording, not numerical accuracy")
+                    .isCloseTo(finalLevel1, within(1e-9));
+        }
+    }
+
+    @Nested
     @DisplayName("Subscript expansion and dependency graph ordering")
     class SubscriptDependencyGraph {
 


### PR DESCRIPTION
## Summary
- **StepSyncHandler** only updated `stepHolder[0]` on recorded steps (when `shouldRecord` was true), causing all stateful compiled formulas (SMOOTH, DELAY1, DELAY3, TREND, FORECAST, NPV, STEP, RAMP, PULSE) to see stale step values between recordings
- Replaced event-based step sync with a **pre-step callback** on `Simulation` that fires every step regardless of `savePer`
- Removed the now-unnecessary `StepSyncHandler` inner class from `CompiledModel`

## Test plan
- [x] Added regression test: SMOOTH-based model produces identical results with `savePer=1` vs `savePer=5`
- [x] All 162 tests pass
- [x] SpotBugs clean

Closes #1363