### PR TITLE
Extract CanvasEventBus for cascade callbacks

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -4,6 +4,8 @@ import systems.courant.sd.app.canvas.controllers.AlignmentController;
 import systems.courant.sd.app.canvas.AnalysisRunner;
 import systems.courant.sd.app.canvas.ActivityLogPanel;
 import systems.courant.sd.app.canvas.BreadcrumbBar;
+import systems.courant.sd.app.canvas.CanvasEvent;
+import systems.courant.sd.app.canvas.CanvasEventBus;
 import systems.courant.sd.app.canvas.CanvasToolBar;
 import systems.courant.sd.app.canvas.Clipboard;
 import systems.courant.sd.app.canvas.CommandPalette;
@@ -118,6 +120,7 @@ public class ModelWindow {
     private volatile boolean editorShown;
     private final List<MenuItem> editorOnlyItems = new ArrayList<>();
     private MenuItem validationIssuesItem;
+    private final CanvasEventBus eventBus = new CanvasEventBus();
 
     public ModelWindow(Stage stage, CourantApp app, Clipboard clipboard) {
         this.stage = stage;
@@ -288,15 +291,20 @@ public class ModelWindow {
 
     private void configureCanvasCallbacks() {
         canvas.setToolBar(toolBar);
-        canvas.setOnStatusChanged(() -> {
-            updateStatusBar();
+        // StatusChanged: publish on bus, subscribers handle their own updates
+        canvas.setOnStatusChanged(() -> eventBus.publish(new CanvasEvent.StatusChanged()));
+        eventBus.subscribe(CanvasEvent.StatusChanged.class, e -> updateStatusBar());
+        eventBus.subscribe(CanvasEvent.StatusChanged.class, e -> {
             if (canvas.analysis().isLoopHighlightActive()) {
                 updateLoopNavigator();
             }
+        });
+        eventBus.subscribe(CanvasEvent.StatusChanged.class, e -> {
             if (propertiesPanel != null) {
                 propertiesPanel.updateSelection(canvas, canvas.getEditor());
             }
         });
+
         canvas.setOnPasteWarning(replaced -> {
             String names = String.join(", ", replaced);
             activityLogPanel.log("warning",
@@ -304,12 +312,18 @@ public class ModelWindow {
                     + (replaced.size() == 1 ? "" : "s")
                     + " replaced with 0 (" + names + ")");
         });
-        canvas.analysis().setOnValidationChanged(result -> {
-            statusBar.updateValidation(result.errorCount(), result.warningCount());
+
+        // ValidationChanged: publish on bus
+        canvas.analysis().setOnValidationChanged(result ->
+                eventBus.publish(new CanvasEvent.ValidationChanged(result)));
+        eventBus.subscribe(CanvasEvent.ValidationChanged.class, e ->
+                statusBar.updateValidation(e.result().errorCount(), e.result().warningCount()));
+        eventBus.subscribe(CanvasEvent.ValidationChanged.class, e -> {
             if (validationIssuesItem != null) {
-                validationIssuesItem.setDisable(result.isClean());
+                validationIssuesItem.setDisable(e.result().isClean());
             }
         });
+
         statusBar.setOnValidationClicked(this::showValidationDialog);
 
         breadcrumbBar = new BreadcrumbBar();
@@ -317,7 +331,17 @@ public class ModelWindow {
             canvas.navigation().navigateToDepth(depth);
             canvas.requestFocus();
         });
-        canvas.navigation().setOnNavigationChanged(this::updateBreadcrumb);
+
+        // NavigationChanged: publish on bus
+        canvas.navigation().setOnNavigationChanged(() ->
+                eventBus.publish(new CanvasEvent.NavigationChanged()));
+        eventBus.subscribe(CanvasEvent.NavigationChanged.class, e -> {
+            if (breadcrumbBar != null && canvas.getEditor() != null) {
+                breadcrumbBar.update(canvas.navigation().getNavigationPath());
+            }
+        });
+        eventBus.subscribe(CanvasEvent.NavigationChanged.class, e -> updateTitle());
+        eventBus.subscribe(CanvasEvent.NavigationChanged.class, e -> updateStatusBar());
     }
 
     private void createRightPanel() {
@@ -949,13 +973,7 @@ public class ModelWindow {
         dockManager.updateTitle(name);
     }
 
-    private void updateBreadcrumb() {
-        if (breadcrumbBar != null && canvas.getEditor() != null) {
-            breadcrumbBar.update(canvas.navigation().getNavigationPath());
-        }
-        updateTitle();
-        updateStatusBar();
-    }
+    // updateBreadcrumb() replaced by NavigationChanged event bus subscribers
 
     Path getCurrentFile() {
         return fileController.getCurrentFile();

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasEvent.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasEvent.java
@@ -1,0 +1,22 @@
+package systems.courant.sd.app.canvas;
+
+import systems.courant.sd.model.def.ValidationResult;
+
+/**
+ * Events published on the {@link CanvasEventBus} by canvas components.
+ * Sealed so that all event types are known at compile time.
+ *
+ * <p>New events can be added here without modifying publishers or
+ * subscribers of existing event types.</p>
+ */
+public sealed interface CanvasEvent {
+
+    /** Canvas status changed: selection, zoom, tool, or element counts. */
+    record StatusChanged() implements CanvasEvent {}
+
+    /** Module navigation depth changed (drill-in or navigate-back). */
+    record NavigationChanged() implements CanvasEvent {}
+
+    /** Background validation completed with updated results. */
+    record ValidationChanged(ValidationResult result) implements CanvasEvent {}
+}

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasEventBus.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasEventBus.java
@@ -1,0 +1,64 @@
+package systems.courant.sd.app.canvas;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Lightweight publish-subscribe event bus for canvas component coordination.
+ *
+ * <p>Components publish {@link CanvasEvent} instances, and all registered
+ * subscribers for that event type are invoked in registration order. If a
+ * subscriber throws, the exception is logged and remaining subscribers
+ * still execute (error isolation).</p>
+ *
+ * <p>This bus is designed for single-threaded use on the JavaFX Application
+ * Thread. It does not provide thread safety guarantees.</p>
+ */
+public final class CanvasEventBus {
+
+    private static final Logger logger = LoggerFactory.getLogger(CanvasEventBus.class);
+
+    private final Map<Class<? extends CanvasEvent>, List<Consumer<? extends CanvasEvent>>>
+            subscribers = new LinkedHashMap<>();
+
+    /**
+     * Subscribes a handler to events of the given type. The handler will be
+     * invoked each time an event of that exact type is published.
+     *
+     * @param eventType the event class to subscribe to
+     * @param handler   the handler to invoke when the event is published
+     * @param <E>       the event type
+     */
+    public <E extends CanvasEvent> void subscribe(Class<E> eventType, Consumer<E> handler) {
+        subscribers.computeIfAbsent(eventType, k -> new ArrayList<>()).add(handler);
+    }
+
+    /**
+     * Publishes an event to all subscribers registered for its concrete type.
+     * Subscribers are invoked in registration order. If a subscriber throws,
+     * the exception is logged and remaining subscribers still execute.
+     *
+     * @param event the event to publish
+     */
+    @SuppressWarnings("unchecked")
+    public void publish(CanvasEvent event) {
+        List<Consumer<? extends CanvasEvent>> handlers = subscribers.get(event.getClass());
+        if (handlers == null) {
+            return;
+        }
+        for (Consumer<? extends CanvasEvent> handler : handlers) {
+            try {
+                ((Consumer<CanvasEvent>) handler).accept(event);
+            } catch (Exception e) {
+                logger.error("Event subscriber failed for {}: {}",
+                        event.getClass().getSimpleName(), e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/CanvasEventBusTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/CanvasEventBusTest.java
@@ -1,0 +1,102 @@
+package systems.courant.sd.app.canvas;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import systems.courant.sd.model.def.ValidationResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("CanvasEventBus")
+class CanvasEventBusTest {
+
+    private CanvasEventBus bus;
+
+    @BeforeEach
+    void setUp() {
+        bus = new CanvasEventBus();
+    }
+
+    @Nested
+    @DisplayName("Publish and Subscribe")
+    class PublishAndSubscribe {
+
+        @Test
+        void shouldInvokeSubscriberForMatchingEventType() {
+            AtomicInteger count = new AtomicInteger();
+            bus.subscribe(CanvasEvent.StatusChanged.class, e -> count.incrementAndGet());
+
+            bus.publish(new CanvasEvent.StatusChanged());
+
+            assertThat(count.get()).isEqualTo(1);
+        }
+
+        @Test
+        void shouldInvokeMultipleSubscribersInOrder() {
+            List<String> order = new ArrayList<>();
+            bus.subscribe(CanvasEvent.StatusChanged.class, e -> order.add("first"));
+            bus.subscribe(CanvasEvent.StatusChanged.class, e -> order.add("second"));
+            bus.subscribe(CanvasEvent.StatusChanged.class, e -> order.add("third"));
+
+            bus.publish(new CanvasEvent.StatusChanged());
+
+            assertThat(order).containsExactly("first", "second", "third");
+        }
+
+        @Test
+        void shouldNotInvokeSubscriberForDifferentEventType() {
+            AtomicInteger statusCount = new AtomicInteger();
+            AtomicInteger navCount = new AtomicInteger();
+            bus.subscribe(CanvasEvent.StatusChanged.class, e -> statusCount.incrementAndGet());
+            bus.subscribe(CanvasEvent.NavigationChanged.class, e -> navCount.incrementAndGet());
+
+            bus.publish(new CanvasEvent.StatusChanged());
+
+            assertThat(statusCount.get()).isEqualTo(1);
+            assertThat(navCount.get()).isEqualTo(0);
+        }
+
+        @Test
+        void shouldPassEventDataToSubscriber() {
+            var result = new ValidationResult(List.of());
+            var received = new Object() { ValidationResult value; };
+            bus.subscribe(CanvasEvent.ValidationChanged.class, e -> received.value = e.result());
+
+            bus.publish(new CanvasEvent.ValidationChanged(result));
+
+            assertThat(received.value).isSameAs(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases")
+    class EdgeCases {
+
+        @Test
+        void shouldNotThrowWhenPublishingWithNoSubscribers() {
+            assertThatCode(() -> bus.publish(new CanvasEvent.StatusChanged()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldContinueToNextSubscriberWhenOneThrows() {
+            AtomicInteger count = new AtomicInteger();
+            bus.subscribe(CanvasEvent.StatusChanged.class, e -> count.incrementAndGet());
+            bus.subscribe(CanvasEvent.StatusChanged.class, e -> {
+                throw new RuntimeException("subscriber failure");
+            });
+            bus.subscribe(CanvasEvent.StatusChanged.class, e -> count.incrementAndGet());
+
+            bus.publish(new CanvasEvent.StatusChanged());
+
+            assertThat(count.get()).isEqualTo(2);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduced `CanvasEventBus` — type-safe publish-subscribe hub with error isolation
- Created sealed `CanvasEvent` interface with 3 record subtypes: `StatusChanged`, `NavigationChanged`, `ValidationChanged`
- Converted 3 cascade callbacks in ModelWindow where one event triggers multiple component updates
- New subscribers can be added with a single `subscribe()` call — no edits to existing lambdas needed
- Simple 1:1 wirings intentionally left as direct callbacks (no bus overhead where fan-out = 1)

## Test plan
- [x] Full reactor `mvn clean test` — all tests pass
- [x] SpotBugs clean
- [x] New `CanvasEventBusTest` — 6 tests covering dispatch, type isolation, error isolation

Closes #1445