### PR TITLE
Defer SMOOTH/DELAY initial values to simulation start

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/model/Delay1.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Delay1.java
@@ -49,7 +49,7 @@ public class Delay1 implements Formula, Resettable {
     private final double delayTime;
     private final LongSupplier currentStep;
     private final double[] dtHolder;
-    private final double explicitInitial;
+    private final DoubleSupplier initialValueSupplier;
     private final boolean hasExplicitInitial;
 
     private double stage;
@@ -59,7 +59,8 @@ public class Delay1 implements Formula, Resettable {
     private long lastStep = -1;
 
     private Delay1(DoubleSupplier input, double delayTime, LongSupplier currentStep,
-                   double[] dtHolder, double explicitInitial, boolean hasExplicitInitial) {
+                   double[] dtHolder, DoubleSupplier initialValueSupplier,
+                   boolean hasExplicitInitial) {
         Preconditions.checkNotNull(input, "input supplier must not be null");
         Preconditions.checkNotNull(currentStep, "currentStep supplier must not be null");
         Preconditions.checkArgument(delayTime > 0,
@@ -68,7 +69,7 @@ public class Delay1 implements Formula, Resettable {
         this.delayTime = delayTime;
         this.currentStep = currentStep;
         this.dtHolder = dtHolder;
-        this.explicitInitial = explicitInitial;
+        this.initialValueSupplier = initialValueSupplier;
         this.hasExplicitInitial = hasExplicitInitial;
     }
 
@@ -81,7 +82,7 @@ public class Delay1 implements Formula, Resettable {
      * @return a new Delay1 formula
      */
     public static Delay1 of(DoubleSupplier input, double delayTime, LongSupplier currentStep) {
-        return new Delay1(input, delayTime, currentStep, UNIT_DT, 0, false);
+        return new Delay1(input, delayTime, currentStep, UNIT_DT, () -> 0.0, false);
     }
 
     /**
@@ -89,7 +90,7 @@ public class Delay1 implements Formula, Resettable {
      */
     public static Delay1 of(DoubleSupplier input, double delayTime,
                             double[] dtHolder, LongSupplier currentStep) {
-        return new Delay1(input, delayTime, currentStep, dtHolder, 0, false);
+        return new Delay1(input, delayTime, currentStep, dtHolder, () -> 0.0, false);
     }
 
     /**
@@ -103,7 +104,7 @@ public class Delay1 implements Formula, Resettable {
      */
     public static Delay1 of(DoubleSupplier input, double delayTime, double initialValue,
                             LongSupplier currentStep) {
-        return new Delay1(input, delayTime, currentStep, UNIT_DT, initialValue, true);
+        return new Delay1(input, delayTime, currentStep, UNIT_DT, () -> initialValue, true);
     }
 
     /**
@@ -111,6 +112,15 @@ public class Delay1 implements Formula, Resettable {
      */
     public static Delay1 of(DoubleSupplier input, double delayTime, double initialValue,
                             double[] dtHolder, LongSupplier currentStep) {
+        return new Delay1(input, delayTime, currentStep, dtHolder, () -> initialValue, true);
+    }
+
+    /**
+     * Creates a DELAY1 formula with a deferred initial value and runtime DT support.
+     */
+    public static Delay1 of(DoubleSupplier input, double delayTime, DoubleSupplier initialValue,
+                            double[] dtHolder, LongSupplier currentStep) {
+        Preconditions.checkNotNull(initialValue, "initialValue supplier must not be null");
         return new Delay1(input, delayTime, currentStep, dtHolder, initialValue, true);
     }
 
@@ -139,7 +149,7 @@ public class Delay1 implements Formula, Resettable {
         long step = currentStep.getAsLong();
         if (!initialized) {
             double inputAtInit = input.getAsDouble();
-            double init = hasExplicitInitial ? explicitInitial : inputAtInit;
+            double init = hasExplicitInitial ? initialValueSupplier.getAsDouble() : inputAtInit;
             stage = init * delayTime;
             output = init;
             lastInputVal = inputAtInit;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Delay3.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Delay3.java
@@ -51,7 +51,7 @@ public class Delay3 implements Formula, Resettable {
     private final double delayTime;
     private final LongSupplier currentStep;
     private final double[] dtHolder;
-    private final double explicitInitial;
+    private final DoubleSupplier initialValueSupplier;
     private final boolean hasExplicitInitial;
 
     private double stage1;
@@ -63,7 +63,8 @@ public class Delay3 implements Formula, Resettable {
     private long lastStep = -1;
 
     private Delay3(DoubleSupplier input, double delayTime, LongSupplier currentStep,
-                   double[] dtHolder, double explicitInitial, boolean hasExplicitInitial) {
+                   double[] dtHolder, DoubleSupplier initialValueSupplier,
+                   boolean hasExplicitInitial) {
         Preconditions.checkNotNull(input, "input supplier must not be null");
         Preconditions.checkNotNull(currentStep, "currentStep supplier must not be null");
         Preconditions.checkArgument(delayTime > 0,
@@ -72,7 +73,7 @@ public class Delay3 implements Formula, Resettable {
         this.delayTime = delayTime;
         this.currentStep = currentStep;
         this.dtHolder = dtHolder;
-        this.explicitInitial = explicitInitial;
+        this.initialValueSupplier = initialValueSupplier;
         this.hasExplicitInitial = hasExplicitInitial;
     }
 
@@ -85,7 +86,7 @@ public class Delay3 implements Formula, Resettable {
      * @return a new Delay3 formula
      */
     public static Delay3 of(DoubleSupplier input, double delayTime, LongSupplier currentStep) {
-        return new Delay3(input, delayTime, currentStep, UNIT_DT, 0, false);
+        return new Delay3(input, delayTime, currentStep, UNIT_DT, () -> 0.0, false);
     }
 
     /**
@@ -93,7 +94,7 @@ public class Delay3 implements Formula, Resettable {
      */
     public static Delay3 of(DoubleSupplier input, double delayTime,
                             double[] dtHolder, LongSupplier currentStep) {
-        return new Delay3(input, delayTime, currentStep, dtHolder, 0, false);
+        return new Delay3(input, delayTime, currentStep, dtHolder, () -> 0.0, false);
     }
 
     /**
@@ -107,7 +108,7 @@ public class Delay3 implements Formula, Resettable {
      */
     public static Delay3 of(DoubleSupplier input, double delayTime, double initialValue,
                             LongSupplier currentStep) {
-        return new Delay3(input, delayTime, currentStep, UNIT_DT, initialValue, true);
+        return new Delay3(input, delayTime, currentStep, UNIT_DT, () -> initialValue, true);
     }
 
     /**
@@ -115,6 +116,15 @@ public class Delay3 implements Formula, Resettable {
      */
     public static Delay3 of(DoubleSupplier input, double delayTime, double initialValue,
                             double[] dtHolder, LongSupplier currentStep) {
+        return new Delay3(input, delayTime, currentStep, dtHolder, () -> initialValue, true);
+    }
+
+    /**
+     * Creates a DELAY3 formula with a deferred initial value and runtime DT support.
+     */
+    public static Delay3 of(DoubleSupplier input, double delayTime, DoubleSupplier initialValue,
+                            double[] dtHolder, LongSupplier currentStep) {
+        Preconditions.checkNotNull(initialValue, "initialValue supplier must not be null");
         return new Delay3(input, delayTime, currentStep, dtHolder, initialValue, true);
     }
 
@@ -145,7 +155,7 @@ public class Delay3 implements Formula, Resettable {
         long step = currentStep.getAsLong();
         if (!initialized) {
             double inputAtInit = input.getAsDouble();
-            double init = hasExplicitInitial ? explicitInitial : inputAtInit;
+            double init = hasExplicitInitial ? initialValueSupplier.getAsDouble() : inputAtInit;
             double stageTime = delayTime / 3.0;
             stage1 = init * stageTime;
             stage2 = init * stageTime;

--- a/courant-engine/src/main/java/systems/courant/sd/model/SampleIfTrue.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/SampleIfTrue.java
@@ -20,7 +20,7 @@ public class SampleIfTrue implements Formula, Resettable {
 
     private final DoubleSupplier condition;
     private final DoubleSupplier input;
-    private final double initialValue;
+    private final DoubleSupplier initialValueSupplier;
     private final LongSupplier currentStep;
 
     private double heldValue;
@@ -30,13 +30,15 @@ public class SampleIfTrue implements Formula, Resettable {
     private long lastStep = -1;
 
     private SampleIfTrue(DoubleSupplier condition, DoubleSupplier input,
-                          double initialValue, LongSupplier currentStep) {
+                          DoubleSupplier initialValueSupplier, LongSupplier currentStep) {
         Preconditions.checkNotNull(condition, "condition supplier must not be null");
         Preconditions.checkNotNull(input, "input supplier must not be null");
+        Preconditions.checkNotNull(initialValueSupplier,
+                "initialValueSupplier must not be null");
         Preconditions.checkNotNull(currentStep, "currentStep supplier must not be null");
         this.condition = condition;
         this.input = input;
-        this.initialValue = initialValue;
+        this.initialValueSupplier = initialValueSupplier;
         this.currentStep = currentStep;
     }
 
@@ -51,6 +53,14 @@ public class SampleIfTrue implements Formula, Resettable {
      */
     public static SampleIfTrue of(DoubleSupplier condition, DoubleSupplier input,
                                    double initialValue, LongSupplier currentStep) {
+        return new SampleIfTrue(condition, input, () -> initialValue, currentStep);
+    }
+
+    /**
+     * Creates a SAMPLE IF TRUE formula with a deferred initial value.
+     */
+    public static SampleIfTrue of(DoubleSupplier condition, DoubleSupplier input,
+                                   DoubleSupplier initialValue, LongSupplier currentStep) {
         return new SampleIfTrue(condition, input, initialValue, currentStep);
     }
 
@@ -74,8 +84,9 @@ public class SampleIfTrue implements Formula, Resettable {
                 lastInputVal = input.getAsDouble();
                 heldValue = lastInputVal;
             } else {
-                lastInputVal = initialValue;
-                heldValue = initialValue;
+                double initVal = initialValueSupplier.getAsDouble();
+                lastInputVal = initVal;
+                heldValue = initVal;
             }
         } else if (step > lastStep) {
             long delta = step - lastStep;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Smooth.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Smooth.java
@@ -45,7 +45,7 @@ public class Smooth implements Formula, Resettable {
     private final DoubleSupplier smoothingTime;
     private final LongSupplier currentStep;
     private final double[] dtHolder;
-    private final double explicitInitial;
+    private final DoubleSupplier initialValueSupplier;
     private final boolean hasExplicitInitial;
 
     private double smoothed;
@@ -55,7 +55,8 @@ public class Smooth implements Formula, Resettable {
     private boolean warnedNonPositive;
 
     private Smooth(DoubleSupplier input, DoubleSupplier smoothingTime, LongSupplier currentStep,
-                   double[] dtHolder, double explicitInitial, boolean hasExplicitInitial) {
+                   double[] dtHolder, DoubleSupplier initialValueSupplier,
+                   boolean hasExplicitInitial) {
         Preconditions.checkNotNull(input, "input supplier must not be null");
         Preconditions.checkNotNull(smoothingTime, "smoothingTime supplier must not be null");
         Preconditions.checkNotNull(currentStep, "currentStep supplier must not be null");
@@ -63,7 +64,7 @@ public class Smooth implements Formula, Resettable {
         this.smoothingTime = smoothingTime;
         this.currentStep = currentStep;
         this.dtHolder = dtHolder;
-        this.explicitInitial = explicitInitial;
+        this.initialValueSupplier = initialValueSupplier;
         this.hasExplicitInitial = hasExplicitInitial;
     }
 
@@ -77,7 +78,7 @@ public class Smooth implements Formula, Resettable {
      */
     public static Smooth of(DoubleSupplier input, DoubleSupplier smoothingTime,
                             LongSupplier currentStep) {
-        return new Smooth(input, smoothingTime, currentStep, UNIT_DT, 0, false);
+        return new Smooth(input, smoothingTime, currentStep, UNIT_DT, () -> 0.0, false);
     }
 
     /**
@@ -91,7 +92,7 @@ public class Smooth implements Formula, Resettable {
      */
     public static Smooth of(DoubleSupplier input, DoubleSupplier smoothingTime,
                             double[] dtHolder, LongSupplier currentStep) {
-        return new Smooth(input, smoothingTime, currentStep, dtHolder, 0, false);
+        return new Smooth(input, smoothingTime, currentStep, dtHolder, () -> 0.0, false);
     }
 
     /**
@@ -107,7 +108,7 @@ public class Smooth implements Formula, Resettable {
                             LongSupplier currentStep) {
         Preconditions.checkArgument(smoothingTime > 0,
                 "smoothingTime must be positive, but got %s", smoothingTime);
-        return new Smooth(input, () -> smoothingTime, currentStep, UNIT_DT, 0, false);
+        return new Smooth(input, () -> smoothingTime, currentStep, UNIT_DT, () -> 0.0, false);
     }
 
     /**
@@ -121,7 +122,7 @@ public class Smooth implements Formula, Resettable {
      */
     public static Smooth of(DoubleSupplier input, DoubleSupplier smoothingTime,
                             double initialValue, LongSupplier currentStep) {
-        return new Smooth(input, smoothingTime, currentStep, UNIT_DT, initialValue, true);
+        return new Smooth(input, smoothingTime, currentStep, UNIT_DT, () -> initialValue, true);
     }
 
     /**
@@ -136,6 +137,18 @@ public class Smooth implements Formula, Resettable {
      */
     public static Smooth of(DoubleSupplier input, DoubleSupplier smoothingTime,
                             double initialValue, double[] dtHolder, LongSupplier currentStep) {
+        return new Smooth(input, smoothingTime, currentStep, dtHolder, () -> initialValue, true);
+    }
+
+    /**
+     * Creates a SMOOTH formula with a deferred initial value and runtime DT support.
+     * The initial value supplier is evaluated lazily at simulation start, allowing
+     * references to model elements that may not be initialized at compile time.
+     */
+    public static Smooth of(DoubleSupplier input, DoubleSupplier smoothingTime,
+                            DoubleSupplier initialValue, double[] dtHolder,
+                            LongSupplier currentStep) {
+        Preconditions.checkNotNull(initialValue, "initialValue supplier must not be null");
         return new Smooth(input, smoothingTime, currentStep, dtHolder, initialValue, true);
     }
 
@@ -152,7 +165,7 @@ public class Smooth implements Formula, Resettable {
                             LongSupplier currentStep) {
         Preconditions.checkArgument(smoothingTime > 0,
                 "smoothingTime must be positive, but got %s", smoothingTime);
-        return new Smooth(input, () -> smoothingTime, currentStep, UNIT_DT, initialValue, true);
+        return new Smooth(input, () -> smoothingTime, currentStep, UNIT_DT, () -> initialValue, true);
     }
 
     /**
@@ -181,7 +194,7 @@ public class Smooth implements Formula, Resettable {
         long step = currentStep.getAsLong();
         if (!initialized) {
             double inputAtInit = input.getAsDouble();
-            smoothed = hasExplicitInitial ? explicitInitial : inputAtInit;
+            smoothed = hasExplicitInitial ? initialValueSupplier.getAsDouble() : inputAtInit;
             lastInputVal = inputAtInit;
             initialized = true;
             lastStep = step;

--- a/courant-engine/src/main/java/systems/courant/sd/model/Smooth3.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/Smooth3.java
@@ -47,7 +47,7 @@ public class Smooth3 implements Formula, Resettable {
     private final DoubleSupplier smoothingTime;
     private final LongSupplier currentStep;
     private final double[] dtHolder;
-    private final double explicitInitial;
+    private final DoubleSupplier initialValueSupplier;
     private final boolean hasExplicitInitial;
 
     private double stage1;
@@ -59,7 +59,8 @@ public class Smooth3 implements Formula, Resettable {
     private boolean warnedNonPositive;
 
     private Smooth3(DoubleSupplier input, DoubleSupplier smoothingTime, LongSupplier currentStep,
-                    double[] dtHolder, double explicitInitial, boolean hasExplicitInitial) {
+                    double[] dtHolder, DoubleSupplier initialValueSupplier,
+                    boolean hasExplicitInitial) {
         Preconditions.checkNotNull(input, "input supplier must not be null");
         Preconditions.checkNotNull(smoothingTime, "smoothingTime supplier must not be null");
         Preconditions.checkNotNull(currentStep, "currentStep supplier must not be null");
@@ -67,7 +68,7 @@ public class Smooth3 implements Formula, Resettable {
         this.smoothingTime = smoothingTime;
         this.currentStep = currentStep;
         this.dtHolder = dtHolder;
-        this.explicitInitial = explicitInitial;
+        this.initialValueSupplier = initialValueSupplier;
         this.hasExplicitInitial = hasExplicitInitial;
     }
 
@@ -81,7 +82,7 @@ public class Smooth3 implements Formula, Resettable {
      */
     public static Smooth3 of(DoubleSupplier input, DoubleSupplier smoothingTime,
                              LongSupplier currentStep) {
-        return new Smooth3(input, smoothingTime, currentStep, UNIT_DT, 0, false);
+        return new Smooth3(input, smoothingTime, currentStep, UNIT_DT, () -> 0.0, false);
     }
 
     /**
@@ -89,7 +90,7 @@ public class Smooth3 implements Formula, Resettable {
      */
     public static Smooth3 of(DoubleSupplier input, DoubleSupplier smoothingTime,
                              double[] dtHolder, LongSupplier currentStep) {
-        return new Smooth3(input, smoothingTime, currentStep, dtHolder, 0, false);
+        return new Smooth3(input, smoothingTime, currentStep, dtHolder, () -> 0.0, false);
     }
 
     /**
@@ -99,7 +100,7 @@ public class Smooth3 implements Formula, Resettable {
                              LongSupplier currentStep) {
         Preconditions.checkArgument(smoothingTime > 0,
                 "smoothingTime must be positive, but got %s", smoothingTime);
-        return new Smooth3(input, () -> smoothingTime, currentStep, UNIT_DT, 0, false);
+        return new Smooth3(input, () -> smoothingTime, currentStep, UNIT_DT, () -> 0.0, false);
     }
 
     /**
@@ -113,7 +114,7 @@ public class Smooth3 implements Formula, Resettable {
      */
     public static Smooth3 of(DoubleSupplier input, DoubleSupplier smoothingTime,
                              double initialValue, LongSupplier currentStep) {
-        return new Smooth3(input, smoothingTime, currentStep, UNIT_DT, initialValue, true);
+        return new Smooth3(input, smoothingTime, currentStep, UNIT_DT, () -> initialValue, true);
     }
 
     /**
@@ -121,6 +122,16 @@ public class Smooth3 implements Formula, Resettable {
      */
     public static Smooth3 of(DoubleSupplier input, DoubleSupplier smoothingTime,
                              double initialValue, double[] dtHolder, LongSupplier currentStep) {
+        return new Smooth3(input, smoothingTime, currentStep, dtHolder, () -> initialValue, true);
+    }
+
+    /**
+     * Creates a SMOOTH3 formula with a deferred initial value and runtime DT support.
+     */
+    public static Smooth3 of(DoubleSupplier input, DoubleSupplier smoothingTime,
+                             DoubleSupplier initialValue, double[] dtHolder,
+                             LongSupplier currentStep) {
+        Preconditions.checkNotNull(initialValue, "initialValue supplier must not be null");
         return new Smooth3(input, smoothingTime, currentStep, dtHolder, initialValue, true);
     }
 
@@ -131,7 +142,7 @@ public class Smooth3 implements Formula, Resettable {
                              LongSupplier currentStep) {
         Preconditions.checkArgument(smoothingTime > 0,
                 "smoothingTime must be positive, but got %s", smoothingTime);
-        return new Smooth3(input, () -> smoothingTime, currentStep, UNIT_DT, initialValue, true);
+        return new Smooth3(input, () -> smoothingTime, currentStep, UNIT_DT, () -> initialValue, true);
     }
 
     /**
@@ -160,7 +171,7 @@ public class Smooth3 implements Formula, Resettable {
         long step = currentStep.getAsLong();
         if (!initialized) {
             double inputAtInit = input.getAsDouble();
-            double init = hasExplicitInitial ? explicitInitial : inputAtInit;
+            double init = hasExplicitInitial ? initialValueSupplier.getAsDouble() : inputAtInit;
             stage1 = init;
             stage2 = init;
             stage3 = init;

--- a/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/compile/ExprCompiler.java
@@ -661,13 +661,7 @@ public class ExprCompiler {
         double[] dtH = context.getDtHolder();
         Smooth smooth;
         if (args.size() == 3) {
-            double initial = evaluateAtCompileTime(args.get(2), "SMOOTH initialValue");
-            if (Double.isNaN(initial)) {
-                String msg = "SMOOTH initialValue evaluated to NaN at compile time; using 0.0";
-                logger.warn(msg);
-                context.addWarning(msg);
-                initial = 0.0;
-            }
+            DoubleSupplier initial = compileInitialValue(args.get(2), "SMOOTH initialValue");
             smooth = Smooth.of(input, smoothingTime, initial, dtH, context.getCurrentStep());
         } else {
             smooth = Smooth.of(input, smoothingTime, dtH, context.getCurrentStep());
@@ -680,13 +674,7 @@ public class ExprCompiler {
         requireArgs("SMOOTHI", args, 3);
         DoubleSupplier input = compileExpr(args.get(0));
         DoubleSupplier smoothingTime = compileExpr(args.get(1));
-        double initial = evaluateAtCompileTime(args.get(2), "SMOOTHI initialValue");
-        if (Double.isNaN(initial)) {
-            String msg = "SMOOTHI initialValue evaluated to NaN at compile time; using 0.0";
-            logger.warn(msg);
-            context.addWarning(msg);
-            initial = 0.0;
-        }
+        DoubleSupplier initial = compileInitialValue(args.get(2), "SMOOTHI initialValue");
         double[] dtH = context.getDtHolder();
         Smooth smooth = Smooth.of(input, smoothingTime, initial, dtH, context.getCurrentStep());
         resettables.add(smooth);
@@ -703,13 +691,7 @@ public class ExprCompiler {
         double[] dtH = context.getDtHolder();
         Smooth3 smooth3;
         if (args.size() == 3) {
-            double initial = evaluateAtCompileTime(args.get(2), "SMOOTH3 initialValue");
-            if (Double.isNaN(initial)) {
-                String msg = "SMOOTH3 initialValue evaluated to NaN at compile time; using 0.0";
-                logger.warn(msg);
-                context.addWarning(msg);
-                initial = 0.0;
-            }
+            DoubleSupplier initial = compileInitialValue(args.get(2), "SMOOTH3 initialValue");
             smooth3 = Smooth3.of(input, smoothingTime, initial, dtH, context.getCurrentStep());
         } else {
             smooth3 = Smooth3.of(input, smoothingTime, dtH, context.getCurrentStep());
@@ -722,13 +704,7 @@ public class ExprCompiler {
         requireArgs("SMOOTH3I", args, 3);
         DoubleSupplier input = compileExpr(args.get(0));
         DoubleSupplier smoothingTime = compileExpr(args.get(1));
-        double initial = evaluateAtCompileTime(args.get(2), "SMOOTH3I initialValue");
-        if (Double.isNaN(initial)) {
-            String msg = "SMOOTH3I initialValue evaluated to NaN at compile time; using 0.0";
-            logger.warn(msg);
-            context.addWarning(msg);
-            initial = 0.0;
-        }
+        DoubleSupplier initial = compileInitialValue(args.get(2), "SMOOTH3I initialValue");
         double[] dtH = context.getDtHolder();
         Smooth3 smooth3 = Smooth3.of(input, smoothingTime, initial, dtH, context.getCurrentStep());
         resettables.add(smooth3);
@@ -757,13 +733,7 @@ public class ExprCompiler {
         double[] dtH = context.getDtHolder();
         Delay1 delay1;
         if (args.size() == 3) {
-            double initial = evaluateAtCompileTime(args.get(2), "DELAY1 initialValue");
-            if (Double.isNaN(initial)) {
-                String msg = "DELAY1 initialValue evaluated to NaN at compile time; using 0.0";
-                logger.warn(msg);
-                context.addWarning(msg);
-                initial = 0.0;
-            }
+            DoubleSupplier initial = compileInitialValue(args.get(2), "DELAY1 initialValue");
             delay1 = Delay1.of(input, delayTime, initial, dtH, context.getCurrentStep());
         } else {
             delay1 = Delay1.of(input, delayTime, dtH, context.getCurrentStep());
@@ -794,13 +764,7 @@ public class ExprCompiler {
         double[] dtH = context.getDtHolder();
         Delay3 delay3;
         if (args.size() == 3) {
-            double initial = evaluateAtCompileTime(args.get(2), "DELAY3 initialValue");
-            if (Double.isNaN(initial)) {
-                String msg = "DELAY3 initialValue evaluated to NaN at compile time; using 0.0";
-                logger.warn(msg);
-                context.addWarning(msg);
-                initial = 0.0;
-            }
+            DoubleSupplier initial = compileInitialValue(args.get(2), "DELAY3 initialValue");
             delay3 = Delay3.of(input, delayTime, initial, dtH, context.getCurrentStep());
         } else {
             delay3 = Delay3.of(input, delayTime, dtH, context.getCurrentStep());
@@ -1028,13 +992,7 @@ public class ExprCompiler {
         requireArgs("SAMPLE_IF_TRUE", args, 3);
         DoubleSupplier condition = compileExpr(args.get(0));
         DoubleSupplier input = compileExpr(args.get(1));
-        double initial = evaluateAtCompileTime(args.get(2), "SAMPLE_IF_TRUE initialValue");
-        if (Double.isNaN(initial)) {
-            String msg = "SAMPLE_IF_TRUE initialValue evaluated to NaN at compile time; using 0.0";
-            logger.warn(msg);
-            context.addWarning(msg);
-            initial = 0.0;
-        }
+        DoubleSupplier initial = compileInitialValue(args.get(2), "SAMPLE_IF_TRUE initialValue");
         SampleIfTrue sampler = SampleIfTrue.of(condition, input, initial,
                 context.getCurrentStep());
         resettables.add(sampler);
@@ -1181,6 +1139,28 @@ public class ExprCompiler {
             double elseVal = elseExpr.getAsDouble();
             return condVal != 0 ? thenVal : elseVal;
         };
+    }
+
+    /**
+     * Compiles an initial-value expression. If the expression is a compile-time constant,
+     * returns a supplier wrapping that constant. Otherwise, returns the compiled expression
+     * as a supplier — deferring evaluation to simulation start when all model elements
+     * are initialized through holder indirection.
+     */
+    private DoubleSupplier compileInitialValue(Expr expr, String paramDescription) {
+        try {
+            double constant = evaluateConstant(expr, paramDescription);
+            if (Double.isNaN(constant)) {
+                String msg = paramDescription + " evaluated to NaN; using 0.0";
+                logger.warn(msg);
+                context.addWarning(msg);
+                return () -> 0.0;
+            }
+            return () -> constant;
+        } catch (CompilationException e) {
+            // Defer evaluation to simulation start when holders are filled
+            return compileExpr(expr);
+        }
     }
 
     /**

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ExprCompilerTest.java
@@ -1300,7 +1300,7 @@ class ExprCompilerTest {
         }
 
         @Test
-        void shouldWarnWhenInitialValueIsNotCompileTimeConstant() {
+        void shouldDeferNonConstantInitialValueWithoutWarning() {
             context.addVariable("normal_price",
                     new systems.courant.sd.model.Variable("normal_price",
                             ItemUnits.PEOPLE, () -> 50.0));
@@ -1308,11 +1308,13 @@ class ExprCompilerTest {
                     new systems.courant.sd.model.Variable("input",
                             ItemUnits.PEOPLE, () -> 100.0));
 
-            compiler.compile("SMOOTHI(input, 5, normal_price)");
+            Formula formula = compiler.compile("SMOOTHI(input, 5, normal_price)");
+            // No warning — non-constant initial values are now properly deferred
             assertThat(context.getWarnings())
-                    .anyMatch(w -> w.contains("SMOOTHI initialValue")
-                            && w.contains("not a compile-time constant")
-                            && w.contains("uninitialized variables"));
+                    .noneMatch(w -> w.contains("SMOOTHI initialValue"));
+            // Initial value should be 50 (from normal_price), not 0
+            step[0] = 0;
+            assertThat(formula.getCurrentValue()).isCloseTo(50.0, within(0.01));
         }
     }
 

--- a/courant-engine/src/test/java/systems/courant/sd/model/compile/ModelCompilerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/compile/ModelCompilerTest.java
@@ -779,6 +779,37 @@ class ModelCompilerTest {
     }
 
     @Nested
+    @DisplayName("SMOOTH initial value references model elements (issue #1364)")
+    class SmoothInitialValueDeferred {
+
+        @Test
+        void shouldUseDeferredInitialValueReferencingStock() {
+            // SMOOTH initial value references a stock — must be deferred to simulation
+            // start, not evaluated at compile time when holders are uninitialized.
+            ModelDefinition def = new ModelDefinitionBuilder()
+                    .name("Deferred Init")
+                    .stock("Level", 50, "Thing")
+                    .variable("SmoothedLevel", "SMOOTH(Level, 5, Level)", "Thing")
+                    .flow("Drain", "SmoothedLevel * 0.1", "Day", "Level", null)
+                    .defaultSimulation("Day", 10, "Day")
+                    .build();
+
+            CompiledModel compiled = compiler.compile(def);
+            // Run the simulation — the SMOOTH should start at Level's initial value (50)
+            Simulation sim = compiled.createSimulation();
+            sim.execute();
+
+            // If initial was wrongly evaluated at compile time (0.0), the SMOOTH starts
+            // far below the stock and the drain starts near 0, leaving the stock high.
+            // With correct deferral, SMOOTH starts at 50, so drain starts at 5.0/step.
+            Stock level = findStock(compiled.getModel(), "Level");
+            assertThat(level.getValue())
+                    .as("SMOOTH initial=Level should start at 50, not 0")
+                    .isLessThan(40.0);
+        }
+    }
+
+    @Nested
     @DisplayName("savePer does not affect numerical accuracy (issue #1363)")
     class SavePerAccuracy {
 


### PR DESCRIPTION
## Summary
- `evaluateAtCompileTime()` fell back to immediately evaluating non-constant initial value expressions against uninitialized model state, producing 0.0 instead of the intended value
- Added `compileInitialValue()` that returns a `DoubleSupplier` — constants are wrapped in a lambda, non-constants are deferred to first `getCurrentValue()` call when all holders are filled
- Changed `Smooth`, `Smooth3`, `Delay1`, `Delay3`, and `SampleIfTrue` to store initial values as `DoubleSupplier` (following the existing `DelayFixed` pattern)

## Test plan
- [x] Regression test: SMOOTH with initial value referencing a stock gets the stock's initial value (50), not 0
- [x] Updated ExprCompilerTest to verify non-constant initials are deferred without warning
- [x] All tests pass
- [x] SpotBugs clean

Closes #1364