### PR TITLE
Add simulation tools tutorials (Phase 5, #881)

### DIFF
--- a/courant-app/src/main/resources/tutorials/curriculum.json
+++ b/courant-app/src/main/resources/tutorials/curriculum.json
@@ -36,21 +36,21 @@
           "name": "Core Simulation",
           "description": "Simulation settings, execution, and reading results",
           "recommendedPrerequisites": ["modeling-foundations"],
-          "tutorials": []
+          "tutorials": ["sim-settings", "reading-results"]
         },
         {
           "id": "sim-exploration",
           "name": "Exploration & Sensitivity",
           "description": "Parameter sweeps, multi-sweeps, and Monte Carlo analysis",
           "recommendedPrerequisites": ["sim-core"],
-          "tutorials": []
+          "tutorials": ["parameter-sweeps", "multi-sweeps", "monte-carlo"]
         },
         {
           "id": "sim-optimization",
           "name": "Optimization & Calibration",
           "description": "Optimization, calibration, and full workflow",
           "recommendedPrerequisites": ["sim-exploration"],
-          "tutorials": []
+          "tutorials": ["optimization", "calibration", "putting-together"]
         }
       ]
     }

--- a/courant-app/src/main/resources/tutorials/simulation/calibration.json
+++ b/courant-app/src/main/resources/tutorials/simulation/calibration.json
@@ -1,0 +1,19 @@
+{
+  "id": "calibration",
+  "title": "Calibration",
+  "description": "Fit model parameters to historical data. Learn to set up reference data, define payoff functions, and evaluate goodness of fit.",
+  "difficulty": "advanced",
+  "estimatedMinutes": 20,
+  "model": null,
+  "recommendedPrerequisites": ["optimization"],
+  "steps": [
+    { "title": "What is Calibration?", "content": "calibration/01-what-is-calibration.md" },
+    { "title": "Reference Data", "content": "calibration/02-reference-data.md" },
+    { "title": "Payoff Functions", "content": "calibration/03-payoff-functions.md" },
+    { "title": "Running Calibration", "content": "calibration/04-running.md" },
+    { "title": "Evaluating Fit", "content": "calibration/05-evaluating-fit.md" },
+    { "title": "Pitfalls", "content": "calibration/06-pitfalls.md" },
+    { "title": "Key Takeaways", "content": "calibration/07-key-takeaways.md" }
+  ],
+  "nextTutorial": "putting-together"
+}

--- a/courant-app/src/main/resources/tutorials/simulation/calibration/01-what-is-calibration.md
+++ b/courant-app/src/main/resources/tutorials/simulation/calibration/01-what-is-calibration.md
@@ -1,0 +1,11 @@
+## Matching the model to reality
+
+**Calibration** adjusts model parameters so that simulation output matches historical data. It's a specialized form of optimization where the objective is: *reproduce observed behavior as closely as possible.*
+
+## Why calibrate?
+
+Models contain parameters whose true values are uncertain. Calibration uses real-world data to pin down those values, building confidence that the model captures the dynamics of the system it represents.
+
+## A word of caution
+
+A calibrated model is not necessarily a correct model. If you have enough free parameters, you can fit almost any data -- including noise. The goal is not a perfect numerical match. The goal is a model that reproduces behavior for the right **structural** reasons, so it remains valid under new conditions.

--- a/courant-app/src/main/resources/tutorials/simulation/calibration/02-reference-data.md
+++ b/courant-app/src/main/resources/tutorials/simulation/calibration/02-reference-data.md
@@ -1,0 +1,20 @@
+## Historical data for comparison
+
+**Reference data** is the historical time series you want the model to match. It provides the ground truth that the calibrator measures against.
+
+## Importing reference data
+
+Import reference data via **File --> Import --> Reference Data**. The expected format is CSV with:
+
+- A **time column** matching the model's time units
+- One or more **data columns**, each corresponding to a model variable
+
+## Mapping data to variables
+
+After import, map each data column to a model variable. The calibrator will compare the simulated value of that variable to the reference value at each data point.
+
+## Data quality matters
+
+- Ensure the time column aligns with the model's time horizon
+- Check for missing values or obvious outliers
+- If possible, hold out a portion of the data for validation -- use one subset for calibration and the other to test whether the calibrated model predicts well

--- a/courant-app/src/main/resources/tutorials/simulation/calibration/03-payoff-functions.md
+++ b/courant-app/src/main/resources/tutorials/simulation/calibration/03-payoff-functions.md
@@ -1,0 +1,17 @@
+## Measuring goodness of fit
+
+The **payoff function** quantifies how well the model's output matches the reference data. The calibrator minimizes this function by adjusting parameters.
+
+## Common payoff functions
+
+- **Mean Squared Error (MSE)** -- averages the squared differences between simulated and observed values. Penalizes large errors heavily, making it sensitive to outliers.
+- **Mean Absolute Error (MAE)** -- averages the absolute differences. Treats all errors equally, making it more robust to outliers than MSE.
+- **Mean Absolute Percentage Error (MAPE)** -- normalizes each error by the observed value. Useful when variables have very different scales or magnitudes.
+
+## Choosing a payoff function
+
+Use **MSE** when large deviations are especially undesirable. Use **MAE** when you want a balanced view of all errors. Use **MAPE** when comparing fit quality across variables with different units or magnitudes.
+
+## Multiple variables
+
+When calibrating against more than one data series, the payoff function combines errors across all mapped variables. Ensure the variables are on comparable scales, or use MAPE to normalize automatically.

--- a/courant-app/src/main/resources/tutorials/simulation/calibration/04-running.md
+++ b/courant-app/src/main/resources/tutorials/simulation/calibration/04-running.md
@@ -1,0 +1,23 @@
+## Setting up a calibration run
+
+Open **Simulate --> Calibration**. The setup has three parts:
+
+- **Parameters** -- select the parameters to calibrate and set bounds for each
+- **Reference data** -- select the imported data series and confirm variable mappings
+- **Payoff function** -- choose MSE, MAE, or MAPE
+
+Click **Run** to start.
+
+## What happens during calibration
+
+The calibrator is an optimizer that minimizes the payoff function. It adjusts the selected parameters, runs the simulation, computes the payoff, and repeats. Progress shows:
+
+- The **current best payoff** value
+- The **number of runs** completed
+- The **current parameter values** being tested
+
+Calibration typically requires hundreds of runs, especially with multiple parameters.
+
+## When to stop
+
+The calibrator stops automatically when the payoff function converges. You can also stop early if the payoff has plateaued at an acceptable level. The best parameter set found so far is preserved.

--- a/courant-app/src/main/resources/tutorials/simulation/calibration/05-evaluating-fit.md
+++ b/courant-app/src/main/resources/tutorials/simulation/calibration/05-evaluating-fit.md
@@ -1,0 +1,19 @@
+## Visual inspection
+
+Overlay the calibrated simulation on the reference data. The most important check is visual: does the model capture the **pattern** of the data?
+
+Look for:
+
+- **Shape** -- does the trajectory rise, fall, and curve in the same way?
+- **Timing** -- do peaks, troughs, and turning points occur at the right times?
+- **Magnitude** -- are the levels approximately right?
+
+## Structural fit vs. numerical fit
+
+A perfect numerical match is not the goal. In fact, it's often a warning sign of overfitting. The goal is **structural fit** -- the model reproduces the observed behavior because it captures the right causal mechanisms.
+
+A structurally valid model will continue to perform well under new conditions. An overfit model will not.
+
+## Holdout validation
+
+If you reserved a portion of data for validation, run the calibrated model against it now. Good performance on unseen data is the strongest evidence that the calibration is meaningful.

--- a/courant-app/src/main/resources/tutorials/simulation/calibration/06-pitfalls.md
+++ b/courant-app/src/main/resources/tutorials/simulation/calibration/06-pitfalls.md
@@ -1,0 +1,19 @@
+## Overfitting
+
+Too many free parameters can fit any data, including noise. Every additional calibrated parameter adds flexibility that may not be warranted. Keep the number of calibrated parameters to a minimum -- calibrate only the parameters you genuinely don't know.
+
+## Multiple fits
+
+Different parameter combinations can produce nearly identical fit to the data but generate very different forecasts. Test robustness by calibrating from **multiple starting points**. If different starting points yield different parameter values but similar fit quality, the model may be structurally ambiguous.
+
+## Compensating errors
+
+One wrong parameter value can be masked by another wrong parameter value. The fit looks good, but the individual parameters are meaningless. Guard against this by:
+
+- Validating individual parameter values against independent data or expert judgment
+- Checking that each parameter falls within a physically plausible range
+- Examining whether the model's internal behavior (not just its output) makes sense
+
+## The cure
+
+Fewer free parameters, stronger bounds, and independent validation are the best defenses against all three pitfalls.

