### PR TITLE
Create ExpressionFacade API to decouple app from engine internals

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationAutoComplete.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationAutoComplete.java
@@ -1,7 +1,7 @@
 package systems.courant.sd.app.canvas;
 
+import systems.courant.sd.api.ExpressionFacade;
 import systems.courant.sd.model.compile.FunctionDoc;
-import systems.courant.sd.model.compile.FunctionDocRegistry;
 
 import javafx.beans.value.ChangeListener;
 import javafx.event.ActionEvent;
@@ -58,7 +58,7 @@ public final class EquationAutoComplete {
     private static final double POPUP_WIDTH = 360;
     private static final int MIN_PREFIX_LENGTH = 1;
 
-    public static final List<String> BUILT_IN_FUNCTIONS = FunctionDocRegistry.allNames();
+    public static final List<String> BUILT_IN_FUNCTIONS = ExpressionFacade.builtinFunctionNames();
 
     private static final Set<String> FUNCTION_SET = Set.copyOf(BUILT_IN_FUNCTIONS);
 
@@ -286,7 +286,7 @@ public final class EquationAutoComplete {
                         return null; // bare parentheses, no function name
                     }
                     String funcName = text.substring(nameStart, nameEnd).toUpperCase();
-                    if (FunctionDocRegistry.get(funcName).isPresent()) {
+                    if (ExpressionFacade.getFunctionDoc(funcName).isPresent()) {
                         return new FunctionCallContext(funcName, commas);
                     }
                     return null; // not a known function
@@ -333,7 +333,7 @@ public final class EquationAutoComplete {
 
         // Add functions after elements
         for (String funcName : BUILT_IN_FUNCTIONS) {
-            Optional<FunctionDoc> doc = FunctionDocRegistry.get(funcName);
+            Optional<FunctionDoc> doc = ExpressionFacade.getFunctionDoc(funcName);
             String displayName = doc.map(FunctionDoc::signature).orElse(funcName);
             String description = doc.map(FunctionDoc::oneLiner).orElse("");
             result.add(new AutoCompleteSuggestion(
@@ -743,7 +743,7 @@ public final class EquationAutoComplete {
             }
             lastHintContext = ctx;
 
-            Optional<FunctionDoc> docOpt = FunctionDocRegistry.get(ctx.functionName());
+            Optional<FunctionDoc> docOpt = ExpressionFacade.getFunctionDoc(ctx.functionName());
             if (docOpt.isEmpty() || docOpt.get().parameters().isEmpty()) {
                 hideHint();
                 return;

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationHighlighter.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationHighlighter.java
@@ -1,6 +1,6 @@
 package systems.courant.sd.app.canvas;
 
-import systems.courant.sd.model.compile.FunctionDocRegistry;
+import systems.courant.sd.api.ExpressionFacade;
 
 import org.fxmisc.richtext.model.StyleSpans;
 import org.fxmisc.richtext.model.StyleSpansBuilder;
@@ -26,7 +26,7 @@ public final class EquationHighlighter {
     static {
         // Build keyword alternation from the function registry, longest first
         // to prevent partial matches
-        String keywords = FunctionDocRegistry.allNames().stream()
+        String keywords = ExpressionFacade.builtinFunctionNames().stream()
                 .sorted(Comparator.comparingInt(String::length).reversed())
                 .collect(Collectors.joining("|"));
 

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationReferenceManager.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationReferenceManager.java
@@ -2,11 +2,7 @@ package systems.courant.sd.app.canvas;
 
 import systems.courant.sd.model.def.VariableDef;
 import systems.courant.sd.model.def.FlowDef;
-import systems.courant.sd.model.expr.ExprParser;
-import systems.courant.sd.model.expr.ExprRenamer;
-import systems.courant.sd.model.expr.ExprStringifier;
-import systems.courant.sd.model.expr.Expr;
-import systems.courant.sd.model.expr.ParseException;
+import systems.courant.sd.api.ExpressionFacade;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,18 +201,15 @@ public final class EquationReferenceManager {
         if (equation == null || equation.isBlank()) {
             return equation;
         }
-        try {
-            Expr ast = ExprParser.parse(equation);
-            Expr renamed = ExprRenamer.rename(ast, oldToken, newToken);
-            if (renamed == ast) {
-                return equation;
-            }
-            return ExprStringifier.stringify(renamed);
-        } catch (ParseException e) {
-            log.debug("AST parse failed for equation '{}', falling back to string replacement: {}",
-                    equation, e.getMessage());
-            return replaceTokenByString(equation, oldToken, newToken);
+        // Try AST-based rename first; facade returns original on parse failure
+        if (ExpressionFacade.validateSyntax(equation).isEmpty()) {
+            // Parseable: use AST rename (preserves structure, handles quoted identifiers)
+            return ExpressionFacade.renameReference(equation, oldToken, newToken);
         }
+        // Not parseable: fall back to word-boundary string replacement
+        log.debug("AST parse failed for equation '{}', falling back to string replacement",
+                equation);
+        return replaceTokenByString(equation, oldToken, newToken);
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationValidator.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/EquationValidator.java
@@ -1,9 +1,6 @@
 package systems.courant.sd.app.canvas;
 
-import systems.courant.sd.model.expr.Expr;
-import systems.courant.sd.model.expr.ExprDependencies;
-import systems.courant.sd.model.expr.ExprParser;
-import systems.courant.sd.model.expr.ParseException;
+import systems.courant.sd.api.ExpressionFacade;
 
 import systems.courant.sd.model.def.FlowDef;
 import systems.courant.sd.model.def.StockDef;
@@ -55,15 +52,13 @@ public final class EquationValidator {
         }
 
         // 1. Syntax check
-        Expr expr;
-        try {
-            expr = ExprParser.parse(equation);
-        } catch (ParseException e) {
-            return new Result(false, formatParseError(e), null);
+        var syntaxError = ExpressionFacade.validateSyntax(equation);
+        if (syntaxError.isPresent()) {
+            return new Result(false, syntaxError.get(), null);
         }
 
         // 2. Reference check
-        Set<String> refs = ExprDependencies.extract(expr);
+        Set<String> refs = ExpressionFacade.extractReferences(equation);
         Set<String> knownNames = collectKnownNames(editor);
         List<String> unknowns = new ArrayList<>();
         for (String ref : refs) {
@@ -95,17 +90,6 @@ public final class EquationValidator {
         }
 
         return Result.OK;
-    }
-
-    private static String formatParseError(ParseException e) {
-        String msg = e.getMessage();
-        // Strip the "(at position N)" suffix added by ParseException constructor
-        // for a cleaner display, since position is less useful in a text field
-        int idx = msg.lastIndexOf(" (at position ");
-        if (idx > 0) {
-            return msg.substring(0, idx);
-        }
-        return msg;
     }
 
     private static Set<String> collectKnownNames(ModelEditor editor) {

--- a/courant-engine/src/main/java/systems/courant/sd/api/ExpressionFacade.java
+++ b/courant-engine/src/main/java/systems/courant/sd/api/ExpressionFacade.java
@@ -1,0 +1,124 @@
+package systems.courant.sd.api;
+
+import systems.courant.sd.model.compile.FunctionDoc;
+import systems.courant.sd.model.compile.FunctionDocRegistry;
+import systems.courant.sd.model.expr.Expr;
+import systems.courant.sd.model.expr.ExprDependencies;
+import systems.courant.sd.model.expr.ExprParser;
+import systems.courant.sd.model.expr.ExprRenamer;
+import systems.courant.sd.model.expr.ExprStringifier;
+import systems.courant.sd.model.expr.ParseException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Stable API facade for expression-related operations. Provides equation
+ * validation, reference extraction, renaming, and built-in function
+ * metadata without requiring callers to import internal AST or compiler
+ * classes.
+ *
+ * <p>This is the primary entry point for courant-app code that needs to
+ * work with equations. Internal classes ({@code ExprParser},
+ * {@code ExprDependencies}, {@code FunctionDocRegistry}, etc.) should not
+ * be imported directly by application code.</p>
+ */
+public final class ExpressionFacade {
+
+    private ExpressionFacade() {
+    }
+
+    /**
+     * Validates equation syntax. Returns an empty optional if the equation
+     * is syntactically valid, or an error message describing the parse failure.
+     *
+     * @param equation the equation text to validate
+     * @return empty if valid, or an error message
+     */
+    public static Optional<String> validateSyntax(String equation) {
+        try {
+            ExprParser.parse(equation);
+            return Optional.empty();
+        } catch (ParseException e) {
+            return Optional.of(formatParseError(e));
+        }
+    }
+
+    /**
+     * Parses an equation and extracts the set of variable names it references.
+     * Returns an empty set if the equation cannot be parsed.
+     *
+     * @param equation the equation text
+     * @return set of referenced variable names (normalized), or empty set on parse failure
+     */
+    public static Set<String> extractReferences(String equation) {
+        try {
+            Expr expr = ExprParser.parse(equation);
+            return ExprDependencies.extract(expr);
+        } catch (ParseException e) {
+            return Set.of();
+        }
+    }
+
+    /**
+     * Renames a variable reference within an equation using AST-based
+     * transformation. Falls back to the original equation if parsing fails
+     * (callers should handle text-based fallback themselves if needed).
+     *
+     * @param equation the equation text
+     * @param oldName  the current variable name (normalized)
+     * @param newName  the replacement variable name (normalized)
+     * @return the equation with references renamed, or the original if parsing fails
+     */
+    public static String renameReference(String equation, String oldName, String newName) {
+        try {
+            Expr ast = ExprParser.parse(equation);
+            Expr renamed = ExprRenamer.rename(ast, oldName, newName);
+            if (renamed == ast) {
+                return equation;
+            }
+            return ExprStringifier.stringify(renamed);
+        } catch (ParseException e) {
+            return equation;
+        }
+    }
+
+    /**
+     * Returns the names of all built-in functions recognized by the
+     * expression compiler.
+     */
+    public static List<String> builtinFunctionNames() {
+        return FunctionDocRegistry.allNames();
+    }
+
+    /**
+     * Returns the documentation for a specific built-in function.
+     *
+     * @param name the function name (case-insensitive)
+     * @return the function documentation, or empty if not found
+     */
+    public static Optional<FunctionDoc> getFunctionDoc(String name) {
+        return FunctionDocRegistry.get(name);
+    }
+
+    /**
+     * Returns documentation for all built-in functions.
+     */
+    public static List<FunctionDoc> allFunctionDocs() {
+        return FunctionDocRegistry.all();
+    }
+
+    private static String formatParseError(ParseException e) {
+        String msg = e.getMessage();
+        if (msg == null || msg.isBlank()) {
+            return "Syntax error";
+        }
+        // Strip the "(at position N)" suffix added by ParseException constructor
+        int idx = msg.lastIndexOf(" (at position ");
+        if (idx > 0) {
+            return msg.substring(0, idx);
+        }
+        return msg;
+    }
+}


### PR DESCRIPTION
## Summary

- Created `ExpressionFacade` in `systems.courant.sd.api` — stable entry point for equation validation, reference extraction, AST renaming, and function metadata
- Migrated 4 courant-app files to use the facade, eliminating 12 internal imports:
  - `EquationValidator`: ExprParser + ExprDependencies → `ExpressionFacade.validateSyntax()` + `extractReferences()`
  - `EquationReferenceManager`: ExprParser + ExprRenamer + ExprStringifier → `ExpressionFacade.renameReference()`
  - `EquationHighlighter`: FunctionDocRegistry → `ExpressionFacade.builtinFunctionNames()`
  - `EquationAutoComplete`: FunctionDocRegistry → `ExpressionFacade.builtinFunctionNames()` + `getFunctionDoc()`
- Engine AST/compiler internals can now be refactored without breaking the app
- `FunctionDoc` remains a direct import (stable data record, no internal dependencies)

## Test plan
- [x] Full reactor `mvn clean test` — all tests pass
- [x] SpotBugs clean

Closes #1442