### PR TITLE
Guard ComboBox filter against programmatic updates

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormFieldBuilder.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/forms/FormFieldBuilder.java
@@ -347,6 +347,9 @@ public class FormFieldBuilder {
         GridPane.setHgrow(box, Priority.ALWAYS);
 
         box.getEditor().textProperty().addListener((obs, oldText, newText) -> {
+            if (ctx.isUpdatingFields()) {
+                return;
+            }
             if (newText == null || newText.isEmpty()) {
                 box.setItems(FXCollections.observableArrayList(allItems));
                 return;


### PR DESCRIPTION
## Summary
- Added `ctx.isUpdatingFields()` guard to the filterable ComboBox text listener in `FormFieldBuilder`
- Prevents `setItems()` from firing during form rebuilds and programmatic `setValue()` calls, which was breaking the ComboBox editor's text synchronization
- Fixes the unit field becoming uneditable after changing from undefined to a value

Closes #1418