--- a/courant-app/src/main/resources/tutorials/simulation/calibration/07-key-takeaways.md
+++ b/courant-app/src/main/resources/tutorials/simulation/calibration/07-key-takeaways.md
@@ -1,0 +1,12 @@
+## What to remember
+
+- **Calibration** adjusts parameters so the model matches historical data
+- Import **reference data** as CSV and map columns to model variables
+- The **payoff function** (MSE, MAE, or MAPE) measures fit quality -- choose one that matches your priorities
+- Evaluate **structural fit**, not just numerical match -- the model should reproduce behavior for the right reasons
+- Guard against **overfitting** by minimizing the number of free parameters
+- Watch for **compensating errors** and **multiple fits** -- validate parameters independently
+
+## Next steps
+
+The next tutorial, **Putting It All Together**, walks through the complete system dynamics workflow from model building to presenting findings.

--- a/courant-app/src/main/resources/tutorials/simulation/monte-carlo.json
+++ b/courant-app/src/main/resources/tutorials/simulation/monte-carlo.json
@@ -1,0 +1,19 @@
+{
+  "id": "monte-carlo",
+  "title": "Monte Carlo Analysis",
+  "description": "Run hundreds of simulations with randomly sampled parameters. Learn to configure distributions, interpret confidence bands, and assess risk.",
+  "difficulty": "intermediate",
+  "estimatedMinutes": 20,
+  "model": "introductory/coffee-cooling.json",
+  "recommendedPrerequisites": ["multi-sweeps"],
+  "steps": [
+    { "title": "What is Monte Carlo?", "content": "monte-carlo/01-what-is-monte-carlo.md" },
+    { "title": "Distributions", "content": "monte-carlo/02-distributions.md" },
+    { "title": "Running the Analysis", "content": "monte-carlo/03-running.md" },
+    { "title": "Confidence Bands", "content": "monte-carlo/04-confidence-bands.md" },
+    { "title": "Sample Size", "content": "monte-carlo/05-sample-size.md" },
+    { "title": "Experiment", "content": "monte-carlo/06-experiment.md" },
+    { "title": "Key Takeaways", "content": "monte-carlo/07-key-takeaways.md" }
+  ],
+  "nextTutorial": "optimization"
+}

--- a/courant-app/src/main/resources/tutorials/simulation/monte-carlo/01-what-is-monte-carlo.md
+++ b/courant-app/src/main/resources/tutorials/simulation/monte-carlo/01-what-is-monte-carlo.md
@@ -1,0 +1,11 @@
+## From grids to random sampling
+
+**Monte Carlo analysis** runs the model hundreds or thousands of times, each time sampling parameter values randomly from specified distributions.
+
+Unlike sweeps, which test a fixed grid of values, Monte Carlo explores the full parameter space probabilistically. Each run draws a fresh set of parameter values, so the analysis naturally covers combinations that a grid might miss.
+
+The result is not a single answer but a **distribution of outcomes** -- a range of possibilities with associated likelihoods. This lets you answer questions like:
+
+- What is the most likely outcome?
+- What is the worst case with 90% confidence?
+- How much uncertainty in the inputs translates to uncertainty in the output?

--- a/courant-app/src/main/resources/tutorials/simulation/monte-carlo/02-distributions.md
+++ b/courant-app/src/main/resources/tutorials/simulation/monte-carlo/02-distributions.md
@@ -1,0 +1,9 @@
+## Describe what you know (and don't know)
+
+Each uncertain parameter gets a **probability distribution** that encodes your knowledge about its plausible values.
+
+- **Uniform** -- equally likely anywhere in a range. Use when you only know the bounds (e.g., cooling rate is somewhere between 0.05 and 0.20).
+- **Normal** -- bell curve centered on a mean with a standard deviation. Use when you have a best estimate and a sense of how much it could vary (e.g., room temperature is about 20 with a standard deviation of 3).
+- **Triangular** -- defined by a minimum, most likely value, and maximum. Use when you have an expert estimate with asymmetric bounds (e.g., cooling rate is most likely 0.10, but could be as low as 0.05 or as high as 0.25).
+
+Choose the distribution that best matches what you actually know. When in doubt, uniform is the most conservative -- it assumes the least.

--- a/courant-app/src/main/resources/tutorials/simulation/monte-carlo/03-running.md
+++ b/courant-app/src/main/resources/tutorials/simulation/monte-carlo/03-running.md
@@ -1,0 +1,20 @@
+## Configure and run
+
+Go to **Simulate -> Monte Carlo**. The dialog lists the model's parameters.
+
+For each uncertain parameter:
+
+- Click **Add Parameter**
+- Select the parameter name
+- Choose a **distribution type** (uniform, normal, or triangular)
+- Enter the distribution parameters (min/max, mean/std dev, or min/mode/max)
+
+Set the **number of runs**. Start with **200** for a quick look, then increase for precision.
+
+Click **Run**. The engine samples each parameter from its distribution, runs the model, and collects results. Progress is shown in the status bar.
+
+## Example setup for the coffee model
+
+- `Cooling_Rate`: uniform, min `0.05`, max `0.20`
+- `Room_Temperature`: normal, mean `20`, std dev `3`
+- Runs: `200`

--- a/courant-app/src/main/resources/tutorials/simulation/monte-carlo/04-confidence-bands.md
+++ b/courant-app/src/main/resources/tutorials/simulation/monte-carlo/04-confidence-bands.md
@@ -1,0 +1,14 @@
+## Read the results
+
+Monte Carlo results are shown as **confidence bands** -- shaded regions around the median trajectory.
+
+- The **50% band** shows where half the runs fell. There is a 50% chance the true outcome lies within this region.
+- The **90% band** shows the range for 90% of runs. Only 5% of runs fell above the band and 5% below.
+- The **median line** shows the central tendency across all runs.
+
+## What the bands tell you
+
+- A **wide band** means high uncertainty -- the outcome depends heavily on parameters you don't know precisely
+- A **narrow band** means the outcome is **robust** -- it doesn't change much despite parameter uncertainty
+- If the band is wide early but narrows later, uncertainty resolves over time (common in systems that converge to equilibrium)
+- If the band widens over time, small uncertainties amplify -- the system is chaotically sensitive

--- a/courant-app/src/main/resources/tutorials/simulation/monte-carlo/05-sample-size.md
+++ b/courant-app/src/main/resources/tutorials/simulation/monte-carlo/05-sample-size.md
@@ -1,0 +1,20 @@
+## How many runs are enough?
+
+More runs produce smoother bands and more precise percentile estimates.
+
+- **200 runs** -- gives a rough picture; good for initial exploration
+- **500-1000 runs** -- gives stable confidence intervals; suitable for most analyses
+- **Beyond 1000 runs** -- returns diminish; the bands won't change noticeably
+
+## Signs you need more runs
+
+If the confidence bands still look **jagged or unstable** at 500 runs, one of two things is happening:
+
+- You need more runs to smooth out sampling noise
+- The model has **chaotic sensitivity** -- small parameter changes cause disproportionately large outcome changes
+
+To distinguish: double the run count. If the bands smooth out, you just needed more samples. If they remain jagged, investigate which parameters cause the instability using single-parameter sweeps.
+
+## Balancing speed and precision
+
+Each run takes the same time as a single simulation. Plan accordingly for complex models -- 1000 runs of a 30-second model takes 8+ hours. Start small and scale up.

--- a/courant-app/src/main/resources/tutorials/simulation/monte-carlo/06-experiment.md
+++ b/courant-app/src/main/resources/tutorials/simulation/monte-carlo/06-experiment.md
@@ -1,0 +1,15 @@
+## Try it yourself
+
+Run these Monte Carlo experiments on the coffee cooling model:
+
+- **Full uncertainty**: Set `Cooling_Rate` to uniform [0.05, 0.20] and `Room_Temperature` to normal [20, 3]. Run 500 times. How wide is the 90% confidence band at the end of the simulation?
+
+- **Reduce one source of uncertainty**: Fix `Cooling_Rate` at its default value and re-run with only `Room_Temperature` uncertain. How much does the band narrow?
+
+- **Compare**: The difference in band width tells you which parameter contributes more uncertainty to the final outcome. This is the Monte Carlo equivalent of sensitivity analysis.
+
+## Questions to consider
+
+- Which parameter drives most of the output uncertainty?
+- Does the 90% band include qualitatively different behaviors, or just quantitative variation?
+- How would you use these results to prioritize data collection?

