### PR TITLE
Create AbstractModelImporter and ModelExporter interface

### DIFF
--- a/courant-engine/src/main/java/systems/courant/sd/io/AbstractModelImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/AbstractModelImporter.java
@@ -1,0 +1,76 @@
+package systems.courant.sd.io;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+/**
+ * Base class for {@link ModelImporter} implementations. Provides common
+ * file-reading logic (size validation, encoding fallback) and shared
+ * utilities so that format-specific importers focus only on parsing.
+ *
+ * <p>Subclasses implement {@link #importModel(String, String)} for
+ * format-specific parsing; file I/O is handled here.</p>
+ */
+public abstract class AbstractModelImporter implements ModelImporter {
+
+    /** Maximum file size accepted for import (10 MB). */
+    protected static final long MAX_FILE_SIZE = 10L * 1024 * 1024;
+
+    /** Regex for detecting numeric literals (integer, decimal, scientific notation). */
+    private static final Pattern NUMERIC_PATTERN = Pattern.compile(
+            "^[+-]?(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?$");
+
+    /**
+     * Reads a model file with encoding fallback (UTF-8 → windows-1252),
+     * validates its size, extracts the model name from the filename, and
+     * delegates to {@link #importModel(String, String)}.
+     */
+    @Override
+    public ImportResult importModel(Path path) throws IOException {
+        long size = Files.size(path);
+        if (size > MAX_FILE_SIZE) {
+            throw new IOException("File exceeds maximum allowed size of "
+                    + (MAX_FILE_SIZE / (1024 * 1024)) + " MB: " + path);
+        }
+        String content = readFileContent(path);
+        String modelName = extractModelName(path);
+        return importModel(content, modelName);
+    }
+
+    /**
+     * Reads file content with UTF-8, falling back to windows-1252 on encoding errors.
+     */
+    protected String readFileContent(Path path) throws IOException {
+        try {
+            return Files.readString(path, StandardCharsets.UTF_8);
+        } catch (CharacterCodingException e) {
+            return Files.readString(path, Charset.forName("windows-1252"));
+        }
+    }
+
+    /**
+     * Extracts the model name from a file path by stripping the extension.
+     */
+    protected String extractModelName(Path path) {
+        Path fileName = path.getFileName();
+        String name = fileName != null ? fileName.toString() : path.toString();
+        int dotPos = name.lastIndexOf('.');
+        if (dotPos > 0) {
+            name = name.substring(0, dotPos);
+        }
+        return name;
+    }
+
+    /**
+     * Returns true if the expression is a numeric literal (integer, decimal,
+     * or scientific notation).
+     */
+    protected static boolean isNumericLiteral(String expr) {
+        return expr != null && NUMERIC_PATTERN.matcher(expr.strip()).matches();
+    }
+}

--- a/courant-engine/src/main/java/systems/courant/sd/io/ExportUtils.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/ExportUtils.java
@@ -1,10 +1,16 @@
 package systems.courant.sd.io;
 
+import systems.courant.sd.model.def.CldVariableDef;
+import systems.courant.sd.model.def.FlowDef;
 import systems.courant.sd.model.def.LookupTableDef;
 import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.StockDef;
