### PR TITLE
Add Courant nomenclature cross-references to glossary

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/Glossary.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/Glossary.java
@@ -30,6 +30,7 @@ public final class Glossary {
     public record Entry(
             String term,
             List<String> aliases,
+            String courantTerm,
             String definition,
             String relevance,
             List<String> related
@@ -38,12 +39,14 @@ public final class Glossary {
         public Entry(
                 @JsonProperty("term") String term,
                 @JsonProperty("aliases") List<String> aliases,
+                @JsonProperty("courantTerm") String courantTerm,
                 @JsonProperty("definition") String definition,
                 @JsonProperty("relevance") String relevance,
                 @JsonProperty("related") List<String> related
         ) {
             this.term = term;
             this.aliases = aliases != null ? List.copyOf(aliases) : List.of();
+            this.courantTerm = courantTerm;
             this.definition = definition;
             this.relevance = relevance;
             this.related = related != null ? List.copyOf(related) : List.of();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/GlossaryPane.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/GlossaryPane.java
@@ -102,6 +102,15 @@ public final class GlossaryPane extends VBox {
         termText.setStyle("-fx-font-weight: bold; -fx-font-size: 14px;");
         TextFlow heading = new TextFlow(termText);
 
+        // Courant term
+        if (entry.courantTerm() != null && !entry.courantTerm().isEmpty()) {
+            Text courantLabel = new Text("  In Courant: ");
+            courantLabel.setStyle("-fx-fill: #0066cc;");
+            Text courantText = new Text(entry.courantTerm());
+            courantText.setStyle("-fx-fill: #0066cc; -fx-font-weight: bold;");
+            heading.getChildren().addAll(courantLabel, courantText);
+        }
+
         // Aliases
         if (!entry.aliases().isEmpty()) {
             Text aliasLabel = new Text("  Also: ");

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SdConceptsDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/SdConceptsDialog.java
@@ -98,7 +98,7 @@ public class SdConceptsDialog extends AbstractTutorialDialog {
                         + "an outflow to a cloud means it leaves the model.\n\n"),
                 bold("Flow equations"),
                 plain(" define how fast material moves. They typically depend on stocks, "
-                        + "variables, and constants. For example, a death rate flow might be:\n\n"),
+                        + "variables, and parameters. For example, a death rate flow might be:\n\n"),
                 plain("  deaths = population * mortality_rate\n\n"),
                 plain("The diamond symbol on the diagram represents the flow valve, "
                         + "which controls the rate. The thick pipe shows the path material travels.")

--- a/courant-app/src/main/resources/sd-glossary.json
+++ b/courant-app/src/main/resources/sd-glossary.json
@@ -16,22 +16,25 @@
   {
     "term": "Auxiliary",
     "aliases": ["Converter", "Variable"],
+    "courantTerm": "Variable",
     "definition": "An intermediate variable used to compute values that feed into flows or other auxiliaries. Auxiliaries do not accumulate.",
-    "relevance": "Auxiliaries break complex equations into understandable pieces and make model logic transparent.",
+    "relevance": "Auxiliaries break complex equations into understandable pieces and make model logic transparent. In Courant, both auxiliaries and constants are represented as Variable elements.",
     "related": ["Flow", "Constant", "Connector"]
   },
   {
     "term": "Constant",
     "aliases": ["Parameter"],
+    "courantTerm": "Variable",
     "definition": "A model element whose value does not change during a simulation run. Constants represent fixed assumptions or parameters.",
-    "relevance": "Constants capture assumptions that can be varied across scenarios, sensitivity analyses, or optimization runs.",
+    "relevance": "Constants capture assumptions that can be varied across scenarios, sensitivity analyses, or optimization runs. In Courant, constants are Variable elements whose equation is a single numeric literal.",
     "related": ["Auxiliary", "Parameter Sweep", "Sensitivity Analysis"]
   },
   {
     "term": "Connector",
-    "aliases": ["Information Link", "Causal Arrow"],
+    "aliases": ["Information Link", "Info Link", "Causal Arrow"],
+    "courantTerm": "Info Link",
     "definition": "An arrow indicating that one variable's value is used in the equation of another. Connectors carry information, not material.",
-    "relevance": "Connectors make the causal structure of a model explicit, showing which variables influence which equations.",
+    "relevance": "Connectors make the causal structure of a model explicit, showing which variables influence which equations. In Courant, these are called Info Links.",
     "related": ["Auxiliary", "Flow", "Causal Loop Diagram"]
   },
   {

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/GlossaryTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/GlossaryTest.java
@@ -78,6 +78,24 @@ class GlossaryTest {
         }
 
         @Test
+        @DisplayName("should find Connector by Info Link alias")
+        void shouldFindConnectorByInfoLinkAlias() {
+            Optional<Glossary.Entry> entry = Glossary.instance().lookup("Info Link");
+            assertThat(entry).isPresent();
+            assertThat(entry.get().term()).isEqualTo("Connector");
+            assertThat(entry.get().courantTerm()).isEqualTo("Info Link");
+        }
+
+        @Test
+        @DisplayName("should have courantTerm on entries with Courant-specific names")
+        void shouldHaveCourantTermWhereApplicable() {
+            Glossary glossary = Glossary.instance();
+            assertThat(glossary.lookup("Connector").get().courantTerm()).isEqualTo("Info Link");
+            assertThat(glossary.lookup("Auxiliary").get().courantTerm()).isEqualTo("Variable");
+            assertThat(glossary.lookup("Constant").get().courantTerm()).isEqualTo("Variable");
+        }
+
+        @Test
         @DisplayName("should be case-insensitive")
         void shouldBeCaseInsensitive() {
             assertThat(Glossary.instance().lookup("stock")).isPresent();


### PR DESCRIPTION
## Summary
- Added `courantTerm` field to glossary entries linking standard SD terms to Courant equivalents
- Connector → Info Link, Auxiliary → Variable, Constant → Variable
- GlossaryPane now displays "In Courant: X" for entries with Courant-specific names
- Added "Info Link" as alias for Connector so users can search by either term
- Fixed SdConceptsDialog to say "parameters" instead of "constants"

Closes #1421