### PR TITLE
Tutorial integration & polish (Phase 6, #881)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -639,6 +639,16 @@ public class ModelWindow {
                             + AppVersion.get());
             about.showAndWait();
         });
+
+        // Wire tutorial dialog callbacks for glossary and model opening
+        ContentTutorialDialog.setGlossaryNavigator(term -> {
+            showGlossary();
+            contextHelpDialog.showGlossaryTerm(term);
+        });
+        ContentTutorialDialog.setModelOpener(modelPath -> {
+            showEditor();
+            fileController.openExample(null, modelPath);
+        });
     }
 
     private void openSubscriptDimensionsDialog() {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContent.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/HelpContent.java
@@ -622,7 +622,7 @@ public final class HelpContent {
      * Post-processes a TextFlow to annotate glossary terms in plain text nodes
      * with tooltips and hyperlinks. Only the first occurrence of each term is annotated.
      */
-    static void annotateGlossaryTerms(TextFlow flow, Consumer<String> onNavigate) {
+    public static void annotateGlossaryTerms(TextFlow flow, Consumer<String> onNavigate) {
         Map<String, Glossary.Entry> lookupMap = Glossary.instance().lookupMap();
         if (lookupMap.isEmpty()) {
             return;
@@ -692,7 +692,9 @@ public final class HelpContent {
             tip.setWrapText(true);
             tip.setMaxWidth(350);
             Tooltip.install(link, tip);
-            link.setOnAction(e -> onNavigate.accept(entry.term()));
+            if (onNavigate != null) {
+                link.setOnAction(e -> onNavigate.accept(entry.term()));
+            }
             nodes.add(link);
 
             lastEnd = matcher.end();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ContentTutorialDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/ContentTutorialDialog.java
@@ -1,21 +1,38 @@
 package systems.courant.sd.app.canvas.dialogs;
 
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tab;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.TextFlow;
+
+import systems.courant.sd.app.canvas.HelpContent;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * A tutorial dialog whose content is loaded from Markdown step files
  * via {@link TutorialContentLoader}, rather than hardcoded in Java.
  *
  * <p>Each step becomes a tab whose content is rendered from Markdown
- * using {@link MarkdownToTextFlow}.
+ * using {@link MarkdownToTextFlow}. Glossary terms in the rendered
+ * text are annotated with tooltips (and optional navigation links)
+ * via {@link HelpContent#annotateGlossaryTerms}.
+ *
+ * <p>When the tutorial's {@link TutorialContent#model()} field is
+ * non-null and a model opener callback has been registered, an
+ * "Open Example Model" button is displayed at the top of the first
+ * tab so the user can load the companion model directly.
  */
 public class ContentTutorialDialog extends AbstractTutorialDialog {
 
     private static final double CONTENT_MAX_WIDTH = 610;
+
+    private static Consumer<String> glossaryNavigator;
+    private static Consumer<String> modelOpener;
 
     /**
      * Creates a dialog for the given tutorial content.
@@ -25,6 +42,24 @@ public class ContentTutorialDialog extends AbstractTutorialDialog {
                 660, 540, CONTENT_MAX_WIDTH,
                 content.id(),
                 buildStepTabs(content));
+    }
+
+    /**
+     * Sets the callback invoked when the user clicks an annotated glossary
+     * term. Pass {@code null} to retain tooltip-only annotations without
+     * navigation.
+     */
+    public static void setGlossaryNavigator(Consumer<String> navigator) {
+        glossaryNavigator = navigator;
+    }
+
+    /**
+     * Sets the callback invoked when the user clicks the "Open Example
+     * Model" button. The callback receives the model resource path from
+     * {@link TutorialContent#model()}.
+     */
+    public static void setModelOpener(Consumer<String> opener) {
+        modelOpener = opener;
     }
 
     @Override
@@ -39,8 +74,40 @@ public class ContentTutorialDialog extends AbstractTutorialDialog {
             TutorialContent.Step step = steps.get(i);
             String tabTitle = (i + 1) + ". " + step.title();
             TextFlow rendered = MarkdownToTextFlow.convert(step.markdown());
-            tabs.add(createStyledTab(tabTitle, rendered, CONTENT_MAX_WIDTH));
+            HelpContent.annotateGlossaryTerms(rendered, glossaryNavigator);
+
+            if (i == 0 && content.model() != null && modelOpener != null) {
+                tabs.add(createModelTab(tabTitle, rendered, content.model()));
+            } else {
+                tabs.add(createStyledTab(tabTitle, rendered, CONTENT_MAX_WIDTH));
+            }
         }
         return tabs;
+    }
+
+    /**
+     * Creates a tab whose content is preceded by an "Open Example Model"
+     * button. The button invokes the registered {@link #modelOpener}
+     * callback with the given model resource path.
+     */
+    private static Tab createModelTab(String title, TextFlow rendered,
+                                       String modelPath) {
+        Button openModelBtn = new Button("Open Example Model");
+        openModelBtn.setStyle(
+                "-fx-background-color: #E8F0FE; -fx-text-fill: #1A73E8;"
+                + " -fx-font-size: 12px; -fx-padding: 6 16;"
+                + " -fx-background-radius: 4; -fx-cursor: hand;");
+        openModelBtn.setOnAction(e -> modelOpener.accept(modelPath));
+
+        rendered.setPadding(Insets.EMPTY);
+        rendered.setLineSpacing(4);
+        rendered.setMaxWidth(CONTENT_MAX_WIDTH);
+
+        VBox wrapper = new VBox(8, openModelBtn, rendered);
+        wrapper.setPadding(new Insets(16));
+
+        ScrollPane scroll = new ScrollPane(wrapper);
+        scroll.setFitToWidth(true);
+        return new Tab(title, scroll);
     }
 }

--- a/courant-app/src/main/resources/tutorials/curriculum.json
+++ b/courant-app/src/main/resources/tutorials/curriculum.json
@@ -28,7 +28,7 @@
       ]
     },
     {
-      "id": "simulation-tools",
+      "id": "simulation",
       "name": "Simulation & Analysis Tools",
       "tiers": [
         {

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/CurriculumLoaderTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/CurriculumLoaderTest.java
@@ -28,7 +28,7 @@ class CurriculumLoaderTest {
     @Test
     @DisplayName("second track is simulation tools")
     void secondTrackIsSimulationTools() {
-        assertThat(tracks.get(1).id()).isEqualTo("simulation-tools");
+        assertThat(tracks.get(1).id()).isEqualTo("simulation");
     }
 
     @Test

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/TutorialStructuralTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/TutorialStructuralTest.java
@@ -1,0 +1,286 @@
+package systems.courant.sd.app.canvas.dialogs;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Tutorial structural validation")
+class TutorialStructuralTest {
+
+    private final List<CurriculumLoader.Track> tracks = CurriculumLoader.load();
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    record LoadedTutorial(String id, String trackId, String jsonPath, TutorialContent content) {
+    }
+
+    private List<LoadedTutorial> loadAllTutorials() {
+        List<LoadedTutorial> result = new ArrayList<>();
+        for (CurriculumLoader.Track track : tracks) {
+            for (CurriculumLoader.Tier tier : track.tiers()) {
+                for (String tutorialId : tier.tutorialIds()) {
+                    String path = track.id() + "/" + tutorialId + ".json";
+                    TutorialContent content = TutorialContentLoader.load(path);
+                    result.add(new LoadedTutorial(tutorialId, track.id(), path, content));
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Collects every tutorial ID that appears anywhere in the curriculum
+     * (across all tracks and tiers).
+     */
+    private Set<String> allCurriculumTutorialIds() {
+        Set<String> ids = new HashSet<>();
+        for (CurriculumLoader.Track track : tracks) {
+            for (CurriculumLoader.Tier tier : track.tiers()) {
+                ids.addAll(tier.tutorialIds());
+            }
+        }
+        return ids;
+    }
+
+    // ── Curriculum integrity ─────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Curriculum integrity")
+    class CurriculumIntegrity {
+
+        @TestFactory
+        @DisplayName("all tutorial IDs in curriculum load successfully")
+        Stream<DynamicTest> allTutorialIdsInCurriculumLoadSuccessfully() {
+            List<DynamicTest> tests = new ArrayList<>();
+            for (CurriculumLoader.Track track : tracks) {
+                for (CurriculumLoader.Tier tier : track.tiers()) {
+                    for (String tutorialId : tier.tutorialIds()) {
+                        String path = track.id() + "/" + tutorialId + ".json";
+                        String name = track.id() + " / " + tier.id() + " / " + tutorialId;
+                        tests.add(DynamicTest.dynamicTest(name, () -> {
+                            TutorialContent content = TutorialContentLoader.load(path);
+                            assertThat(content).as("loaded tutorial for %s", path).isNotNull();
+                            assertThat(content.id()).isEqualTo(tutorialId);
+                        }));
+                    }
+                }
+            }
+            return tests.stream();
+        }
+
+        @Test
+        @DisplayName("no duplicate tutorial IDs across tiers")
+        void noDuplicateTutorialIds() {
+            Set<String> seen = new HashSet<>();
+            List<String> duplicates = new ArrayList<>();
+            for (CurriculumLoader.Track track : tracks) {
+                for (CurriculumLoader.Tier tier : track.tiers()) {
+                    for (String tutorialId : tier.tutorialIds()) {
+                        if (!seen.add(tutorialId)) {
+                            duplicates.add(tutorialId + " (in " + tier.id() + ")");
+                        }
+                    }
+                }
+            }
+            assertThat(duplicates)
+                    .as("tutorial IDs appearing in more than one tier")
+                    .isEmpty();
+        }
+
+        @TestFactory
+        @DisplayName("all tiers have at least one tutorial")
+        Stream<DynamicTest> allTiersHaveAtLeastOneTutorial() {
+            List<DynamicTest> tests = new ArrayList<>();
+            for (CurriculumLoader.Track track : tracks) {
+                for (CurriculumLoader.Tier tier : track.tiers()) {
+                    String name = track.id() + " / " + tier.id();
+                    tests.add(DynamicTest.dynamicTest(name, () ->
+                            assertThat(tier.tutorialIds())
+                                    .as("tutorials in tier %s", tier.id())
+                                    .isNotEmpty()));
+                }
+            }
+            return tests.stream();
+        }
+    }
+
+    // ── Step content ────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Step content")
+    class StepContent {
+
+        @TestFactory
+        @DisplayName("all steps have non-empty markdown")
+        Stream<DynamicTest> allStepsHaveNonEmptyMarkdown() {
+            return loadAllTutorials().stream().flatMap(tutorial ->
+                    tutorial.content().steps().stream().map(step -> {
+                        String name = tutorial.id() + " / " + step.title();
+                        return DynamicTest.dynamicTest(name, () ->
+                                assertThat(step.markdown())
+                                        .as("markdown for step '%s' in tutorial '%s'",
+                                                step.title(), tutorial.id())
+                                        .isNotBlank());
+                    }));
+        }
+
+        @TestFactory
+        @DisplayName("all steps have non-empty titles")
+        Stream<DynamicTest> allStepsHaveNonEmptyTitles() {
+            return loadAllTutorials().stream().flatMap(tutorial -> {
+                List<DynamicTest> stepTests = new ArrayList<>();
+                List<TutorialContent.Step> steps = tutorial.content().steps();
+                for (int i = 0; i < steps.size(); i++) {
+                    TutorialContent.Step step = steps.get(i);
+                    int stepNumber = i + 1;
+                    String name = tutorial.id() + " / step " + stepNumber;
+                    stepTests.add(DynamicTest.dynamicTest(name, () ->
+                            assertThat(step.title())
+                                    .as("title of step %d in tutorial '%s'",
+                                            stepNumber, tutorial.id())
+                                    .isNotBlank()));
+                }
+                return stepTests.stream();
+            });
+        }
+
+        @TestFactory
+        @DisplayName("all tutorials have at least two steps")
+        Stream<DynamicTest> allTutorialsHaveAtLeastTwoSteps() {
+            return loadAllTutorials().stream().map(tutorial ->
+                    DynamicTest.dynamicTest(tutorial.id(), () ->
+                            assertThat(tutorial.content().steps())
+                                    .as("steps in tutorial '%s'", tutorial.id())
+                                    .hasSizeGreaterThanOrEqualTo(2)));
+        }
+    }
+
+    // ── Model references ────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Model references")
+    class ModelReferences {
+
+        @TestFactory
+        @DisplayName("all model references point to existing files")
+        Stream<DynamicTest> allModelReferencesPointToExistingFiles() {
+            return loadAllTutorials().stream()
+                    .filter(tutorial -> tutorial.content().model() != null)
+                    .map(tutorial -> {
+                        String model = tutorial.content().model();
+                        String name = tutorial.id() + " -> " + model;
+                        return DynamicTest.dynamicTest(name, () -> {
+                            String resourcePath = "/models/" + model;
+                            try (InputStream is = getClass().getResourceAsStream(resourcePath)) {
+                                assertThat(is)
+                                        .as("model resource '%s' referenced by tutorial '%s'",
+                                                resourcePath, tutorial.id())
+                                        .isNotNull();
+                            }
+                        });
+                    });
+        }
+    }
+
+    // ── Next tutorial chain ─────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Next tutorial chain")
+    class NextTutorialChain {
+
+        @TestFactory
+        @DisplayName("all nextTutorial references are valid")
+        Stream<DynamicTest> allNextTutorialReferencesAreValid() {
+            Set<String> allIds = allCurriculumTutorialIds();
+            return loadAllTutorials().stream()
+                    .filter(tutorial -> tutorial.content().nextTutorial() != null)
+                    .map(tutorial -> {
+                        String next = tutorial.content().nextTutorial();
+                        String name = tutorial.id() + " -> " + next;
+                        return DynamicTest.dynamicTest(name, () ->
+                                assertThat(allIds)
+                                        .as("nextTutorial '%s' referenced by '%s' must exist in curriculum",
+                                                next, tutorial.id())
+                                        .contains(next));
+                    });
+        }
+
+        @TestFactory
+        @DisplayName("no circular nextTutorial chains")
+        Stream<DynamicTest> noCircularNextTutorialChains() {
+            List<LoadedTutorial> all = loadAllTutorials();
+
+            // Build a map from tutorial ID to its nextTutorial
+            java.util.Map<String, String> nextMap = new java.util.HashMap<>();
+            for (LoadedTutorial tutorial : all) {
+                if (tutorial.content().nextTutorial() != null) {
+                    nextMap.put(tutorial.id(), tutorial.content().nextTutorial());
+                }
+            }
+
+            return all.stream().map(tutorial ->
+                    DynamicTest.dynamicTest(tutorial.id(), () -> {
+                        Set<String> visited = new HashSet<>();
+                        String current = tutorial.id();
+                        while (current != null && nextMap.containsKey(current)) {
+                            assertThat(visited.add(current))
+                                    .as("circular chain detected at '%s' starting from '%s'",
+                                            current, tutorial.id())
+                                    .isTrue();
+                            current = nextMap.get(current);
+                        }
+                    }));
+        }
+    }
+
+    // ── Metadata quality ────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Metadata quality")
+    class MetadataQuality {
+
+        private static final Set<String> VALID_DIFFICULTIES =
+                Set.of("beginner", "intermediate", "advanced");
+
+        @TestFactory
+        @DisplayName("all tutorials have valid difficulty")
+        Stream<DynamicTest> allTutorialsHaveDifficulty() {
+            return loadAllTutorials().stream().map(tutorial ->
+                    DynamicTest.dynamicTest(tutorial.id(), () ->
+                            assertThat(tutorial.content().difficulty())
+                                    .as("difficulty of tutorial '%s'", tutorial.id())
+                                    .isIn(VALID_DIFFICULTIES)));
+        }
+
+        @TestFactory
+        @DisplayName("all tutorials have positive estimatedMinutes")
+        Stream<DynamicTest> allTutorialsHavePositiveEstimatedMinutes() {
+            return loadAllTutorials().stream().map(tutorial ->
+                    DynamicTest.dynamicTest(tutorial.id(), () ->
+                            assertThat(tutorial.content().estimatedMinutes())
+                                    .as("estimatedMinutes of tutorial '%s'", tutorial.id())
+                                    .isPositive()));
+        }
+
+        @TestFactory
+        @DisplayName("all tutorials have descriptions")
+        Stream<DynamicTest> allTutorialsHaveDescriptions() {
+            return loadAllTutorials().stream().map(tutorial ->
+                    DynamicTest.dynamicTest(tutorial.id(), () ->
+                            assertThat(tutorial.content().description())
+                                    .as("description of tutorial '%s'", tutorial.id())
+                                    .isNotBlank()));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Cross-linking**: Glossary terms in tutorial content are annotated with tooltips via `HelpContent.annotateGlossaryTerms`
- **Model auto-open**: "Open Example Model" button on first step of tutorials with a companion model, wired to `FileController.openExample`
- **Search**: Search field in CurriculumBrowserDialog filters tutorials by title, description, and step titles
- **Structural tests**: 510 dynamic tests validating all 24 tutorials (curriculum integrity, step content, model references, nextTutorial chains, metadata quality)
- **Bug fix**: Renamed simulation track ID from `simulation-tools` to `simulation` to match resource directory

## Test plan
- [x] All tests pass (including 510 new structural tests)
- [x] SpotBugs clean

Closes #881