--- a/courant-app/src/main/resources/tutorials/simulation/monte-carlo/07-key-takeaways.md
+++ b/courant-app/src/main/resources/tutorials/simulation/monte-carlo/07-key-takeaways.md
@@ -1,0 +1,17 @@
+## What you learned
+
+- **Monte Carlo analysis** explores parameter uncertainty probabilistically by running hundreds of simulations with randomly sampled inputs
+- **Distributions** (uniform, normal, triangular) encode what you know about each uncertain parameter
+- **Confidence bands** show the range of possible outcomes -- wide bands mean high uncertainty, narrow bands mean robust outcomes
+- **Sample size** affects precision: 200 runs for exploration, 500-1000 for stable results
+- Monte Carlo identifies which uncertainties matter most for the outcome, guiding data collection and risk assessment
+
+## Behavior modes seen
+
+- Stochastic variation in trajectories
+- Convergence of confidence bands at equilibrium
+
+## Try next
+
+- Apply Monte Carlo to a model with stronger nonlinearity to see how small input uncertainties can produce large output uncertainty
+- Combine Monte Carlo with **optimization** (next tutorial) to find robust strategies that perform well across a range of uncertainties

--- a/courant-app/src/main/resources/tutorials/simulation/multi-sweeps.json
+++ b/courant-app/src/main/resources/tutorials/simulation/multi-sweeps.json
@@ -1,0 +1,18 @@
+{
+  "id": "multi-sweeps",
+  "title": "Multi-Parameter Sweeps",
+  "description": "Sweep multiple parameters simultaneously to explore interaction effects and build scenario matrices.",
+  "difficulty": "intermediate",
+  "estimatedMinutes": 15,
+  "model": "introductory/coffee-cooling.json",
+  "recommendedPrerequisites": ["parameter-sweeps"],
+  "steps": [
+    { "title": "Why Multiple Parameters?", "content": "multi-sweeps/01-why-multiple.md" },
+    { "title": "Setting Up", "content": "multi-sweeps/02-setting-up.md" },
+    { "title": "Combinatorial Explosion", "content": "multi-sweeps/03-combinatorial.md" },
+    { "title": "Interaction Effects", "content": "multi-sweeps/04-interaction-effects.md" },
+    { "title": "Scenario Matrices", "content": "multi-sweeps/05-scenario-matrices.md" },
+    { "title": "Key Takeaways", "content": "multi-sweeps/06-key-takeaways.md" }
+  ],
+  "nextTutorial": "monte-carlo"
+}

--- a/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/01-why-multiple.md
+++ b/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/01-why-multiple.md
@@ -1,0 +1,7 @@
+## Parameters don't act alone
+
+Single-parameter sweeps hold everything else fixed. This is useful but incomplete -- in real systems, parameters often **interact**. The effect of one parameter depends on the value of another.
+
+For example, in the coffee model: does the cooling rate matter equally whether the room is cold or warm? A single sweep of `Cooling_Rate` can't answer that because it tests only one room temperature.
+
+**Multi-parameter sweeps** vary two or more parameters simultaneously, revealing **interaction effects** that single sweeps miss. If parameters interact, analyzing them one at a time can be misleading.

--- a/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/02-setting-up.md
+++ b/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/02-setting-up.md
@@ -1,0 +1,14 @@
+## Add a second swept parameter
+
+In **Simulate -> Parameter Sweep**, click **Add Parameter** to sweep a second parameter alongside the first.
+
+Each parameter gets its own configuration:
+
+- **Parameter 1**: `Cooling_Rate` -- min `0.05`, max `0.25`, steps `5`
+- **Parameter 2**: `Room_Temperature` -- min `10`, max `30`, steps `5`
+
+Click **Run**. The engine runs every combination of values: 5 steps times 5 steps = **25 runs** total.
+
+## How combinations are generated
+
+The sweep forms a grid. Each point in the grid is a unique combination of parameter values. For two parameters with 5 steps each, the grid has 25 cells. For three parameters with 5 steps each, it has 125 cells. Each cell is one simulation run.

--- a/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/03-combinatorial.md
+++ b/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/03-combinatorial.md
@@ -1,0 +1,17 @@
+## Combinations multiply fast
+
+Adding parameters multiplies the number of runs:
+
+- **1 parameter**, 10 steps = 10 runs
+- **2 parameters**, 10 steps each = 100 runs
+- **3 parameters**, 10 steps each = 1,000 runs
+- **4 parameters**, 10 steps each = 10,000 runs
+
+This **combinatorial explosion** means exhaustive sweeps become impractical beyond 2-3 parameters.
+
+## Practical guidelines
+
+- Start with **3-5 steps** per parameter when sweeping multiple parameters
+- If you need more detail, increase the step count for **one parameter at a time** to see where it matters
+- For **4 or more** uncertain parameters, consider switching to Monte Carlo analysis (next tutorial) instead of exhaustive grid sweeps
+- Watch the total run count displayed in the sweep dialog before clicking **Run**

--- a/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/04-interaction-effects.md
+++ b/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/04-interaction-effects.md
@@ -1,0 +1,14 @@
+## Detecting interactions
+
+An **interaction effect** means the influence of one parameter changes depending on the value of another.
+
+To check for interactions, compare the fan chart shape at different slices:
+
+- Filter the results to show only runs where `Room_Temperature` is low (10). Look at how `Cooling_Rate` affects the outcome.
+- Filter again for high `Room_Temperature` (30). Does `Cooling_Rate` have the same effect?
+
+If the fan shape changes -- wider in one case, narrower in the other, or shifted in a different direction -- the parameters **interact**. You cannot analyze them independently.
+
+## Why interactions matter
+
+If parameters interact, single-parameter sensitivity results can be misleading. A parameter might appear insensitive when tested at the default value of another, but highly sensitive at a different value. Multi-parameter sweeps catch this.

--- a/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/05-scenario-matrices.md
+++ b/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/05-scenario-matrices.md
@@ -1,0 +1,19 @@
+## Structure exploration with scenarios
+
+A **scenario matrix** is a multi-parameter sweep with deliberately chosen, named combinations rather than a uniform grid. Common scenarios include:
+
+- **Best case** -- favorable values for all key parameters
+- **Worst case** -- unfavorable values for all key parameters
+- **Most likely** -- best estimates for each parameter
+- **Mixed cases** -- favorable on one dimension, unfavorable on another
+
+## Building a scenario matrix
+
+Define 2-3 meaningful values per parameter (not 10). Run all combinations. This gives decision-makers a structured, interpretable view of possible outcomes.
+
+For the coffee model, you might define:
+
+- `Cooling_Rate`: slow (0.05), medium (0.10), fast (0.20)
+- `Room_Temperature`: cold room (10), warm room (25)
+
+Six combinations, each with a clear physical interpretation. This is easier to communicate than a 100-run grid.

--- a/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/06-key-takeaways.md
+++ b/courant-app/src/main/resources/tutorials/simulation/multi-sweeps/06-key-takeaways.md
@@ -1,0 +1,16 @@
+## What you learned
+
+- **Multi-parameter sweeps** vary two or more parameters simultaneously, revealing interaction effects that single sweeps miss
+- **Interaction effects** mean one parameter's influence depends on another's value -- you can't analyze them independently
+- **Combinatorial explosion** makes exhaustive sweeps impractical beyond 2-3 parameters -- be conservative with step counts
+- **Scenario matrices** use named, meaningful combinations to communicate structured results to decision-makers
+
+## Behavior modes seen
+
+- Parameter interactions in coupled systems
+- Convergence toward equilibrium across all scenarios
+
+## Try next
+
+- Use **Monte Carlo analysis** (next tutorial) to explore many uncertain parameters simultaneously without exhaustive grids
+- Apply multi-sweeps to a more complex model to see stronger interaction effects

