### PR TITLE
Add bias parameter for 2D causal link curve control

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CausalLinkGeometry.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CausalLinkGeometry.java
@@ -91,9 +91,14 @@ public final class CausalLinkGeometry {
         // and the reciprocal curves the other way.
         int direction = curveDirection(fromName, toName, allLinks);
 
+        // Bias shifts the control point along the chord direction
+        double bias = findBias(fromName, toName, allLinks);
+        double chordUnitX = dx / dist;
+        double chordUnitY = dy / dist;
+
         return new ControlPoint(
-                midX + perpX * bulge * direction,
-                midY + perpY * bulge * direction
+                midX + chordUnitX * bias + perpX * bulge * direction,
+                midY + chordUnitY * bias + perpY * bulge * direction
         );
     }
 
@@ -108,6 +113,19 @@ public final class CausalLinkGeometry {
             }
         }
         return Double.NaN;
+    }
+
+    /**
+     * Finds the bias for a specific causal link, or 0 if none.
+     */
+    static double findBias(String fromName, String toName,
+                                    List<CausalLinkDef> allLinks) {
+        for (CausalLinkDef link : allLinks) {
+            if (link.from().equals(fromName) && link.to().equals(toName)) {
+                return link.bias();
+            }
+        }
+        return 0.0;
     }
 
     /**
@@ -223,9 +241,14 @@ public final class CausalLinkGeometry {
 
         int direction = curveDirection(fromName, toName, allLinks);
 
+        // Bias shifts the control point along the chord direction
+        double bias = findBias(fromName, toName, allLinks);
+        double chordUnitX = dx / chordLen;
+        double chordUnitY = dy / chordLen;
+
         return new ControlPoint(
-                midX + finalDirX * bulge * direction,
-                midY + finalDirY * bulge * direction
+                midX + chordUnitX * bias + finalDirX * bulge * direction,
+                midY + chordUnitY * bias + finalDirY * bulge * direction
         );
     }
 
@@ -465,9 +488,14 @@ public final class CausalLinkGeometry {
 
         int direction = curveDirection(fromName, toName, allLinks);
 
+        // Bias shifts the control point along the chord direction
+        double bias = findBias(fromName, toName, allLinks);
+        double chordUnitX = dx / chordLen;
+        double chordUnitY = dy / chordLen;
+
         return new ControlPoint(
-                midX + perpX * bulge * direction,
-                midY + perpY * bulge * direction
+                midX + chordUnitX * bias + perpX * bulge * direction,
+                midY + chordUnitY * bias + perpY * bulge * direction
         );
     }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ElementCascadeManager.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ElementCascadeManager.java
@@ -102,7 +102,8 @@ final class ElementCascadeManager {
                         toMatch ? newName : link.to(),
                         link.polarity(),
                         link.comment(),
-                        link.strength()));
+                        link.strength(),
+                        link.bias()));
             }
         }
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/InputDispatcher.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/InputDispatcher.java
@@ -478,16 +478,16 @@ final class InputDispatcher {
         }
 
         if (causalLinkDrag.isActive()) {
-            double strength = causalLinkDrag.drag(
+            CausalLinkDragController.DragResult result = causalLinkDrag.drag(
                     viewport.toWorldX(event.getX()),
                     viewport.toWorldY(event.getY()));
             ModelEditor editor = canvas.getEditor();
             if (editor != null) {
                 canvas.saveUndoStateTentative("Adjust curve");
-                editor.setCausalLinkStrength(
+                editor.setCausalLinkStrengthAndBias(
                         causalLinkDrag.getFromName(),
                         causalLinkDrag.getToName(),
-                        strength);
+                        result.strength(), result.bias());
             }
             canvas.requestRedraw();
             event.consume();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
@@ -583,7 +583,8 @@ public class ModelEditor {
         for (int i = 0; i < causalLinks.size(); i++) {
             CausalLinkDef link = causalLinks.get(i);
             if (link.from().equals(from) && link.to().equals(to)) {
-                causalLinks.set(i, new CausalLinkDef(from, to, polarity, link.comment(), link.strength()));
+                causalLinks.set(i, new CausalLinkDef(from, to, polarity, link.comment(),
+                        link.strength(), link.bias()));
                 return true;
             }
         }
@@ -597,6 +598,20 @@ public class ModelEditor {
             CausalLinkDef link = causalLinks.get(i);
             if (link.from().equals(from) && link.to().equals(to)) {
                 causalLinks.set(i, link.withStrength(strength));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** @return true if the causal link was found and its strength and bias updated */
