### PR TITLE
Suppress empty loop elements popup

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/LoopNavigatorBar.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/LoopNavigatorBar.java
@@ -209,6 +209,9 @@ public class LoopNavigatorBar extends HBox {
         content.setStyle("-fx-background-color: white;");
 
         List<String> path = loop.path();
+        if (path.isEmpty()) {
+            return;
+        }
         if (isSFGroup) {
             // S&F feedback group: plain list of stocks (no polarity)
             for (String stock : path) {


### PR DESCRIPTION
## Summary
- Added early return in `showElementsPopup` when the loop path is empty, preventing a utility window from appearing with just a title and no content
- Also benefits from the ComboBox filter guard added in #1422 which prevents spurious ComboBox dropdowns during form rebuilds

Closes #1417