--- a/courant-app/src/main/resources/tutorials/simulation/optimization.json
+++ b/courant-app/src/main/resources/tutorials/simulation/optimization.json
@@ -1,0 +1,19 @@
+{
+  "id": "optimization",
+  "title": "Optimization",
+  "description": "Find the best parameter values to achieve a goal. Learn to define objective functions, decision variables, and constraints.",
+  "difficulty": "advanced",
+  "estimatedMinutes": 20,
+  "model": "introductory/coffee-cooling.json",
+  "recommendedPrerequisites": ["monte-carlo"],
+  "steps": [
+    { "title": "What is Optimization?", "content": "optimization/01-what-is-optimization.md" },
+    { "title": "Decision Variables", "content": "optimization/02-decision-variables.md" },
+    { "title": "Objective Functions", "content": "optimization/03-objective-functions.md" },
+    { "title": "Constraints", "content": "optimization/04-constraints.md" },
+    { "title": "Running the Optimizer", "content": "optimization/05-running.md" },
+    { "title": "Interpreting Results", "content": "optimization/06-interpreting.md" },
+    { "title": "Key Takeaways", "content": "optimization/07-key-takeaways.md" }
+  ],
+  "nextTutorial": "calibration"
+}

--- a/courant-app/src/main/resources/tutorials/simulation/optimization/01-what-is-optimization.md
+++ b/courant-app/src/main/resources/tutorials/simulation/optimization/01-what-is-optimization.md
@@ -1,0 +1,19 @@
+## Finding the best answer
+
+**Optimization** finds the parameter values that best achieve a goal. Instead of manually trying different values and eyeballing results, the optimizer searches systematically.
+
+## A concrete example
+
+Imagine you want the coffee to reach exactly 60 degrees at minute 10. You could guess a cooling rate, run the simulation, check the result, and try again. That works for one parameter, but becomes impractical for two or more.
+
+The optimizer automates this process:
+
+1. **Pick a value** for Cooling_Rate
+2. **Run the simulation** with that value
+3. **Check the result** -- how close is the temperature to 60 at minute 10?
+4. **Adjust** the value based on what it learned
+5. **Repeat** until it finds the best value
+
+## When to use optimization
+
+Optimization is the right tool when you have a clear goal and controllable parameters. It answers the question: *what's the best I can do?*

--- a/courant-app/src/main/resources/tutorials/simulation/optimization/02-decision-variables.md
+++ b/courant-app/src/main/resources/tutorials/simulation/optimization/02-decision-variables.md
@@ -1,0 +1,22 @@
+## What the optimizer can change
+
+**Decision variables** are the parameters the optimizer is allowed to adjust. They represent real decisions -- things you can actually control in the system being modeled.
+
+## Setting up decision variables
+
+Select decision variables in **Simulate --> Optimization**. For each variable, set upper and lower bounds:
+
+- **Cooling_Rate**: 0.01 to 0.50
+- **Room_Temperature**: 15 to 30
+
+The optimizer searches only within these bounds. Tight bounds focus the search but may exclude the true optimum. Wide bounds give more freedom but may slow convergence.
+
+## Choosing well
+
+Good decision variables are:
+
+- **Controllable** -- you can actually set their value in the real system
+- **Influential** -- changing them has a meaningful effect on the outcome
+- **Bounded** -- you know a reasonable range for each
+
+Avoid using internal model constants (like unit conversions) as decision variables. The optimizer will happily change them, but the results won't mean anything useful.

--- a/courant-app/src/main/resources/tutorials/simulation/optimization/03-objective-functions.md
+++ b/courant-app/src/main/resources/tutorials/simulation/optimization/03-objective-functions.md
@@ -1,0 +1,24 @@
+## Defining "best"
+
+The **objective function** tells the optimizer what "best" means. Without it, the optimizer has no direction -- it doesn't know whether to make values larger, smaller, or closer to a target.
+
+## Common objectives
+
+- **Minimize** the difference between a stock and a target at a specific time
+- **Minimize** total cost over the simulation horizon
+- **Maximize** throughput or efficiency
+- **Minimize** the peak value of an undesirable outcome
+
+## Setting the objective in Courant
+
+Define the objective as a variable in your model (or use an existing one), then select it as the optimization target in **Simulate --> Optimization**. Choose whether to **minimize** or **maximize**.
+
+For the coffee model, a useful objective might be:
+
+    Error = ABS(Coffee_Temperature - 60)
+
+evaluated at time 10. The optimizer minimizes this error by adjusting the decision variables.
+
+## One objective at a time
+
+Each optimization run uses a single objective. If you have multiple goals, combine them into a weighted sum or run separate optimizations and compare the trade-offs.

--- a/courant-app/src/main/resources/tutorials/simulation/optimization/04-constraints.md
+++ b/courant-app/src/main/resources/tutorials/simulation/optimization/04-constraints.md
@@ -1,0 +1,19 @@
+## Beyond variable bounds
+
+**Constraints** limit the search space in ways that variable bounds alone cannot express. They prevent the optimizer from finding solutions that are mathematically optimal but practically impossible.
+
+## Examples of constraints
+
+- Inventory must never drop below zero during the simulation
+- Total cost must stay under $1M
+- Temperature must remain above freezing at all times
+
+These are conditions on the **behavior** of the model, not just the values of individual parameters.
+
+## Why constraints matter
+
+Without constraints, the optimizer is free to exploit any loophole. It might find a "solution" that drains a stock negative, exceeds a physical limit, or violates a policy rule. Constraints keep the search grounded in reality.
+
+## Setting constraints in Courant
+
+Add constraints in **Simulate --> Optimization** alongside your decision variables and objective. Each constraint specifies a model variable, a condition (greater than, less than, or equal to), and a threshold value.

--- a/courant-app/src/main/resources/tutorials/simulation/optimization/05-running.md
+++ b/courant-app/src/main/resources/tutorials/simulation/optimization/05-running.md
@@ -1,0 +1,23 @@
+## Launching an optimization
+
+Open **Simulate --> Optimization**. You'll see three sections:
+
+- **Decision variables** -- select parameters and set bounds for each
+- **Objective** -- choose the target variable and whether to minimize or maximize
+- **Constraints** -- add any behavioral limits (optional)
+
+Click **Run** to start the optimizer.
+
+## What happens during a run
+
+The optimizer runs many simulations, adjusting decision variables between each run to improve the objective. The progress panel shows:
+
+- **Current best value** of the objective function
+- **Number of runs** completed so far
+- **Current parameter values** being tested
+
+The search may take dozens to hundreds of runs depending on the number of decision variables and the complexity of the model.
+
+## Stopping early
+
+If the objective value has plateaued and you're satisfied with the result, you can stop the optimizer early. The best solution found so far is preserved.

--- a/courant-app/src/main/resources/tutorials/simulation/optimization/06-interpreting.md
+++ b/courant-app/src/main/resources/tutorials/simulation/optimization/06-interpreting.md
@@ -1,0 +1,19 @@
+## Check the results critically
+
+Finding an optimal value is only the first step. You need to verify that the solution makes sense.
+
+## Physical plausibility
+
+Run the model with the optimal parameter values and inspect the behavior. Does the trajectory look reasonable? A mathematically optimal solution can still be physically nonsensical if the model or constraints are incomplete.
+
+## Boundary effects
+
+Are any optimal values sitting right at their bounds? That often means the true optimum lies outside the range you specified. Consider widening the bounds and re-running.
+
+## Local optima
+
+Optimization can get trapped in **local optima** -- solutions that are better than their neighbors but not the best overall. Try running the optimizer from different starting points. If you get different answers, the best one is more likely to be near the global optimum.
+
+## Sensitivity near the optimum
+
+Small changes near the optimum should produce small changes in the objective. If the objective is very sensitive to tiny parameter shifts, the solution may be fragile and hard to implement reliably in practice.

--- a/courant-app/src/main/resources/tutorials/simulation/optimization/07-key-takeaways.md
+++ b/courant-app/src/main/resources/tutorials/simulation/optimization/07-key-takeaways.md
@@ -1,0 +1,12 @@
+## What to remember
+
+- **Optimization** finds the best parameter values for a given objective, replacing trial-and-error with systematic search
+- **Decision variables** are the parameters the optimizer adjusts -- choose ones that represent real, controllable decisions
+- The **objective function** defines what "best" means -- minimize cost, maximize throughput, or hit a target
+- **Constraints** keep solutions grounded in reality by ruling out physically or practically impossible outcomes
+- Always **check results** for physical plausibility, boundary effects, and local optima
+- Run from **multiple starting points** to increase confidence that you've found the global optimum
+
+## Next steps
+
+The next tutorial covers **Calibration** -- a specialized form of optimization where the goal is to match historical data.