+import systems.courant.sd.model.def.SubscriptDef;
 import systems.courant.sd.model.def.VariableDef;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -92,5 +98,49 @@ public final class ExportUtils {
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Builds a mapping from normalized (equation-form) names to display names
+     * for all elements in the model. This allows expression denormalization to
+     * preserve the original underscore/space distinction. Useful for any
+     * exporter that needs to translate internal names back to display format.
+     */
+    public static Map<String, String> buildNameMap(ModelDefinition def) {
+        Map<String, String> map = new HashMap<>();
+        for (StockDef s : def.stocks()) {
+            putDisplayName(map, s.name());
+        }
+        for (FlowDef f : def.flows()) {
+            putDisplayName(map, f.name());
+        }
+        for (VariableDef v : def.variables()) {
+            putDisplayName(map, v.name());
+        }
+        for (LookupTableDef l : def.lookupTables()) {
+            putDisplayName(map, l.name());
+        }
+        for (CldVariableDef c : def.cldVariables()) {
+            putDisplayName(map, c.name());
+        }
+        for (SubscriptDef s : def.subscripts()) {
+            putDisplayName(map, s.name());
+            for (String label : s.labels()) {
+                putDisplayName(map, label);
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Adds a display name → normalized name mapping. The normalized form
+     * replaces spaces with underscores (equation-form).
+     */
+    public static void putDisplayName(Map<String, String> map, String displayName) {
+        if (displayName == null || displayName.isBlank()) {
+            return;
+        }
+        String normalized = displayName.strip().replace(' ', '_');
+        map.put(normalized, displayName);
     }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/io/ModelExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/ModelExporter.java
@@ -1,0 +1,34 @@
+package systems.courant.sd.io;
+
+import systems.courant.sd.model.def.ModelDefinition;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Format-agnostic interface for exporting system dynamics models to external
+ * tool formats (e.g., Vensim .mdl, XMILE).
+ *
+ * <p>Implementations translate a {@link ModelDefinition} into the target
+ * file format. Shared export utilities (lookup handling, name map building)
+ * are available in {@link ExportUtils}.</p>
+ */
+public interface ModelExporter {
+
+    /**
+     * Exports a model definition to a string in the target format.
+     *
+     * @param definition the model definition to export
+     * @return the formatted model content
+     */
+    String export(ModelDefinition definition);
+
+    /**
+     * Exports a model definition to a file on disk.
+     *
+     * @param definition the model definition to export
+     * @param path       the file path to write to
+     * @throws IOException if the file cannot be written
+     */
+    void exportToFile(ModelDefinition definition, Path path) throws IOException;
+}

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimExporter.java
@@ -2,6 +2,7 @@ package systems.courant.sd.io.vensim;
 
 import systems.courant.sd.io.ExportUtils;
 import systems.courant.sd.io.FormatUtils;
+import systems.courant.sd.io.ModelExporter;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.CausalLinkDef;
 import systems.courant.sd.model.def.CldVariableDef;
@@ -48,7 +49,7 @@ import java.util.regex.Pattern;
  * VensimExporter.toFile(modelDefinition, Path.of("model.mdl"));
  * }</pre>
  */
-public final class VensimExporter {
+public final class VensimExporter implements ModelExporter {
 
     private static final Logger logger = LoggerFactory.getLogger(VensimExporter.class);
 
@@ -79,7 +80,17 @@ public final class VensimExporter {
     private static final Pattern LOOKUP_AREA_EXPORT_PATTERN = Pattern.compile(
             "(?i)\\bLOOKUP_AREA\\s*\\(");
 
-    private VensimExporter() {
+    public VensimExporter() {
+    }
+
+    @Override
+    public String export(ModelDefinition definition) {
+        return toVensim(definition);
+    }
+
+    @Override
+    public void exportToFile(ModelDefinition definition, Path path) throws IOException {
+        toFile(definition, path);
     }
 
     /**
@@ -93,7 +104,7 @@ public final class VensimExporter {
         sb.append("{UTF-8}\n");
 
         // Build name map for expression denormalization (normalized → display name)
-        Map<String, String> nameMap = buildNameMap(def);
+        Map<String, String> nameMap = ExportUtils.buildNameMap(def);
 
         // Collect lookup names referenced by variables (embedded as WITH LOOKUP)
         Set<String> embeddedLookupNames = ExportUtils.collectEmbeddedLookupNames(def);
@@ -798,46 +809,6 @@ public final class VensimExporter {
             }
         }
         return result.toString();
-    }
-
-    /**
-     * Builds a mapping from normalized (equation-form) names to display names
-     * for all elements in the model. This allows expression denormalization to
-     * preserve the original underscore/space distinction.
-     */
-    private static Map<String, String> buildNameMap(ModelDefinition def) {
-        Map<String, String> map = new HashMap<>();
-        for (StockDef s : def.stocks()) {
-            putDisplayName(map, s.name());
-        }
-        for (FlowDef f : def.flows()) {
-            putDisplayName(map, f.name());
-        }
-        for (VariableDef v : def.variables()) {
-            putDisplayName(map, v.name());
-        }
-        for (LookupTableDef l : def.lookupTables()) {
-            putDisplayName(map, l.name());
-        }
-        for (CldVariableDef c : def.cldVariables()) {
-            putDisplayName(map, c.name());
-        }
-        for (SubscriptDef s : def.subscripts()) {
-            putDisplayName(map, s.name());
-            for (String label : s.labels()) {
-                putDisplayName(map, label);
-            }
-        }
-        return map;
-    }
-
-    private static void putDisplayName(Map<String, String> map, String displayName) {
-        if (displayName == null || displayName.isBlank()) {
-            return;
-        }
-        // Convert display name to equation-form (spaces → underscores)
-        String normalized = displayName.strip().replace(' ', '_');
-        map.put(normalized, displayName);
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/vensim/VensimImporter.java
@@ -1,8 +1,8 @@
 package systems.courant.sd.io.vensim;
 
+import systems.courant.sd.io.AbstractModelImporter;
 import systems.courant.sd.io.FormatUtils;
 import systems.courant.sd.io.ImportResult;
-import systems.courant.sd.io.ModelImporter;
 import systems.courant.sd.io.ReferenceDataCsvReader;
 import systems.courant.sd.model.def.ReferenceDataset;
 import systems.courant.sd.model.def.VariableDef;
@@ -17,9 +17,6 @@ import systems.courant.sd.model.def.StockDef;
 import systems.courant.sd.model.def.ViewDef;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -50,18 +47,16 @@ import java.util.regex.Pattern;
  * ModelDefinition def = result.definition();
  * }</pre>
  */
-public class VensimImporter implements ModelImporter {
+public class VensimImporter extends AbstractModelImporter {
 
     private static final Pattern INTEG_PATTERN = Pattern.compile(
             "(?i)^INTEG\\s*\\(");
-    private static final Pattern NUMERIC_PATTERN = Pattern.compile(
-            "^[+-]?(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?$");
     private static final Set<String> SYSTEM_VAR_KEYS = Set.of(
             "INITIAL TIME", "FINAL TIME", "TIME STEP", "SAVEPER");
     private static final Pattern SUBSCRIPT_NAME_PATTERN = Pattern.compile(
             "^(.+?)\\[(.+?)\\]$");
     private static final Set<String> CONTROL_GROUPS = Set.of(".Control");
-    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+    // MAX_FILE_SIZE inherited from AbstractModelImporter
 
     @Override
     public ImportResult importModel(Path path) throws IOException {
@@ -70,21 +65,11 @@ public class VensimImporter implements ModelImporter {
             throw new IOException("File exceeds maximum allowed size of "
                     + (MAX_FILE_SIZE / (1024 * 1024)) + " MB: " + path);
         }
-        String content;
-        try {
-            content = Files.readString(path, StandardCharsets.UTF_8);
-        } catch (CharacterCodingException e) {
-            content = Files.readString(path, Charset.forName("windows-1252"));
-        }
+        String content = readFileContent(path);
         if (content.indexOf('\0') >= 0) {
             throw new IOException("File appears to be binary, not a valid Vensim .mdl file: " + path);
         }
-        Path fileName = path.getFileName();
-        String modelName = fileName != null ? fileName.toString() : path.toString();
-        int dotPos = modelName.lastIndexOf('.');
-        if (dotPos > 0) {
-            modelName = modelName.substring(0, dotPos);
-        }
+        String modelName = extractModelName(path);
         return importModel(content, modelName, path.getParent());
     }
 
@@ -1067,10 +1052,6 @@ public class VensimImporter implements ModelImporter {
                         lookupNames, subscriptDimensions);
         warnings.addAll(tr.warnings());
         return InitialValueResult.ofExpression(tr.expression());
-    }
-
-    private static boolean isNumericLiteral(String expr) {
-        return expr != null && NUMERIC_PATTERN.matcher(expr.strip()).matches();
     }
 
     private static boolean isSystemVar(String name) {

--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileExporter.java
@@ -2,6 +2,7 @@ package systems.courant.sd.io.xmile;
 
 import systems.courant.sd.io.ExportUtils;
 import systems.courant.sd.io.FormatUtils;
+import systems.courant.sd.io.ModelExporter;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.FlowDef;
 import systems.courant.sd.model.def.LookupTableDef;
@@ -48,11 +49,21 @@ import java.util.StringJoiner;
  * XmileExporter.toFile(modelDefinition, Path.of("model.xmile"));
  * }</pre>
  */
-public final class XmileExporter {
+public final class XmileExporter implements ModelExporter {
 
     private static final int MAX_MODULE_DEPTH = 50;
 
-    private XmileExporter() {
+    public XmileExporter() {
+    }
+
+    @Override
+    public String export(ModelDefinition definition) {
+        return toXmile(definition);
+    }
+
+    @Override
+    public void exportToFile(ModelDefinition definition, Path path) throws IOException {
+        toFile(definition, path);
     }
 
     /**

--- a/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileImporter.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/xmile/XmileImporter.java
@@ -1,7 +1,7 @@
 package systems.courant.sd.io.xmile;
 
+import systems.courant.sd.io.AbstractModelImporter;
 import systems.courant.sd.io.ImportResult;
-import systems.courant.sd.io.ModelImporter;
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.FlowDef;
 import systems.courant.sd.model.def.LookupTableDef;
@@ -28,11 +28,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.charset.Charset;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -60,38 +55,14 @@ import java.util.regex.Pattern;
  * ModelDefinition def = result.definition();
  * }</pre>
  */
-public class XmileImporter implements ModelImporter {
+public class XmileImporter extends AbstractModelImporter {
 
     private static final Logger log = LoggerFactory.getLogger(XmileImporter.class);
 
-    private static final Pattern NUMERIC_PATTERN = Pattern.compile(
-            "^[+-]?(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?$");
-    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+    // NUMERIC_PATTERN and MAX_FILE_SIZE inherited from AbstractModelImporter
     private static final Set<String> UNSUPPORTED_ELEMENTS = Set.of(
             XmileConstants.GROUP, XmileConstants.MACRO,
             XmileConstants.EVENT_POSTER);
-
-    @Override
-    public ImportResult importModel(Path path) throws IOException {
-        long size = Files.size(path);
-        if (size > MAX_FILE_SIZE) {
-            throw new IOException("File exceeds maximum allowed size of "
-                    + (MAX_FILE_SIZE / (1024 * 1024)) + " MB: " + path);
-        }
-        String content;
-        try {
-            content = Files.readString(path, StandardCharsets.UTF_8);
-        } catch (CharacterCodingException e) {
-            content = Files.readString(path, Charset.forName("windows-1252"));
-        }
-        Path fileName = path.getFileName();
-        String modelName = fileName != null ? fileName.toString() : path.toString();
-        int dotPos = modelName.lastIndexOf('.');
-        if (dotPos > 0) {
-            modelName = modelName.substring(0, dotPos);
-        }
-        return importModel(content, modelName);
-    }
 
     @Override
     public ImportResult importModel(String content, String modelName) {
@@ -656,9 +627,7 @@ public class XmileImporter implements ModelImporter {
         return defaultValue;
     }
 
-    private static boolean isNumericLiteral(String expr) {
-        return expr != null && NUMERIC_PATTERN.matcher(expr.strip()).matches();
-    }
+
 
     static Optional<double[]> parseCommaSeparated(String text) {
         if (text == null || text.isBlank()) {


### PR DESCRIPTION
## Summary

- Created `AbstractModelImporter` base class with shared file reading (UTF-8 → windows-1252 fallback), model name extraction, and `isNumericLiteral()` utility
- `VensimImporter` and `XmileImporter` now extend `AbstractModelImporter`, eliminating duplicated file I/O and numeric detection code
- Created `ModelExporter` interface with `export()` and `exportToFile()` methods; both `VensimExporter` and `XmileExporter` implement it
- Moved `buildNameMap()` and `putDisplayName()` from `VensimExporter` to `ExportUtils` for reuse by any exporter

## Test plan
- [x] Full reactor `mvn clean test` — all tests pass
- [x] SpotBugs clean

Closes #1441