+    public boolean setCausalLinkStrengthAndBias(String from, String to,
+                                                 double strength, double bias) {
+        checkFxThread();
+        for (int i = 0; i < causalLinks.size(); i++) {
+            CausalLinkDef link = causalLinks.get(i);
+            if (link.from().equals(from) && link.to().equals(to)) {
+                causalLinks.set(i, link.withStrengthAndBias(strength, bias));
                 return true;
             }
         }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CausalLinkDragController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CausalLinkDragController.java
@@ -11,8 +11,9 @@ import java.util.List;
 /**
  * Controller for dragging the curvature handle on a selected causal link.
  * The handle appears at the midpoint (t=0.5) of the quadratic Bézier curve.
- * Dragging it adjusts the link's strength value by projecting the drag
- * position onto the same direction axis the renderer uses.
+ * Dragging it adjusts both the link's strength (perpendicular offset) and
+ * bias (parallel offset along the chord), giving the user full 2D control
+ * over the curve shape.
  */
 public final class CausalLinkDragController {
 
@@ -22,13 +23,22 @@ public final class CausalLinkDragController {
     /** Visual radius of the drawn handle. */
     public static final double HANDLE_RADIUS = 5;
 
+    /**
+     * Result of a drag operation: perpendicular strength and parallel bias.
+     */
+    public record DragResult(double strength, double bias) {
+    }
+
     private boolean active;
     private String fromName;
     private String toName;
 
-    // Direction unit vector and chord midpoint, captured at drag start
+    // Direction unit vector (perpendicular) and chord midpoint, captured at drag start
     private double dirX;
     private double dirY;
+    // Chord unit vector (parallel), captured at drag start
+    private double chordUnitX;
+    private double chordUnitY;
     private double midX;
     private double midY;
 
@@ -85,9 +95,8 @@ public final class CausalLinkDragController {
 
     /**
      * Begins a handle drag for the given causal link.
-     * Derives the projection axis from the auto-computed control point
-     * (the same algorithm the renderer uses), so the drag direction
-     * matches what the user sees on screen.
+     * Derives the perpendicular projection axis from the auto-computed control
+     * point, and the parallel axis from the chord direction.
      */
     public void start(ConnectionId connection, CanvasState state,
                       List<CausalLinkDef> allLinks,
@@ -104,10 +113,22 @@ public final class CausalLinkDragController {
         this.midX = (fromX + toX) / 2;
         this.midY = (fromY + toY) / 2;
 
+        // Chord unit vector (raw direction from source to target)
+        double cdx = toX - fromX;
+        double cdy = toY - fromY;
+        double chordLen = Math.sqrt(cdx * cdx + cdy * cdy);
+        if (chordLen >= 1) {
+            this.chordUnitX = cdx / chordLen;
+            this.chordUnitY = cdy / chordLen;
+        } else {
+            this.chordUnitX = 1;
+            this.chordUnitY = 0;
+        }
+
         // Compute the auto control point using the same algorithm as the renderer,
-        // temporarily ignoring any existing strength override so we get the
+        // temporarily ignoring any existing user overrides so we get the
         // natural direction vector.
-        List<CausalLinkDef> autoLinks = stripStrength(fromName, toName, allLinks);
+        List<CausalLinkDef> autoLinks = stripUserOverrides(fromName, toName, allLinks);
         CausalLinkGeometry.ControlPoint autoCP = CausalLinkGeometry.controlPoint(
                 fromX, fromY, toX, toY, fromName, toName, autoLinks, loopCtx);
 
@@ -117,15 +138,12 @@ public final class CausalLinkDragController {
 
         if (aDist < 0.001) {
             // Degenerate — fall back to simple perpendicular
-            double dx = toX - fromX;
-            double dy = toY - fromY;
-            double dist = Math.sqrt(dx * dx + dy * dy);
-            if (dist < 1) {
+            if (chordLen < 1) {
                 this.dirX = 0;
                 this.dirY = -1;
             } else {
-                this.dirX = -dy / dist;
-                this.dirY = dx / dist;
+                this.dirX = -cdy / chordLen;
+                this.dirY = cdx / chordLen;
             }
         } else {
             this.dirX = ax / aDist;
@@ -134,16 +152,18 @@ public final class CausalLinkDragController {
     }
 
     /**
-     * Updates the strength based on the current drag position.
-     * Projects the drag point onto the direction axis derived at start.
-     * Negative values reverse the curve direction.
+     * Updates strength and bias based on the current drag position.
+     * Decomposes the drag displacement into perpendicular (strength) and
+     * parallel (bias) components.
      *
-     * @return the computed strength value
+     * @return the computed strength and bias values
      */
-    public double drag(double worldX, double worldY) {
+    public DragResult drag(double worldX, double worldY) {
         double dx = worldX - midX;
         double dy = worldY - midY;
-        return dx * dirX + dy * dirY;
+        double strength = dx * dirX + dy * dirY;
+        double bias = dx * chordUnitX + dy * chordUnitY;
+        return new DragResult(strength, bias);
     }
 
     /**
@@ -168,15 +188,16 @@ public final class CausalLinkDragController {
     }
 
     /**
-     * Returns a copy of the link list with the strength stripped from the
-     * specific link, so we can compute the auto control point direction.
+     * Returns a copy of the link list with user overrides (strength and bias)
+     * stripped from the specific link, so we can compute the auto control
+     * point direction.
      */
-    private static List<CausalLinkDef> stripStrength(String from, String to,
-                                                      List<CausalLinkDef> allLinks) {
+    private static List<CausalLinkDef> stripUserOverrides(String from, String to,
+                                                            List<CausalLinkDef> allLinks) {
         return allLinks.stream()
                 .map(link -> {
                     if (link.from().equals(from) && link.to().equals(to)
-                            && link.hasStrength()) {
+                            && (link.hasStrength() || link.hasBias())) {
                         return new CausalLinkDef(link.from(), link.to(),
                                 link.polarity(), link.comment());
                     }

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/CausalLinkGeometryTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/CausalLinkGeometryTest.java
@@ -312,6 +312,68 @@ class CausalLinkGeometryTest {
     }
 
     @Nested
+    class BiasControlPoint {
+
+        @Test
+        void shouldShiftControlPointAlongChordWithBias() {
+            // Horizontal chord: A at (0,0), B at (200,0)
+            List<CausalLinkDef> linksNoBias = List.of(new CausalLinkDef("A", "B"));
+            List<CausalLinkDef> linksWithBias = List.of(
+                    new CausalLinkDef("A", "B", CausalLinkDef.Polarity.UNKNOWN,
+                            null, Double.NaN, 30.0));
+
+            CausalLinkGeometry.ControlPoint cpAuto = CausalLinkGeometry.controlPoint(
+                    0, 0, 200, 0, "A", "B", linksNoBias);
+            CausalLinkGeometry.ControlPoint cpBias = CausalLinkGeometry.controlPoint(
+                    0, 0, 200, 0, "A", "B", linksWithBias);
+
+            // Bias=30 on a horizontal chord should shift X by 30
+            assertThat(cpBias.x()).isCloseTo(cpAuto.x() + 30,
+                    org.assertj.core.data.Offset.offset(0.01));
+            // Y (perpendicular) should be unchanged
+            assertThat(cpBias.y()).isCloseTo(cpAuto.y(),
+                    org.assertj.core.data.Offset.offset(0.01));
+        }
+
+        @Test
+        void shouldWorkWithLoopContextOverload() {
+            CanvasState state = new CanvasState();
+            state.loadFrom(new ViewDef("test", List.of(
+                    new ElementPlacement("A", ElementType.CLD_VARIABLE, 0, 0),
+                    new ElementPlacement("B", ElementType.CLD_VARIABLE, 200, 0)
+            ), List.of(), List.of()));
+
+            List<CausalLinkDef> linksNoBias = List.of(new CausalLinkDef("A", "B"));
+            List<CausalLinkDef> linksWithBias = List.of(
+                    new CausalLinkDef("A", "B", CausalLinkDef.Polarity.UNKNOWN,
+                            null, Double.NaN, 40.0));
+
+            CausalLinkGeometry.LoopContext ctx = CausalLinkGeometry.loopContext(state);
+
+            CausalLinkGeometry.ControlPoint cpAuto = CausalLinkGeometry.controlPoint(
+                    0, 0, 200, 0, "A", "B", linksNoBias, ctx);
+            CausalLinkGeometry.ControlPoint cpBias = CausalLinkGeometry.controlPoint(
+                    0, 0, 200, 0, "A", "B", linksWithBias, ctx);
+
+            assertThat(cpBias.x()).isCloseTo(cpAuto.x() + 40,
+                    org.assertj.core.data.Offset.offset(0.01));
+        }
+
+        @Test
+        void shouldDefaultToZeroBias() {
+            // Links without explicit bias should have bias=0 (no shift)
+            List<CausalLinkDef> links = List.of(new CausalLinkDef("A", "B"));
+
+            CausalLinkGeometry.ControlPoint cp = CausalLinkGeometry.controlPoint(
+                    0, 0, 200, 0, "A", "B", links);
+
+            // Midpoint X is 100 — control point X should be at 100 (no bias shift)
+            assertThat(cp.x()).isCloseTo(100,
+                    org.assertj.core.data.Offset.offset(0.01));
+        }
+    }
+
+    @Nested
     class GraphCentroidComputation {
 
         @Test

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/CausalLinkDragControllerTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/controllers/CausalLinkDragControllerTest.java
@@ -129,9 +129,9 @@ class CausalLinkDragControllerTest {
             // direction as the handle offset
             double dragX = pos[0] + (pos[0] - 250) * 2;
             double dragY = pos[1] + (pos[1] - 200) * 2;
-            double strength = controller.drag(dragX, dragY);
+            CausalLinkDragController.DragResult result = controller.drag(dragX, dragY);
 
-            assertThat(strength).isGreaterThan(0);
+            assertThat(result.strength()).isGreaterThan(0);
         }
 
         @Test
@@ -143,19 +143,54 @@ class CausalLinkDragControllerTest {
                     connection, state, links, loopCtx);
             double dragX = 250 - (pos[0] - 250) * 2;
             double dragY = 200 - (pos[1] - 200) * 2;
-            double strength = controller.drag(dragX, dragY);
+            CausalLinkDragController.DragResult result = controller.drag(dragX, dragY);
 
-            assertThat(strength).isLessThan(0);
+            assertThat(result.strength()).isLessThan(0);
         }
 
         @Test
-        void shouldReturnZeroAtChordMidpoint() {
+        void shouldReturnZeroBothAtChordMidpoint() {
             controller.start(connection, state, links, loopCtx);
 
-            // Drag to chord midpoint
-            double strength = controller.drag(250, 200);
+            // Drag to chord midpoint — both strength and bias should be near zero
+            CausalLinkDragController.DragResult result = controller.drag(250, 200);
 
-            assertThat(strength).isCloseTo(0, within(0.01));
+            assertThat(result.strength()).isCloseTo(0, within(0.01));
+            assertThat(result.bias()).isCloseTo(0, within(0.01));
+        }
+
+        @Test
+        void shouldComputePositiveBiasDraggingTowardTarget() {
+            controller.start(connection, state, links, loopCtx);
+
+            // Drag to the right of midpoint (toward B at x=400)
+            // Chord midpoint is (250, 200), chord goes left-to-right
+            CausalLinkDragController.DragResult result = controller.drag(350, 200);
+
+            assertThat(result.bias()).isGreaterThan(0);
+        }
+
+        @Test
+        void shouldComputeNegativeBiasDraggingTowardSource() {
+            controller.start(connection, state, links, loopCtx);
+
+            // Drag to the left of midpoint (toward A at x=100)
+            CausalLinkDragController.DragResult result = controller.drag(150, 200);
+
+            assertThat(result.bias()).isLessThan(0);
+        }
+
+        @Test
+        void shouldDecomposeDiagonalDragIntoBothComponents() {
+            controller.start(connection, state, links, loopCtx);
+
+            // Drag diagonally — should produce both non-zero strength and bias
+            // For a horizontal chord, dragging up-right should give positive
+            // bias (rightward) and non-zero strength (upward component)
+            CausalLinkDragController.DragResult result = controller.drag(350, 100);
+
+            assertThat(result.strength()).isNotCloseTo(0, within(0.01));
+            assertThat(result.bias()).isNotCloseTo(0, within(0.01));
         }
 
         @Test
@@ -216,6 +251,58 @@ class CausalLinkDragControllerTest {
 
             assertThat(cp1.x()).isCloseTo(cp2.x(), within(0.01));
             assertThat(cp1.y()).isCloseTo(cp2.y(), within(0.01));
+        }
+    }
+
+    @Nested
+    @DisplayName("bias application")
+    class BiasApplication {
+
+        @Test
+        void shouldShiftControlPointAlongChordWithPositiveBias() {
+            // A at (100,200), B at (400,200) — horizontal chord, midpoint at (250,200)
+            List<CausalLinkDef> linksWithBias = List.of(
+                    new CausalLinkDef("A", "B", CausalLinkDef.Polarity.UNKNOWN,
+                            null, Double.NaN, 50.0));
+
+            CausalLinkGeometry.ControlPoint cpBias = CausalLinkGeometry.controlPoint(
+                    100, 200, 400, 200, "A", "B", linksWithBias);
+            CausalLinkGeometry.ControlPoint cpAuto = CausalLinkGeometry.controlPoint(
+                    100, 200, 400, 200, "A", "B", links);
+
+            // Positive bias should shift CP to the right (toward B)
+            assertThat(cpBias.x()).isGreaterThan(cpAuto.x());
+            // Y offset from perpendicular should be the same
+            assertThat(cpBias.y()).isCloseTo(cpAuto.y(), within(0.01));
+        }
+
+        @Test
+        void shouldShiftControlPointOppositeWithNegativeBias() {
+            List<CausalLinkDef> linksWithBias = List.of(
+                    new CausalLinkDef("A", "B", CausalLinkDef.Polarity.UNKNOWN,
+                            null, Double.NaN, -50.0));
+
+            CausalLinkGeometry.ControlPoint cpBias = CausalLinkGeometry.controlPoint(
+                    100, 200, 400, 200, "A", "B", linksWithBias);
+            CausalLinkGeometry.ControlPoint cpAuto = CausalLinkGeometry.controlPoint(
+                    100, 200, 400, 200, "A", "B", links);
+
+            // Negative bias should shift CP to the left (toward A)
+            assertThat(cpBias.x()).isLessThan(cpAuto.x());
+        }
+
+        @Test
+        void shouldCombineStrengthAndBias() {
+            List<CausalLinkDef> linksWithBoth = List.of(
+                    new CausalLinkDef("A", "B", CausalLinkDef.Polarity.UNKNOWN,
+                            null, 60.0, 40.0));
+
+            CausalLinkGeometry.ControlPoint cp = CausalLinkGeometry.controlPoint(
+                    100, 200, 400, 200, "A", "B", linksWithBoth);
+
+            // For a horizontal chord: bias shifts X, strength shifts Y
+            // Midpoint is (250, 200), bias=40 shifts right, strength=60 shifts perpendicular
+            assertThat(cp.x()).isCloseTo(250 + 40, within(1.0));
         }
     }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -479,6 +479,9 @@ public class ModelDefinitionSerializer {
             if (link.hasStrength()) {
                 node.put("strength", link.strength());
             }
+            if (link.hasBias()) {
+                node.put("bias", link.bias());
+            }
             arr.add(node);
         }
         return arr;
@@ -718,12 +721,15 @@ public class ModelDefinitionSerializer {
                 }
                 double strength = n.has("strength")
                         ? n.get("strength").asDouble() : Double.NaN;
+                double bias = n.has("bias")
+                        ? n.get("bias").asDouble() : 0.0;
                 causalLinks.add(new CausalLinkDef(
                         requiredText(n, "from"),
                         requiredText(n, "to"),
                         polarity,
                         textOrNull(n, "comment"),
-                        strength));
+                        strength,
+                        bias));
             }
         }
         return causalLinks;

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/CausalLinkDef.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/CausalLinkDef.java
@@ -10,13 +10,15 @@ package systems.courant.sd.model.def;
  * @param polarity the direction of influence (positive, negative, or unknown)
  * @param comment optional annotation (e.g., "after a delay")
  * @param strength curve strength override ({@code NaN} = auto-computed curvature)
+ * @param bias control point offset along the chord direction ({@code 0.0} = centered)
  */
 public record CausalLinkDef(
         String from,
         String to,
         Polarity polarity,
         String comment,
-        double strength
+        double strength,
+        double bias
 ) {
 
     public enum Polarity {
@@ -78,7 +80,28 @@ public record CausalLinkDef(
     }
 
     /**
-     * Creates a causal link with default (auto) curve strength.
+     * Returns true if this link has a non-zero bias (apex shifted along chord).
+     */
+    public boolean hasBias() {
+        return bias != 0.0;
+    }
+
+    /**
+     * Creates a causal link with default (auto) curve strength and no bias.
+     *
+     * @param from     the source variable name
+     * @param to       the target variable name
+     * @param polarity the direction of influence
+     * @param comment  optional annotation
+     * @param strength curve strength override
+     */
+    public CausalLinkDef(String from, String to, Polarity polarity, String comment,
+                          double strength) {
+        this(from, to, polarity, comment, strength, 0.0);
+    }
+
+    /**
+     * Creates a causal link with default (auto) curve strength and no bias.
      *
      * @param from     the source variable name
      * @param to       the target variable name
@@ -86,7 +109,7 @@ public record CausalLinkDef(
      * @param comment  optional annotation
      */
     public CausalLinkDef(String from, String to, Polarity polarity, String comment) {
-        this(from, to, polarity, comment, Double.NaN);
+        this(from, to, polarity, comment, Double.NaN, 0.0);
     }
 
     /**
@@ -97,7 +120,7 @@ public record CausalLinkDef(
      * @param polarity the direction of influence
      */
     public CausalLinkDef(String from, String to, Polarity polarity) {
-        this(from, to, polarity, null, Double.NaN);
+        this(from, to, polarity, null, Double.NaN, 0.0);
     }
 
     /**
@@ -107,13 +130,27 @@ public record CausalLinkDef(
      * @param to   the target variable name
      */
     public CausalLinkDef(String from, String to) {
-        this(from, to, Polarity.UNKNOWN, null, Double.NaN);
+        this(from, to, Polarity.UNKNOWN, null, Double.NaN, 0.0);
     }
 
     /**
-     * Returns a copy of this link with a different strength value.
+     * Returns a copy of this link with a different strength value, preserving bias.
      */
     public CausalLinkDef withStrength(double newStrength) {
-        return new CausalLinkDef(from, to, polarity, comment, newStrength);
+        return new CausalLinkDef(from, to, polarity, comment, newStrength, bias);
+    }
+
+    /**
+     * Returns a copy of this link with a different bias value, preserving strength.
+     */
+    public CausalLinkDef withBias(double newBias) {
+        return new CausalLinkDef(from, to, polarity, comment, strength, newBias);
+    }
+
+    /**
+     * Returns a copy of this link with both strength and bias replaced.
+     */
+    public CausalLinkDef withStrengthAndBias(double newStrength, double newBias) {
+        return new CausalLinkDef(from, to, polarity, comment, newStrength, newBias);
     }
 }

--- a/courant-engine/src/test/java/systems/courant/sd/io/json/ModelDefinitionSerializerTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/io/json/ModelDefinitionSerializerTest.java
@@ -326,6 +326,49 @@ class ModelDefinitionSerializerTest {
     }
 
     @Test
+    void shouldRoundTripCausalLinkBias() {
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("Test")
+                .cldVariable("A")
+                .cldVariable("B")
+                .causalLink(new CausalLinkDef("A", "B",
+                        CausalLinkDef.Polarity.POSITIVE, null, 60.0, 25.0))
+                .build();
+
+        ModelDefinition roundTripped = serializer.fromJson(serializer.toJson(def));
+        CausalLinkDef link = roundTripped.causalLinks().get(0);
+        assertThat(link.strength()).isEqualTo(60.0);
+        assertThat(link.bias()).isEqualTo(25.0);
+    }
+
+    @Test
+    void shouldDefaultBiasWhenAbsentInJson() {
+        String json = """
+                {
+                  "name": "Test",
+                  "cldVariables": [{"name": "A"}, {"name": "B"}],
+                  "causalLinks": [{"from": "A", "to": "B", "polarity": "POSITIVE", "strength": 50.0}]
+                }
+                """;
+        ModelDefinition def = serializer.fromJson(json);
+        assertThat(def.causalLinks().get(0).bias()).isEqualTo(0.0);
+    }
+
+    @Test
+    void shouldOmitBiasWhenZero() {
+        ModelDefinition def = new ModelDefinitionBuilder()
+                .name("Test")
+                .cldVariable("A")
+                .cldVariable("B")
+                .causalLink(new CausalLinkDef("A", "B",
+                        CausalLinkDef.Polarity.POSITIVE, null, 50.0, 0.0))
+                .build();
+
+        String json = serializer.toJson(def);
+        assertThat(json).doesNotContain("\"bias\"");
+    }
+
+    @Test
     void shouldRoundTripMixedSfAndCldModel() {
         ModelDefinition def = new ModelDefinitionBuilder()
                 .name("Mixed")

--- a/courant-engine/src/test/java/systems/courant/sd/model/def/CausalLinkDefTest.java
+++ b/courant-engine/src/test/java/systems/courant/sd/model/def/CausalLinkDefTest.java
@@ -55,4 +55,48 @@ class CausalLinkDefTest {
         assertThat(Polarity.NEGATIVE.symbol()).isEqualTo("-");
         assertThat(Polarity.UNKNOWN.symbol()).isEqualTo("?");
     }
+
+    @Test
+    void shouldDefaultBiasToZero() {
+        assertThat(new CausalLinkDef("A", "B").bias()).isEqualTo(0.0);
+        assertThat(new CausalLinkDef("A", "B", Polarity.POSITIVE).bias()).isEqualTo(0.0);
+        assertThat(new CausalLinkDef("A", "B", Polarity.POSITIVE, "note").bias()).isEqualTo(0.0);
+        assertThat(new CausalLinkDef("A", "B", Polarity.POSITIVE, null, 50.0).bias()).isEqualTo(0.0);
+    }
+
+    @Test
+    void shouldReportHasBias() {
+        assertThat(new CausalLinkDef("A", "B").hasBias()).isFalse();
+        assertThat(new CausalLinkDef("A", "B", Polarity.UNKNOWN, null, Double.NaN, 10.0).hasBias()).isTrue();
+        assertThat(new CausalLinkDef("A", "B", Polarity.UNKNOWN, null, Double.NaN, 0.0).hasBias()).isFalse();
+    }
+
+    @Test
+    void shouldReturnCopyWithBias() {
+        CausalLinkDef link = new CausalLinkDef("A", "B", Polarity.POSITIVE, "note", 50.0);
+        CausalLinkDef withBias = link.withBias(30.0);
+
+        assertThat(withBias.bias()).isEqualTo(30.0);
+        assertThat(withBias.strength()).isEqualTo(50.0);
+        assertThat(withBias.polarity()).isEqualTo(Polarity.POSITIVE);
+        assertThat(withBias.comment()).isEqualTo("note");
+    }
+
+    @Test
+    void shouldReturnCopyWithStrengthAndBias() {
+        CausalLinkDef link = new CausalLinkDef("A", "B");
+        CausalLinkDef updated = link.withStrengthAndBias(80.0, -20.0);
+
+        assertThat(updated.strength()).isEqualTo(80.0);
+        assertThat(updated.bias()).isEqualTo(-20.0);
+    }
+
+    @Test
+    void shouldPreserveBiasInWithStrength() {
+        CausalLinkDef link = new CausalLinkDef("A", "B", Polarity.UNKNOWN, null, 50.0, 25.0);
+        CausalLinkDef updated = link.withStrength(100.0);
+
+        assertThat(updated.strength()).isEqualTo(100.0);
+        assertThat(updated.bias()).isEqualTo(25.0);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a `bias` field to `CausalLinkDef` that shifts the curve's control point along the chord direction
- Combined with `strength` (perpendicular offset), gives users full 2D control over curve shape
- Drag handle now decomposes mouse movement into both perpendicular (strength) and parallel (bias) components simultaneously
- Backward compatible: old files without `bias` default to `0.0`; zero bias is omitted from JSON

## Test plan
- [x] CausalLinkDefTest: bias defaults, `hasBias()`, `withBias()`, `withStrengthAndBias()`, bias preserved by `withStrength()`
- [x] ModelDefinitionSerializerTest: round-trip bias, backward compat (no bias in JSON → 0.0), zero bias omitted
- [x] CausalLinkGeometryTest: bias shifts CP along chord, works with LoopContext, defaults to zero
- [x] CausalLinkDragControllerTest: DragResult with both components, parallel drag, diagonal decomposition
- [x] All existing tests pass (full reactor)
- [x] SpotBugs clean

Closes #1431