--- a/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps.json
+++ b/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps.json
@@ -1,0 +1,18 @@
+{
+  "id": "parameter-sweeps",
+  "title": "Parameter Sweeps",
+  "description": "Systematically vary a single parameter to explore how it affects model behavior. Learn to set up sweeps, read fan charts, and identify sensitivity.",
+  "difficulty": "intermediate",
+  "estimatedMinutes": 15,
+  "model": "introductory/coffee-cooling.json",
+  "recommendedPrerequisites": ["reading-results"],
+  "steps": [
+    { "title": "What is a Sweep?", "content": "parameter-sweeps/01-what-is-a-sweep.md" },
+    { "title": "Setting Up", "content": "parameter-sweeps/02-setting-up.md" },
+    { "title": "Reading Fan Charts", "content": "parameter-sweeps/03-reading-fan-charts.md" },
+    { "title": "Identifying Sensitivity", "content": "parameter-sweeps/04-identifying-sensitivity.md" },
+    { "title": "Experiment", "content": "parameter-sweeps/05-experiment.md" },
+    { "title": "Key Takeaways", "content": "parameter-sweeps/06-key-takeaways.md" }
+  ],
+  "nextTutorial": "multi-sweeps"
+}

--- a/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/01-what-is-a-sweep.md
+++ b/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/01-what-is-a-sweep.md
@@ -1,0 +1,9 @@
+## Automate parameter exploration
+
+A **parameter sweep** runs the model multiple times, changing one parameter across a range of values. Instead of manually adjusting a parameter, running, recording the result, and repeating, the sweep automates the entire process.
+
+The engine takes a parameter, a minimum value, a maximum value, and a number of steps. It runs the model once for each step, producing a set of time series -- one per parameter value.
+
+The result is a **fan chart**: multiple time series overlaid on a single plot, showing how the system behaves across the parameter range. Fan charts make it immediately visible whether a parameter matters.
+
+By the end of this tutorial, you'll answer: *Which parameters in the coffee cooling model have the most influence on the outcome?*

--- a/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/02-setting-up.md
+++ b/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/02-setting-up.md
@@ -1,0 +1,14 @@
+## Configure a single-parameter sweep
+
+Go to **Simulate -> Parameter Sweep**. The sweep dialog opens with the model's parameters listed.
+
+- Select the parameter to sweep -- choose `Cooling_Rate`
+- Set the **minimum** value: `0.01`
+- Set the **maximum** value: `0.30`
+- Set the **number of steps**: `10`
+
+Click **Run**. The engine runs the model 10 times, once for each value of `Cooling_Rate` evenly spaced between 0.01 and 0.30.
+
+## What happens behind the scenes
+
+Each run uses a different value of `Cooling_Rate` while holding all other parameters at their default values. The results are collected and displayed together as a fan chart in the Chart tab.

--- a/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/03-reading-fan-charts.md
+++ b/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/03-reading-fan-charts.md
@@ -1,0 +1,14 @@
+## Interpret the fan chart
+
+The fan chart shows all runs overlaid on a single plot. Each line represents a different value of the swept parameter.
+
+- A **wide fan** means the model is **sensitive** to that parameter -- small changes in the parameter cause large differences in behavior
+- A **narrow fan** means the model is **insensitive** -- the parameter doesn't matter much for the outcome
+
+## What to look for
+
+- **Where is the fan widest?** That's when sensitivity peaks. In the coffee model, the fan may be widest during the rapid cooling phase and narrow near equilibrium.
+- **Do the lines converge?** If all runs end at the same value regardless of the parameter, the parameter affects the path but not the final outcome.
+- **Do the lines cross?** Crossing lines can indicate nonlinear behavior or regime changes.
+
+Hover over individual lines to see which parameter value produced that trajectory.

--- a/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/04-identifying-sensitivity.md
+++ b/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/04-identifying-sensitivity.md
@@ -1,0 +1,16 @@
+## Which parameters matter most?
+
+**Sensitivity analysis** asks a practical question: where should you invest effort in getting accurate data?
+
+The approach is straightforward:
+
+- Sweep each parameter individually across a plausible range
+- Compare the resulting fan widths
+- Parameters that produce wide fans need careful estimation -- errors in these values will significantly affect your conclusions
+- Parameters that produce narrow fans can tolerate rough estimates
+
+## Practical guidance
+
+Not all sensitivity is equal. A parameter the model is sensitive to only matters if you're uncertain about its real-world value. If you know the cooling rate precisely, its sensitivity is irrelevant. Focus on parameters that are **both** sensitive **and** uncertain.
+
+This combination -- high sensitivity plus high uncertainty -- identifies where additional data collection, measurement, or expert judgment will most improve your model's usefulness.

--- a/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/05-experiment.md
+++ b/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/05-experiment.md
@@ -1,0 +1,15 @@
+## Try it yourself
+
+Run these sweeps on the coffee cooling model and observe the results:
+
+- **Sweep Cooling_Rate** from `0.01` to `0.30` with 10 steps. How much does the final temperature vary across runs? Is the fan wide or narrow at the end of the simulation?
+
+- **Sweep Room_Temperature** from `10` to `30` with 10 steps. Is the model more sensitive to room temperature or cooling rate? Compare the fan widths.
+
+- **Sweep the initial Coffee_Temperature** from `60` to `100` with 10 steps. Does the starting temperature affect where the coffee ends up, or just how long it takes to get there?
+
+## Questions to consider
+
+- Which parameter has the strongest effect on the **final** temperature?
+- Which parameter has the strongest effect on the **rate** of cooling?
+- If you could only measure one parameter precisely, which would it be?

--- a/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/06-key-takeaways.md
+++ b/courant-app/src/main/resources/tutorials/simulation/parameter-sweeps/06-key-takeaways.md
@@ -1,0 +1,16 @@
+## What you learned
+
+- **Parameter sweeps** automate the process of exploring how a single parameter affects model behavior
+- **Fan charts** overlay multiple runs, making sensitivity immediately visible
+- A **wide fan** means the model is sensitive to that parameter; a **narrow fan** means it is insensitive
+- **Sensitivity analysis** identifies which parameters matter most -- focus data collection effort on parameters that are both sensitive and uncertain
+
+## Behavior modes seen
+
+- Exponential decay (coffee cooling toward room temperature)
+- Goal-seeking (temperature approaching equilibrium)
+
+## Try next
+
+- Add a second swept parameter to explore **interaction effects** in the next tutorial
+- Try sweeping parameters in other models to build intuition about which structures create sensitivity

--- a/courant-app/src/main/resources/tutorials/simulation/putting-together.json
+++ b/courant-app/src/main/resources/tutorials/simulation/putting-together.json
@@ -1,0 +1,18 @@
+{
+  "id": "putting-together",
+  "title": "Putting It All Together",
+  "description": "Walk through the full SD workflow: build, validate, sweep, calibrate, optimize, and present findings.",
+  "difficulty": "advanced",
+  "estimatedMinutes": 20,
+  "model": null,
+  "recommendedPrerequisites": ["calibration"],
+  "steps": [
+    { "title": "The Full Workflow", "content": "putting-together/01-the-full-workflow.md" },
+    { "title": "Build & Validate", "content": "putting-together/02-build-validate.md" },
+    { "title": "Explore & Calibrate", "content": "putting-together/03-explore-calibrate.md" },
+    { "title": "Analyze & Optimize", "content": "putting-together/04-analyze-optimize.md" },
+    { "title": "Present & Communicate", "content": "putting-together/05-present.md" },
+    { "title": "What You've Learned", "content": "putting-together/06-what-youve-learned.md" }
+  ],
+  "nextTutorial": null
+}

--- a/courant-app/src/main/resources/tutorials/simulation/putting-together/01-the-full-workflow.md
+++ b/courant-app/src/main/resources/tutorials/simulation/putting-together/01-the-full-workflow.md
@@ -1,0 +1,12 @@
+## The system dynamics modeling cycle
+
+SD modeling is not a straight line from start to finish. It's a cycle with six stages, each building on the previous:
+
+1. **Build** -- translate a dynamic hypothesis into stocks, flows, and feedback loops
+2. **Validate** -- test the model's structure and behavior against known facts
+3. **Explore** -- use sweeps and Monte Carlo to understand sensitivity and uncertainty
+4. **Calibrate** -- fit uncertain parameters to historical data
+5. **Optimize** -- search for the best policy or intervention
+6. **Present** -- communicate findings to stakeholders
+
+Results from later stages often send you back to refine the model. A calibration that fails badly may reveal a structural flaw. An optimization that produces implausible results may expose missing constraints. This iteration is normal and productive.

--- a/courant-app/src/main/resources/tutorials/simulation/putting-together/02-build-validate.md
+++ b/courant-app/src/main/resources/tutorials/simulation/putting-together/02-build-validate.md
@@ -1,0 +1,19 @@
+## Build
+
+Start with a clear **problem statement** and a **reference mode** -- a sketch of the behavior you're trying to explain. Then translate your dynamic hypothesis into a model:
+
+- Identify the **stocks** that accumulate
+- Define the **flows** that change them
+- Connect variables through **feedback loops** that drive behavior
+
+Keep the model as simple as possible while still capturing the essential dynamics.
+
+## Validate
+
+Validation builds confidence that the model's structure and behavior are sound:
+
+- **Check units** with `Ctrl+B` -- every equation must be dimensionally consistent
+- **Test extreme conditions** -- set parameters to very large or very small values and verify the model behaves sensibly
+- **Compare to reference mode** -- does the model reproduce the expected pattern of behavior?
+
+Iterate between building and validating until the model passes all structure and behavior tests. Don't move to exploration until the foundation is solid.

--- a/courant-app/src/main/resources/tutorials/simulation/putting-together/03-explore-calibrate.md
+++ b/courant-app/src/main/resources/tutorials/simulation/putting-together/03-explore-calibrate.md
@@ -1,0 +1,18 @@
+## Explore
+
+With a validated model, explore its behavior systematically:
+
+- **Parameter sweeps** identify which parameters the model is most sensitive to. Focus attention on the parameters that matter most.
+- **Monte Carlo analysis** quantifies the range of possible outcomes when multiple parameters are uncertain simultaneously. It answers: *how wide is the envelope of behavior?*
+
+Exploration reveals where the model's predictions are robust and where they depend heavily on uncertain assumptions.
+
+## Calibrate
+
+If historical data is available, calibrate the uncertain parameters:
+
+- Import reference data and map it to model variables
+- Select the parameters to calibrate and set plausible bounds
+- Run the calibrator and evaluate the fit
+
+After calibration, test the model against **holdout data** -- data that was not used during calibration. Good performance on unseen data is the strongest evidence that calibration captured real dynamics, not noise.

--- a/courant-app/src/main/resources/tutorials/simulation/putting-together/04-analyze-optimize.md
+++ b/courant-app/src/main/resources/tutorials/simulation/putting-together/04-analyze-optimize.md
@@ -1,0 +1,22 @@
+## Analyze
+
+Use the validated, calibrated model to test policies and interventions:
+
+- What changes improve the problematic behavior?
+- Which interventions have the largest effect?
+- Are there unintended side effects or delayed consequences?
+
+Run each policy scenario and compare results side by side. Pay attention to feedback effects -- interventions in complex systems often produce counterintuitive responses.
+
+## Optimize
+
+When you have clear **objectives** and **decision variables**, use the optimizer to find the best policy:
+
+- Define what "best" means as a measurable objective
+- Set bounds on the controllable parameters
+- Add constraints to rule out impractical solutions
+- Run the optimization
+
+## Stress-test the result
+
+Test the optimal policy with **Monte Carlo analysis** to ensure it performs well under uncertainty. A policy that's optimal under perfect knowledge but fragile to parameter uncertainty may not be the best practical choice.

--- a/courant-app/src/main/resources/tutorials/simulation/putting-together/05-present.md
+++ b/courant-app/src/main/resources/tutorials/simulation/putting-together/05-present.md
@@ -1,0 +1,16 @@
+## Communicating findings
+
+The model's value is realized only when findings reach the people who make decisions. Effective presentation translates technical results into clear insight.
+
+## Visual strategies
+
+- **Reference mode overlay** -- show the observed behavior alongside the model's simulation to demonstrate that the model captures reality
+- **Sensitivity fan charts** -- display the range of outcomes across parameter sweeps to show which factors matter most
+- **Confidence bands** -- use Monte Carlo results to show the envelope of uncertainty around key outputs
+- **Policy comparisons** -- place scenarios side by side so stakeholders can see the trade-offs directly
+
+## Focus on insight
+
+The most important output of a modeling project is not the numbers -- it's the **insight**. What did the model reveal that wasn't obvious from intuition alone? Which feedback loops drive the problem? Which interventions are surprisingly effective or surprisingly ineffective?
+
+Lead with the story the model tells, and use the charts to support it.

--- a/courant-app/src/main/resources/tutorials/simulation/putting-together/06-what-youve-learned.md
+++ b/courant-app/src/main/resources/tutorials/simulation/putting-together/06-what-youve-learned.md
@@ -1,0 +1,18 @@
+## The complete toolkit
+
+You've completed the full tutorial curriculum. Across these tutorials, you've learned to:
+
+- **Build** system dynamics models from stocks, flows, and feedback loops
+- **Configure** simulation settings for accuracy and performance
+- **Validate** models with unit checks and extreme-condition tests
+- **Explore** behavior with parameter sweeps and multi-dimensional sweeps
+- **Quantify uncertainty** with Monte Carlo analysis and confidence bands
+- **Calibrate** parameters against historical data using payoff functions
+- **Optimize** policies by defining objectives, decision variables, and constraints
+- **Present** findings with clear visuals and insight-driven narratives
+
+## Where to go from here
+
+These tools form a complete analytical toolkit for understanding and improving complex systems. Apply them to your own problems: start with a dynamic hypothesis, build a model, validate it rigorously, and let the analysis guide your decisions.
+
+The best way to learn modeling is to model. Pick a system you care about and work through the full cycle.

--- a/courant-app/src/main/resources/tutorials/simulation/reading-results.json
+++ b/courant-app/src/main/resources/tutorials/simulation/reading-results.json
@@ -1,0 +1,18 @@
+{
+  "id": "reading-results",
+  "title": "Reading Results & Time Series",
+  "description": "Interpret simulation output using charts, dashboards, and CSV export. Learn to compare runs and identify behavior patterns.",
+  "difficulty": "beginner",
+  "estimatedMinutes": 15,
+  "model": "introductory/coffee-cooling.json",
+  "recommendedPrerequisites": ["sim-settings"],
+  "steps": [
+    { "title": "The Chart Tab", "content": "reading-results/01-the-chart-tab.md" },
+    { "title": "Adding Variables", "content": "reading-results/02-adding-variables.md" },
+    { "title": "Reading Time Series", "content": "reading-results/03-reading-time-series.md" },
+    { "title": "Comparing Runs", "content": "reading-results/04-comparing-runs.md" },
+    { "title": "Exporting Data", "content": "reading-results/05-exporting-data.md" },
+    { "title": "Key Takeaways", "content": "reading-results/06-key-takeaways.md" }
+  ],
+  "nextTutorial": "parameter-sweeps"
+}

--- a/courant-app/src/main/resources/tutorials/simulation/reading-results/01-the-chart-tab.md
+++ b/courant-app/src/main/resources/tutorials/simulation/reading-results/01-the-chart-tab.md
@@ -1,0 +1,20 @@
+## The chart view
+
+After running a simulation (`Ctrl+R`), switch to the **Chart** tab in the dashboard at the bottom of the window.
+
+The chart displays:
+
+- **X-axis** — time, from INITIAL_TIME to FINAL_TIME
+- **Y-axis** — variable values, auto-scaled to fit the data
+
+By default, all stocks in the model are plotted. Each stock gets its own colored line with a legend entry.
+
+## Navigating the chart
+
+- **Hover** over a point to see its exact time and value in a tooltip
+- **Scroll** the mouse wheel to zoom in or out on the time axis
+- **Click and drag** to pan across the time range
+
+## Auto-scaling
+
+The y-axis automatically adjusts to show the full range of plotted variables. If you plot variables with very different scales (e.g., temperature 0-100 and a rate 0-1), the smaller variable may appear flat. The next step shows how to control which variables are displayed.

--- a/courant-app/src/main/resources/tutorials/simulation/reading-results/02-adding-variables.md
+++ b/courant-app/src/main/resources/tutorials/simulation/reading-results/02-adding-variables.md
@@ -1,0 +1,23 @@
+## The Variables panel
+
+The **Variables** panel on the left side of the dashboard lists every element in the model — stocks, flows, and auxiliaries.
+
+Each variable has a checkbox:
+
+- **Checked** — the variable is plotted on the chart
+- **Unchecked** — the variable is hidden
+
+By default, all stocks are checked. Flows and auxiliaries start unchecked.
+
+## Combining stocks and flows
+
+Check a flow alongside its stock to see how the rate relates to the level. In the coffee cooling model:
+
+- Plot **Coffee_Temperature** (stock) and **Cooling** (flow) together
+- Notice the flow starts high when the temperature gap is large, then shrinks as the coffee approaches room temperature
+
+This is the signature of goal-seeking behavior: a rate that diminishes as the stock approaches its target.
+
+## Keeping charts readable
+
+Plot two or three variables at a time for clarity. Too many lines make the chart hard to interpret. Uncheck variables you are not currently investigating.

--- a/courant-app/src/main/resources/tutorials/simulation/reading-results/03-reading-time-series.md
+++ b/courant-app/src/main/resources/tutorials/simulation/reading-results/03-reading-time-series.md
@@ -1,0 +1,23 @@
+## Recognizing behavior patterns
+
+System dynamics models produce a small set of fundamental behavior modes. Learning to recognize them on sight tells you what feedback structure is dominant.
+
+- **Exponential growth** — curves upward with increasing slope. Driven by reinforcing feedback with no constraint.
+
+- **Goal-seeking** — rises (or falls) quickly, then levels off at a target value. Driven by balancing feedback. The coffee cooling model shows this pattern.
+
+- **Oscillation** — swings above and below a center line in repeated cycles. Caused by balancing feedback with a delay.
+
+- **S-shaped growth** — starts slow, accelerates, then saturates as it approaches a limit. Reinforcing feedback gives way to balancing feedback.
+
+- **Overshoot and collapse** — rises past a sustainable limit, then crashes when a resource is depleted. Reinforcing growth with a delayed balancing response.
+
+## What to look for
+
+When you see a new chart, ask:
+
+- Is the curve accelerating, decelerating, or oscillating?
+- Does it approach a steady state, or keep changing?
+- Are there turning points where the dominant feedback shifts?
+
+Matching the chart shape to a behavior mode points you toward the feedback loops that matter most.

--- a/courant-app/src/main/resources/tutorials/simulation/reading-results/04-comparing-runs.md
+++ b/courant-app/src/main/resources/tutorials/simulation/reading-results/04-comparing-runs.md
@@ -1,0 +1,25 @@
+## Why compare runs?
+
+Changing a parameter and re-running replaces the previous results. To see both runs side by side, use run comparison.
+
+## Overlaying results
+
+1. Run the simulation with the current parameter values (`Ctrl+R`)
+2. Change a parameter — for example, set **Cooling_Rate** to 0.05
+3. Go to **Simulate --> Compare Runs** or toggle the comparison control in the dashboard
+4. Run again (`Ctrl+R`)
+
+The chart now shows both runs overlaid: the original in its normal color, and the new run in a contrasting style. This makes it easy to see exactly where and how much the behavior changes.
+
+## Example: fast vs. slow cooling
+
+Run the coffee cooling model twice:
+
+- **Run 1:** Cooling_Rate = 0.20 (thin ceramic mug)
+- **Run 2:** Cooling_Rate = 0.05 (insulated travel mug)
+
+With comparison enabled, you can see that the travel mug keeps coffee above 60 degrees C far longer. The curves diverge immediately and the gap persists throughout the simulation.
+
+## Clearing comparisons
+
+To discard previous comparison runs and start fresh, use **Simulate --> Clear Comparisons** or close the comparison panel.

--- a/courant-app/src/main/resources/tutorials/simulation/reading-results/05-exporting-data.md
+++ b/courant-app/src/main/resources/tutorials/simulation/reading-results/05-exporting-data.md
@@ -1,0 +1,34 @@
+## Exporting to CSV
+
+To save simulation results for external analysis:
+
+1. Go to **File --> Export --> CSV**
+2. Choose a file name and location
+3. Click **Save**
+
+You can also right-click the chart and select **Export CSV** from the context menu.
+
+## CSV format
+
+The exported file contains:
+
+- **First column** — time values (one row per recorded time step)
+- **Remaining columns** — one column per variable that was recorded during the simulation
+- **Header row** — variable names
+
+Example:
+
+    Time, Coffee_Temperature, Cooling, Room_Temperature
+    0,    95.0,               7.5,     20.0
+    1,    87.5,               6.75,    20.0
+    2,    80.75,              6.075,   20.0
+
+## Using exported data
+
+Import the CSV into your preferred analysis tool:
+
+- **Excel / Google Sheets** — pivot tables, custom charts, what-if formulas
+- **Python (pandas)** — `pd.read_csv("results.csv")` for statistical analysis or plotting with matplotlib
+- **R** — `read.csv("results.csv")` for econometric or statistical modeling
+
+Exporting is especially useful when you need to apply analysis techniques not built into the simulation tool.

--- a/courant-app/src/main/resources/tutorials/simulation/reading-results/06-key-takeaways.md
+++ b/courant-app/src/main/resources/tutorials/simulation/reading-results/06-key-takeaways.md
@@ -1,0 +1,17 @@
+## What you learned
+
+- **Chart tab** — shows time series with time on the x-axis and values on the y-axis; auto-scales to fit the data
+- **Variables panel** — check or uncheck variables to control what is plotted
+- **Behavior patterns** — exponential growth, goal-seeking, oscillation, S-shaped growth, overshoot and collapse
+- **Run comparison** — overlay multiple runs to see how parameter changes affect behavior
+- **CSV export** — save results via **File --> Export --> CSV** for external analysis
+
+## Key insight
+
+The shape of a time series tells you which feedback loops are dominant. Learning to read behavior patterns is one of the most valuable skills in system dynamics — it connects model structure to model behavior.
+
+## Try next
+
+- Plot Coffee_Temperature and Cooling together to see the stock-flow relationship
+- Compare runs with Cooling_Rate = 0.05 and 0.20 to see the effect on cooling speed
+- Export the results and plot them in Excel or Python to practice working with simulation data outside the tool

--- a/courant-app/src/main/resources/tutorials/simulation/sim-settings.json
+++ b/courant-app/src/main/resources/tutorials/simulation/sim-settings.json
@@ -1,0 +1,18 @@
+{
+  "id": "sim-settings",
+  "title": "Simulation Settings & Execution",
+  "description": "Configure time step, duration, DT, and integration method. Understand how simulation settings affect accuracy and performance.",
+  "difficulty": "beginner",
+  "estimatedMinutes": 15,
+  "model": "introductory/coffee-cooling.json",
+  "recommendedPrerequisites": ["first-model"],
+  "steps": [
+    { "title": "The Simulation Loop", "content": "sim-settings/01-the-simulation-loop.md" },
+    { "title": "Time Step & Duration", "content": "sim-settings/02-time-step-duration.md" },
+    { "title": "DT — Sub-stepping", "content": "sim-settings/03-dt-sub-stepping.md" },
+    { "title": "INITIAL TIME & FINAL TIME", "content": "sim-settings/04-initial-final-time.md" },
+    { "title": "Running a Simulation", "content": "sim-settings/05-running.md" },
+    { "title": "Key Takeaways", "content": "sim-settings/06-key-takeaways.md" }
+  ],
+  "nextTutorial": "reading-results"
+}

--- a/courant-app/src/main/resources/tutorials/simulation/sim-settings/01-the-simulation-loop.md
+++ b/courant-app/src/main/resources/tutorials/simulation/sim-settings/01-the-simulation-loop.md
@@ -1,0 +1,22 @@
+## How a simulation works
+
+A simulation is a loop that repeats four steps:
+
+1. **Evaluate flows** — compute all rates from current stock values
+2. **Update stocks** — add or subtract the net flow for each stock
+3. **Advance time** — move the clock forward by one time step
+4. **Repeat** — go back to step 1 until time runs out
+
+Each pass through the loop is one **time step**. The simulation starts at **INITIAL TIME** and ends at **FINAL TIME**.
+
+## The integration rule
+
+The engine uses **Euler integration**, the simplest numerical method:
+
+    Stock(t + dt) = Stock(t) + NetFlow * dt
+
+At every step, each stock's new value equals its old value plus the net flow multiplied by the time increment. This is the discrete approximation of continuous change that makes simulation possible.
+
+## Why this matters
+
+Every setting you configure in the next few steps controls some part of this loop — how big each time step is, how many steps to take, and how finely to subdivide each step for accuracy.

--- a/courant-app/src/main/resources/tutorials/simulation/sim-settings/02-time-step-duration.md
+++ b/courant-app/src/main/resources/tutorials/simulation/sim-settings/02-time-step-duration.md
@@ -1,0 +1,25 @@
+## Open simulation settings
+
+Go to **Simulate --> Simulation Settings**. Two fields control the time horizon:
+
+- **Time Step** — the unit of time (Day, Week, Month, Year)
+- **Duration** — how many time units to simulate
+
+## Example
+
+Set the following:
+
+    Time Step:      Minute
+    Duration:       60
+    Duration Unit:  Minute
+
+This simulates one hour of coffee cooling, one minute at a time. The engine will execute 60 iterations of the simulation loop.
+
+## Choosing a time step
+
+Shorter time steps give more resolution — you see finer-grained behavior — but the simulation takes longer because there are more iterations.
+
+- **Too coarse** — you miss rapid changes and get inaccurate results
+- **Too fine** — the simulation runs slowly with no improvement in insight
+
+A good rule of thumb: the time step should be shorter than the fastest important dynamic in your model. For coffee cooling measured in minutes, a one-minute step works well. For population models spanning decades, a one-year step is usually sufficient.

--- a/courant-app/src/main/resources/tutorials/simulation/sim-settings/03-dt-sub-stepping.md
+++ b/courant-app/src/main/resources/tutorials/simulation/sim-settings/03-dt-sub-stepping.md
@@ -1,0 +1,25 @@
+## What is DT?
+
+**DT** (delta time) subdivides each time step into smaller calculation intervals. It controls the precision of the Euler integration without changing the time step reported in your results.
+
+- **DT = 1.0** (default) — one calculation per time step
+- **DT = 0.5** — two calculations per time step
+- **DT = 0.25** — four calculations per time step
+
+Smaller DT values improve accuracy because the Euler approximation is better over shorter intervals.
+
+## When to reduce DT
+
+Use a smaller DT when:
+
+- **Oscillations appear jagged** — the chart shows sharp zigzags instead of smooth waves
+- **Stocks overshoot impossible values** — a population goes negative, or a percentage exceeds 100%
+- **Results change significantly when you halve DT** — this means the current DT is too coarse
+
+## A practical test
+
+Run the coffee cooling model with DT = 1.0, then again with DT = 0.25. If the curves are nearly identical, DT = 1.0 is fine. If they differ noticeably, use the smaller value.
+
+## Trade-off
+
+Each halving of DT doubles the computation. For most tutorial models, DT = 1.0 is sufficient. Reserve smaller values for stiff systems or fast-changing dynamics.

--- a/courant-app/src/main/resources/tutorials/simulation/sim-settings/04-initial-final-time.md
+++ b/courant-app/src/main/resources/tutorials/simulation/sim-settings/04-initial-final-time.md
@@ -1,0 +1,30 @@
+## Built-in time constants
+
+The engine provides two constants you can use in any equation:
+
+- **INITIAL_TIME** — the time value at the start of the simulation (defaults to 0)
+- **FINAL_TIME** — the time value at the end, calculated as `INITIAL_TIME + Duration`
+
+## Changing INITIAL TIME
+
+Some models set INITIAL_TIME to a calendar year for readability. A model of product adoption from 1990 to 2020 is easier to understand with `INITIAL_TIME = 1990` than `INITIAL_TIME = 0`.
+
+Set this in **Simulate --> Simulation Settings** under **Initial Time**.
+
+## Using time constants in equations
+
+These constants are available anywhere you write an equation. Common patterns:
+
+- **Policy switch at the midpoint:**
+
+      IF THEN ELSE(Time > (INITIAL_TIME + FINAL_TIME) / 2, new_policy, old_policy)
+
+- **Fraction of time elapsed:**
+
+      (Time - INITIAL_TIME) / (FINAL_TIME - INITIAL_TIME)
+
+- **Phase-in over the first quarter:**
+
+      MIN(1, (Time - INITIAL_TIME) / ((FINAL_TIME - INITIAL_TIME) * 0.25))
+
+These let you write time-aware equations without hard-coding specific numbers.

--- a/courant-app/src/main/resources/tutorials/simulation/sim-settings/05-running.md
+++ b/courant-app/src/main/resources/tutorials/simulation/sim-settings/05-running.md
@@ -1,0 +1,24 @@
+## Start a simulation
+
+Press `Ctrl+R` to run the simulation. You can also use **Simulate --> Run Simulation** from the menu bar.
+
+The status bar at the bottom of the window shows progress as the engine steps through the simulation loop.
+
+## Viewing results
+
+When the simulation completes, the dashboard opens with two tabs:
+
+- **Chart** — a line chart plotting stocks over time
+- **Table** — a sortable grid showing values at each time step
+
+Switch between tabs to explore the output from different angles.
+
+## Cancelling a run
+
+To cancel a running simulation, press `Escape`. This stops the engine immediately and discards partial results.
+
+Long simulations — millions of steps or complex models — show a progress indicator. If a run is taking too long, cancel it and consider increasing DT or using a coarser time step.
+
+## Re-running after changes
+
+After changing any parameter or equation, press `Ctrl+R` again to re-run. The dashboard updates with fresh results. Previous results are replaced unless you use run comparison (covered in the next tutorial).

--- a/courant-app/src/main/resources/tutorials/simulation/sim-settings/06-key-takeaways.md
+++ b/courant-app/src/main/resources/tutorials/simulation/sim-settings/06-key-takeaways.md
@@ -1,0 +1,22 @@
+## What you learned
+
+- **Simulation loop** — evaluate flows, update stocks, advance time, repeat
+- **Euler integration** — `Stock(t+dt) = Stock(t) + NetFlow * dt`
+- **Time Step** — sets the unit of time (Minute, Day, Year)
+- **Duration** — sets how many time units to simulate
+- **DT** — subdivides each time step for improved accuracy; halving DT doubles computation
+- **INITIAL_TIME / FINAL_TIME** — built-in constants available in any equation
+
+## Rules of thumb
+
+- Choose a time step shorter than the fastest important dynamic
+- Start with DT = 1.0; reduce only if results change when you halve it
+- Use `INITIAL_TIME` and `FINAL_TIME` instead of hard-coding time values in equations
+
+## Try next
+
+Open the coffee cooling model and experiment:
+
+- Run with Duration = 60 minutes, then 120 minutes — watch the temperature approach room temperature
+- Change DT from 1.0 to 0.25 and compare — for this gentle system, results should be nearly identical
+- Set INITIAL_TIME to 2025 and use `Time` in a variable equation to see it referenced as a year

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/CurriculumBrowserDialogFxTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/CurriculumBrowserDialogFxTest.java
@@ -102,11 +102,10 @@ class CurriculumBrowserDialogFxTest {
     }
 
     @Test
-    @DisplayName("simulation tiers have no tutorial children yet")
-    void emptyTiersHaveNoChildren(FxRobot robot) {
-        // Core Simulation tier (1st tier of simulation-tools track) should be empty
+    @DisplayName("simulation core tier has two tutorial children")
+    void simCoreTierHasTutorials(FxRobot robot) {
         TreeItem<Object> simCore = tree().getRoot().getChildren().get(1)
                 .getChildren().getFirst();
-        assertThat(simCore.getChildren()).isEmpty();
+        assertThat(simCore.getChildren()).hasSize(2);
     }
 }


### PR DESCRIPTION
## Summary
- Added 8 tutorials completing the simulation & analysis tools track
- All 3 tiers now populated in curriculum.json

### Tier 1 — Core Simulation (2 tutorials)
1. **sim-settings** — Time step, duration, DT, INITIAL/FINAL TIME
2. **reading-results** — Charts, time series patterns, CSV export

### Tier 2 — Exploration & Sensitivity (3 tutorials)
3. **parameter-sweeps** — Single-parameter sweeps, fan charts
4. **multi-sweeps** — Combinatorial sweeps, interaction effects
5. **monte-carlo** — Distributions, confidence bands, risk assessment

### Tier 3 — Optimization & Calibration (3 tutorials)
6. **optimization** — Objective functions, decision variables, constraints
7. **calibration** — Reference data, payoff functions, goodness of fit
8. **putting-together** — Full SD workflow end-to-end

## Test plan
- [x] All tests pass
- [x] SpotBugs clean

Partial close of #881 (Phase 5)