### PR TITLE
Extract JavaCodeBuilder and CliArgumentParser for DemoClassGenerator

### DIFF
--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/BatchImportCli.java
@@ -382,8 +382,8 @@ public class BatchImportCli {
         CliArgs parsed = new CliArgs();
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
-                case "--manifest" -> { parsed.manifestFile = requireValue(args, i); i++; }
-                case "--output-dir" -> { parsed.outputDir = requireValue(args, i); i++; }
+                case "--manifest" -> { parsed.manifestFile = CliArgumentParser.requireValue(args, i); i++; }
+                case "--output-dir" -> { parsed.outputDir = CliArgumentParser.requireValue(args, i); i++; }
                 case "--json-only" -> parsed.jsonOnly = true;
                 case "--dry-run" -> parsed.dryRun = true;
                 case "--overwrite" -> parsed.overwrite = true;
@@ -393,15 +393,6 @@ public class BatchImportCli {
             }
         }
         return parsed;
-    }
-
-    private static String requireValue(String[] args, int flagIndex) {
-        int valueIndex = flagIndex + 1;
-        if (valueIndex >= args.length) {
-            throw new IllegalArgumentException(
-                    args[flagIndex] + " requires a value");
-        }
-        return args[valueIndex];
     }
 
     private static void printUsage() {

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/CliArgumentParser.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/CliArgumentParser.java
@@ -1,0 +1,27 @@
+package systems.courant.sd.tools.importer;
+
+/**
+ * Shared CLI argument parsing utilities for importer command-line tools.
+ */
+public final class CliArgumentParser {
+
+    private CliArgumentParser() {}
+
+    /**
+     * Returns the value for the flag at {@code args[flagIndex]}, which is expected
+     * to be at {@code args[flagIndex + 1]}.
+     *
+     * @param args      the full argument array
+     * @param flagIndex the index of the flag that requires a value
+     * @return the value immediately following the flag
+     * @throws IllegalArgumentException if no value follows the flag
+     */
+    public static String requireValue(String[] args, int flagIndex) {
+        int valueIndex = flagIndex + 1;
+        if (valueIndex >= args.length) {
+            throw new IllegalArgumentException(
+                    args[flagIndex] + " requires a value");
+        }
+        return args[valueIndex];
+    }
+}

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/DemoClassGenerator.java
@@ -23,9 +23,6 @@ import static systems.courant.sd.tools.importer.JavaSourceEscaper.escapeString;
  */
 public class DemoClassGenerator {
 
-    private static final String INDENT = "        ";
-    private static final String INDENT2 = "                ";
-
     private final int copyrightYear;
 
     /**
@@ -59,322 +56,328 @@ public class DemoClassGenerator {
     public String generate(ModelDefinition definition, ModelMetadata metadata,
                            String className, String packageName, String sourceFileName,
                            List<String> importWarnings, List<String> validationErrors) {
-        StringBuilder sb = new StringBuilder(4096);
+        JavaCodeBuilder cb = new JavaCodeBuilder();
 
-        emitLicenseHeader(sb, metadata);
-        emitPackage(sb, packageName);
-        emitImports(sb, definition);
-        emitClassJavadoc(sb, sourceFileName, metadata, importWarnings, validationErrors);
-        emitClassOpen(sb, className);
-        emitMainMethod(sb, className);
-        emitRunMethod(sb, definition, metadata);
-        emitClassClose(sb);
+        emitLicenseHeader(cb, metadata);
+        emitPackage(cb, packageName);
+        emitImports(cb, definition);
+        emitClassJavadoc(cb, sourceFileName, metadata, importWarnings, validationErrors);
+        cb.line("public class " + className + " {");
+        cb.blankLine();
+        cb.indent();
+        emitMainMethod(cb, className);
+        emitRunMethod(cb, definition, metadata);
+        cb.dedent();
+        cb.line("}");
 
-        return sb.toString();
+        return cb.toString();
     }
 
-    private void emitLicenseHeader(StringBuilder sb, ModelMetadata metadata) {
+    private void emitLicenseHeader(JavaCodeBuilder cb, ModelMetadata metadata) {
         String license = metadata.license();
         if (license != null && license.contains("-NC")) {
-            sb.append("/*\n");
-            sb.append(" * Copyright (c) original author(s). See model metadata for attribution.\n");
-            sb.append(" * Licensed under CC-BY-NC-SA-4.0. See THIRD-PARTY-LICENSES for details.\n");
-            sb.append(" */\n");
+            cb.raw("/*\n");
+            cb.raw(" * Copyright (c) original author(s). See model metadata for attribution.\n");
+            cb.raw(" * Licensed under CC-BY-NC-SA-4.0. See THIRD-PARTY-LICENSES for details.\n");
+            cb.raw(" */\n");
         } else {
-            sb.append("/*\n");
-            sb.append(" * Copyright (c) ").append(copyrightYear).append(" Courant Systems\n");
-            sb.append(" * Licensed under CC-BY-SA-4.0. See LICENSE in this module for details.\n");
-            sb.append(" */\n");
+            cb.raw("/*\n");
+            cb.raw(" * Copyright (c) " + copyrightYear + " Courant Systems\n");
+            cb.raw(" * Licensed under CC-BY-SA-4.0. See LICENSE in this module for details.\n");
+            cb.raw(" */\n");
         }
     }
 
-    private void emitPackage(StringBuilder sb, String packageName) {
-        sb.append("package ").append(packageName).append(";\n\n");
+    private void emitPackage(JavaCodeBuilder cb, String packageName) {
+        cb.line("package " + packageName + ";");
+        cb.blankLine();
     }
 
-    private void emitImports(StringBuilder sb, ModelDefinition definition) {
-        sb.append("import systems.courant.sd.Simulation;\n");
-        sb.append("import systems.courant.sd.model.ModelMetadata;\n");
-        sb.append("import systems.courant.sd.model.compile.ModelCompiler;\n");
-        sb.append("import systems.courant.sd.model.def.ModelDefinitionBuilder;\n");
+    private void emitImports(JavaCodeBuilder cb, ModelDefinition definition) {
+        cb.line("import systems.courant.sd.Simulation;");
+        cb.line("import systems.courant.sd.model.ModelMetadata;");
+        cb.line("import systems.courant.sd.model.compile.ModelCompiler;");
+        cb.line("import systems.courant.sd.model.def.ModelDefinitionBuilder;");
 
         if (!definition.variables().isEmpty()) {
-            sb.append("import systems.courant.sd.model.def.VariableDef;\n");
+            cb.line("import systems.courant.sd.model.def.VariableDef;");
         }
         if (!definition.flows().isEmpty()) {
-            sb.append("import systems.courant.sd.model.def.FlowDef;\n");
+            cb.line("import systems.courant.sd.model.def.FlowDef;");
         }
         if (!definition.lookupTables().isEmpty()) {
-            sb.append("import systems.courant.sd.model.def.LookupTableDef;\n");
+            cb.line("import systems.courant.sd.model.def.LookupTableDef;");
         }
         if (!definition.stocks().isEmpty()) {
-            sb.append("import systems.courant.sd.model.def.StockDef;\n");
+            cb.line("import systems.courant.sd.model.def.StockDef;");
         }
         boolean needsList = needsListImport(definition);
         boolean needsSimSettings = needsFullSimulationConstructor(definition.defaultSimulation());
         if (!definition.modules().isEmpty()) {
-            sb.append("import systems.courant.sd.model.def.ModelDefinition;\n");
-            sb.append("import systems.courant.sd.model.def.ModuleInstanceDef;\n");
-            sb.append("import systems.courant.sd.model.def.SimulationSettings;\n");
-            sb.append("\n");
-            sb.append("import java.util.List;\n");
-            sb.append("import java.util.Map;\n");
+            cb.line("import systems.courant.sd.model.def.ModelDefinition;");
+            cb.line("import systems.courant.sd.model.def.ModuleInstanceDef;");
+            cb.line("import systems.courant.sd.model.def.SimulationSettings;");
+            cb.blankLine();
+            cb.line("import java.util.List;");
+            cb.line("import java.util.Map;");
         } else {
             if (needsSimSettings) {
-                sb.append("import systems.courant.sd.model.def.SimulationSettings;\n");
+                cb.line("import systems.courant.sd.model.def.SimulationSettings;");
             }
             if (needsList) {
-                sb.append("\n");
-                sb.append("import java.util.List;\n");
+                cb.blankLine();
+                cb.line("import java.util.List;");
             }
         }
 
-        sb.append('\n');
+        cb.blankLine();
     }
 
-    private void emitClassJavadoc(StringBuilder sb, String sourceFileName,
+    private void emitClassJavadoc(JavaCodeBuilder cb, String sourceFileName,
                                   ModelMetadata metadata,
                                   List<String> importWarnings,
                                   List<String> validationErrors) {
-        sb.append("/**\n");
-        sb.append(" * Imported from: ").append(escapeHtml(sourceFileName)).append('\n');
+        cb.raw("/**\n");
+        cb.raw(" * Imported from: " + escapeHtml(sourceFileName) + "\n");
         if (metadata.source() != null) {
-            sb.append(" * Source: ").append(escapeHtml(metadata.source())).append('\n');
+            cb.raw(" * Source: " + escapeHtml(metadata.source()) + "\n");
         }
         if (metadata.license() != null) {
-            sb.append(" * License: ").append(escapeHtml(metadata.license())).append('\n');
+            cb.raw(" * License: " + escapeHtml(metadata.license()) + "\n");
         }
         if (metadata.author() != null) {
-            sb.append(" * Author: ").append(escapeHtml(metadata.author())).append('\n');
+            cb.raw(" * Author: " + escapeHtml(metadata.author()) + "\n");
         }
-        sb.append(" *\n");
-        sb.append(" * <p>Auto-generated by courant-tools ImportPipeline.\n");
+        cb.raw(" *\n");
+        cb.raw(" * <p>Auto-generated by courant-tools ImportPipeline.\n");
 
         if (!importWarnings.isEmpty()) {
-            sb.append(" *\n");
-            sb.append(" * <p>Import warnings:\n");
-            sb.append(" * <ul>\n");
+            cb.raw(" *\n");
+            cb.raw(" * <p>Import warnings:\n");
+            cb.raw(" * <ul>\n");
             for (String w : importWarnings) {
-                sb.append(" *   <li>").append(escapeHtml(w)).append("</li>\n");
+                cb.raw(" *   <li>" + escapeHtml(w) + "</li>\n");
             }
-            sb.append(" * </ul>\n");
+            cb.raw(" * </ul>\n");
         }
         if (!validationErrors.isEmpty()) {
-            sb.append(" *\n");
-            sb.append(" * <p>Validation errors (model may need manual fixes):\n");
-            sb.append(" * <ul>\n");
+            cb.raw(" *\n");
+            cb.raw(" * <p>Validation errors (model may need manual fixes):\n");
+            cb.raw(" * <ul>\n");
             for (String e : validationErrors) {
-                sb.append(" *   <li>").append(escapeHtml(e)).append("</li>\n");
+                cb.raw(" *   <li>" + escapeHtml(e) + "</li>\n");
             }
-            sb.append(" * </ul>\n");
+            cb.raw(" * </ul>\n");
         }
 
-        sb.append(" */\n");
+        cb.raw(" */\n");
     }
 
-    private void emitClassOpen(StringBuilder sb, String className) {
-        sb.append("public class ").append(className).append(" {\n\n");
+    private void emitMainMethod(JavaCodeBuilder cb, String className) {
+        cb.line("public static void main(String[] args) {");
+        cb.indent();
+        cb.line("new " + className + "().run();");
+        cb.dedent();
+        cb.line("}");
+        cb.blankLine();
     }
 
-    private void emitMainMethod(StringBuilder sb, String className) {
-        sb.append("    public static void main(String[] args) {\n");
-        sb.append("        new ").append(className).append("().run();\n");
-        sb.append("    }\n\n");
-    }
-
-    private void emitRunMethod(StringBuilder sb, ModelDefinition definition,
+    private void emitRunMethod(JavaCodeBuilder cb, ModelDefinition definition,
                                ModelMetadata metadata) {
-        sb.append("    public void run() {\n");
-        sb.append(INDENT).append("var builder = new ModelDefinitionBuilder()\n");
-        sb.append(INDENT2).append(".name(").append(escapeString(definition.name())).append(")");
+        cb.line("public void run() {");
+        cb.indent();
+        String chainIndent = cb.indentAt(2);
+
+        cb.line("var builder = new ModelDefinitionBuilder()");
+        cb.raw(chainIndent + ".name(" + escapeString(definition.name()) + ")");
 
         if (definition.defaultSimulation() != null) {
-            emitDefaultSimulation(sb, definition.defaultSimulation(), INDENT2);
+            emitDefaultSimulation(cb, definition.defaultSimulation(), chainIndent);
         }
-        sb.append(";\n\n");
+        cb.raw(";\n");
+        cb.blankLine();
 
         // Stocks
         if (!definition.stocks().isEmpty()) {
-            sb.append(INDENT).append("// Stocks\n");
+            cb.line("// Stocks");
             for (StockDef stock : definition.stocks()) {
-                emitStockDef(sb, stock, INDENT, "builder");
+                emitStockDef(cb, stock, "builder");
             }
-            sb.append('\n');
+            cb.blankLine();
         }
 
         // Constants (literal-valued variables)
         List<VariableDef> literals = definition.variables().stream()
                 .filter(VariableDef::isLiteral).toList();
         if (!literals.isEmpty()) {
-            sb.append(INDENT).append("// Constants\n");
+            cb.line("// Constants");
             for (VariableDef constant : literals) {
                 if (constant.subscripts().isEmpty()) {
-                    sb.append(INDENT).append("builder.constant(")
-                            .append(escapeString(constant.name())).append(", ")
-                            .append(constant.literalValue()).append(", ")
-                            .append(escapeString(constant.unit()))
-                            .append(");\n");
+                    cb.line("builder.constant("
+                            + escapeString(constant.name()) + ", "
+                            + constant.literalValue() + ", "
+                            + escapeString(constant.unit())
+                            + ");");
                 } else {
                     // Use full VariableDef constructor to preserve subscripts
-                    emitVariableDef(sb, constant, INDENT, "builder");
+                    emitVariableDef(cb, constant, "builder");
                 }
             }
-            sb.append('\n');
+            cb.blankLine();
         }
 
         // Lookup tables
         if (!definition.lookupTables().isEmpty()) {
-            sb.append(INDENT).append("// Lookup tables\n");
+            cb.line("// Lookup tables");
             for (LookupTableDef table : definition.lookupTables()) {
-                emitLookupTableDef(sb, table, INDENT, "builder");
+                emitLookupTableDef(cb, table, "builder");
             }
-            sb.append('\n');
+            cb.blankLine();
         }
 
         // Variables (non-literal only; literals were emitted as constants above)
         List<VariableDef> formulas = definition.variables().stream()
                 .filter(a -> !a.isLiteral()).toList();
         if (!formulas.isEmpty()) {
-            sb.append(INDENT).append("// Variables\n");
+            cb.line("// Variables");
             for (VariableDef v : formulas) {
-                emitVariableDef(sb, v, INDENT, "builder");
+                emitVariableDef(cb, v, "builder");
             }
-            sb.append('\n');
+            cb.blankLine();
         }
 
         // Flows
         if (!definition.flows().isEmpty()) {
-            sb.append(INDENT).append("// Flows\n");
+            cb.line("// Flows");
             for (FlowDef flow : definition.flows()) {
-                emitFlowDef(sb, flow, INDENT, "builder");
+                emitFlowDef(cb, flow, "builder");
             }
-            sb.append('\n');
+            cb.blankLine();
         }
 
         // Modules
         if (!definition.modules().isEmpty()) {
-            sb.append(INDENT).append("// Modules\n");
+            cb.line("// Modules");
             for (ModuleInstanceDef module : definition.modules()) {
-                emitModuleInstance(sb, module);
+                emitModuleInstance(cb, module, "builder");
             }
-            sb.append('\n');
+            cb.blankLine();
         }
 
         // Compile and set metadata
-        sb.append(INDENT).append("var definition = builder.build();\n");
-        sb.append(INDENT).append("var compiled = new ModelCompiler().compile(definition);\n\n");
+        cb.line("var definition = builder.build();");
+        cb.line("var compiled = new ModelCompiler().compile(definition);");
+        cb.blankLine();
 
-        sb.append(INDENT).append("compiled.getModel().setMetadata(ModelMetadata.builder()\n");
+        cb.raw(cb.currentIndent() + "compiled.getModel().setMetadata(ModelMetadata.builder()\n");
         if (metadata.author() != null) {
-            sb.append(INDENT2).append(".author(").append(escapeString(metadata.author())).append(")\n");
+            cb.raw(chainIndent + ".author(" + escapeString(metadata.author()) + ")\n");
         }
         if (metadata.source() != null) {
-            sb.append(INDENT2).append(".source(").append(escapeString(metadata.source())).append(")\n");
+            cb.raw(chainIndent + ".source(" + escapeString(metadata.source()) + ")\n");
         }
         if (metadata.license() != null) {
-            sb.append(INDENT2).append(".license(").append(escapeString(metadata.license())).append(")\n");
+            cb.raw(chainIndent + ".license(" + escapeString(metadata.license()) + ")\n");
         }
         if (metadata.url() != null) {
-            sb.append(INDENT2).append(".url(").append(escapeString(metadata.url())).append(")\n");
+            cb.raw(chainIndent + ".url(" + escapeString(metadata.url()) + ")\n");
         }
-        sb.append(INDENT2).append(".build());\n\n");
+        cb.raw(chainIndent + ".build());\n");
+        cb.blankLine();
 
         // Create and run simulation
-        sb.append(INDENT).append("Simulation sim = compiled.createSimulation();\n");
-        sb.append(INDENT).append("sim.execute();\n");
+        cb.line("Simulation sim = compiled.createSimulation();");
+        cb.line("sim.execute();");
 
-        sb.append("    }\n");
+        cb.dedent();
+        cb.line("}");
     }
 
-    private void emitModuleInstance(StringBuilder sb, ModuleInstanceDef module) {
-        emitModuleInstance(sb, module, INDENT, "builder");
-    }
-
-    private void emitModuleInstance(StringBuilder sb, ModuleInstanceDef module,
-                                    String indent, String parentBuilderName) {
-        // Generate the inner module definition inline
+    private void emitModuleInstance(JavaCodeBuilder cb, ModuleInstanceDef module,
+                                    String parentBuilderName) {
         String varName = JavaSourceEscaper.toValidIdentifier(module.instanceName()) + "Def";
         ModelDefinition inner = module.definition();
 
-        sb.append(indent).append("{\n");
-        String blockIndent = indent + "    ";
-        String chainIndent = indent + "            ";
-        sb.append(blockIndent).append("var innerBuilder = new ModelDefinitionBuilder()\n");
-        sb.append(chainIndent).append(".name(").append(escapeString(inner.name())).append(")");
+        cb.line("{");
+        cb.indent();
+        String chainIndent = cb.indentAt(2);
+        cb.line("var innerBuilder = new ModelDefinitionBuilder()");
+        cb.raw(chainIndent + ".name(" + escapeString(inner.name()) + ")");
         if (inner.defaultSimulation() != null) {
-            emitDefaultSimulation(sb, inner.defaultSimulation(), chainIndent);
+            emitDefaultSimulation(cb, inner.defaultSimulation(), chainIndent);
         }
-        sb.append(";\n");
+        cb.raw(";\n");
 
         // Emit inner stocks, constants, lookups, auxes, flows
         for (StockDef stock : inner.stocks()) {
-            emitStockDef(sb, stock, blockIndent, "innerBuilder");
+            emitStockDef(cb, stock, "innerBuilder");
         }
         for (VariableDef constant : inner.variables().stream().filter(VariableDef::isLiteral).toList()) {
             if (constant.subscripts().isEmpty()) {
-                sb.append(blockIndent).append("innerBuilder.constant(")
-                        .append(escapeString(constant.name())).append(", ")
-                        .append(constant.literalValue()).append(", ")
-                        .append(escapeString(constant.unit()))
-                        .append(");\n");
+                cb.line("innerBuilder.constant("
+                        + escapeString(constant.name()) + ", "
+                        + constant.literalValue() + ", "
+                        + escapeString(constant.unit())
+                        + ");");
             } else {
-                emitVariableDef(sb, constant, blockIndent, "innerBuilder");
+                emitVariableDef(cb, constant, "innerBuilder");
             }
         }
         for (LookupTableDef table : inner.lookupTables()) {
-            emitLookupTableDef(sb, table, blockIndent, "innerBuilder");
+            emitLookupTableDef(cb, table, "innerBuilder");
         }
         for (VariableDef v : inner.variables().stream().filter(a -> !a.isLiteral()).toList()) {
-            emitVariableDef(sb, v, blockIndent, "innerBuilder");
+            emitVariableDef(cb, v, "innerBuilder");
         }
         for (FlowDef flow : inner.flows()) {
-            emitFlowDef(sb, flow, blockIndent, "innerBuilder");
+            emitFlowDef(cb, flow, "innerBuilder");
         }
         // Nested modules (#273)
         for (ModuleInstanceDef nestedModule : inner.modules()) {
-            emitModuleInstance(sb, nestedModule, blockIndent, "innerBuilder");
+            emitModuleInstance(cb, nestedModule, "innerBuilder");
         }
 
-        sb.append(blockIndent).append("ModelDefinition ").append(varName)
-                .append(" = innerBuilder.build();\n");
+        cb.line("ModelDefinition " + varName + " = innerBuilder.build();");
 
         // Emit bindings
-        sb.append(blockIndent).append(parentBuilderName).append(".module(new ModuleInstanceDef(\n");
-        sb.append(chainIndent).append(escapeString(module.instanceName())).append(",\n");
-        sb.append(chainIndent).append(varName).append(",\n");
-        emitMapLiteral(sb, module.inputBindings(), chainIndent);
-        sb.append(",\n");
-        emitMapLiteral(sb, module.outputBindings(), chainIndent);
-        sb.append("));\n");
-        sb.append(indent).append("}\n");
+        cb.raw(cb.currentIndent() + parentBuilderName + ".module(new ModuleInstanceDef(\n");
+        cb.raw(chainIndent + escapeString(module.instanceName()) + ",\n");
+        cb.raw(chainIndent + varName + ",\n");
+        emitMapLiteral(cb, module.inputBindings(), chainIndent);
+        cb.raw(",\n");
+        emitMapLiteral(cb, module.outputBindings(), chainIndent);
+        cb.raw("));\n");
+        cb.dedent();
+        cb.line("}");
     }
 
     private static boolean needsFullSimulationConstructor(SimulationSettings sim) {
         return sim != null && (sim.strictMode() || sim.savePer() != 1 || sim.initialTime() != 0.0);
     }
 
-    private void emitDefaultSimulation(StringBuilder sb, SimulationSettings sim, String indent) {
+    private void emitDefaultSimulation(JavaCodeBuilder cb, SimulationSettings sim,
+                                       String chainIndent) {
         if (needsFullSimulationConstructor(sim)) {
-            sb.append("\n").append(indent)
-                    .append(".defaultSimulation(new SimulationSettings(")
-                    .append(escapeString(sim.timeStep())).append(", ")
-                    .append(sim.duration()).append(", ")
-                    .append(escapeString(sim.durationUnit())).append(", ")
-                    .append(sim.dt()).append(", ")
-                    .append(sim.strictMode()).append(", ")
-                    .append(sim.savePer()).append(", ")
-                    .append(sim.initialTime())
-                    .append("))");
+            cb.raw("\n" + chainIndent
+                    + ".defaultSimulation(new SimulationSettings("
+                    + escapeString(sim.timeStep()) + ", "
+                    + sim.duration() + ", "
+                    + escapeString(sim.durationUnit()) + ", "
+                    + sim.dt() + ", "
+                    + sim.strictMode() + ", "
+                    + sim.savePer() + ", "
+                    + sim.initialTime()
+                    + "))");
         } else {
-            sb.append("\n").append(indent)
-                    .append(".defaultSimulation(")
-                    .append(escapeString(sim.timeStep())).append(", ")
-                    .append(sim.duration()).append(", ")
-                    .append(escapeString(sim.durationUnit()));
+            cb.raw("\n" + chainIndent
+                    + ".defaultSimulation("
+                    + escapeString(sim.timeStep()) + ", "
+                    + sim.duration() + ", "
+                    + escapeString(sim.durationUnit()));
             if (sim.dt() != 1.0) {
-                sb.append(", ").append(sim.dt());
+                cb.raw(", " + sim.dt());
             }
-            sb.append(")");
+            cb.raw(")");
         }
     }
 
@@ -382,26 +385,26 @@ public class DemoClassGenerator {
      * Emits a StockDef constructor call, using the canonical constructor when initialExpression
      * or subscripts are present, and the backward-compatible constructor otherwise.
      */
-    private void emitStockDef(StringBuilder sb, StockDef stock, String indent, String builderName) {
+    private void emitStockDef(JavaCodeBuilder cb, StockDef stock, String builderName) {
         if (stock.initialExpression() != null || !stock.subscripts().isEmpty()) {
             // Use canonical 7-arg constructor to preserve initialExpression and subscripts
-            sb.append(indent).append(builderName).append(".stock(new StockDef(")
-                    .append(escapeString(stock.name())).append(", ")
-                    .append(escapeString(stock.comment())).append(", ")
-                    .append(formatDoubleForSource(stock.initialValue())).append(", ")
-                    .append(escapeString(stock.initialExpression())).append(", ")
-                    .append(escapeString(stock.unit())).append(", ")
-                    .append(escapeString(stock.negativeValuePolicy())).append(", ")
-                    .append(emitStringList(stock.subscripts()))
-                    .append("));\n");
+            cb.line(builderName + ".stock(new StockDef("
+                    + escapeString(stock.name()) + ", "
+                    + escapeString(stock.comment()) + ", "
+                    + formatDoubleForSource(stock.initialValue()) + ", "
+                    + escapeString(stock.initialExpression()) + ", "
+                    + escapeString(stock.unit()) + ", "
+                    + escapeString(stock.negativeValuePolicy()) + ", "
+                    + emitStringList(stock.subscripts())
+                    + "));");
         } else {
-            sb.append(indent).append(builderName).append(".stock(new StockDef(")
-                    .append(escapeString(stock.name())).append(", ")
-                    .append(escapeString(stock.comment())).append(", ")
-                    .append(formatDoubleForSource(stock.initialValue())).append(", ")
-                    .append(escapeString(stock.unit())).append(", ")
-                    .append(escapeString(stock.negativeValuePolicy()))
-                    .append("));\n");
+            cb.line(builderName + ".stock(new StockDef("
+                    + escapeString(stock.name()) + ", "
+                    + escapeString(stock.comment()) + ", "
+                    + formatDoubleForSource(stock.initialValue()) + ", "
+                    + escapeString(stock.unit()) + ", "
+                    + escapeString(stock.negativeValuePolicy())
+                    + "));");
         }
     }
 
@@ -409,22 +412,22 @@ public class DemoClassGenerator {
      * Emits a VariableDef constructor call, using the canonical constructor when subscripts
      * are present.
      */
-    private void emitVariableDef(StringBuilder sb, VariableDef v, String indent, String builderName) {
+    private void emitVariableDef(JavaCodeBuilder cb, VariableDef v, String builderName) {
         if (!v.subscripts().isEmpty()) {
-            sb.append(indent).append(builderName).append(".variable(new VariableDef(")
-                    .append(escapeString(v.name())).append(", ")
-                    .append(escapeString(v.comment())).append(", ")
-                    .append(escapeString(v.equation())).append(", ")
-                    .append(escapeString(v.unit())).append(", ")
-                    .append(emitStringList(v.subscripts()))
-                    .append("));\n");
+            cb.line(builderName + ".variable(new VariableDef("
+                    + escapeString(v.name()) + ", "
+                    + escapeString(v.comment()) + ", "
+                    + escapeString(v.equation()) + ", "
+                    + escapeString(v.unit()) + ", "
+                    + emitStringList(v.subscripts())
+                    + "));");
         } else {
-            sb.append(indent).append(builderName).append(".variable(new VariableDef(")
-                    .append(escapeString(v.name())).append(", ")
-                    .append(escapeString(v.comment())).append(", ")
-                    .append(escapeString(v.equation())).append(", ")
-                    .append(escapeString(v.unit()))
-                    .append("));\n");
+            cb.line(builderName + ".variable(new VariableDef("
+                    + escapeString(v.name()) + ", "
+                    + escapeString(v.comment()) + ", "
+                    + escapeString(v.equation()) + ", "
+                    + escapeString(v.unit())
+                    + "));");
         }
     }
 
@@ -432,44 +435,43 @@ public class DemoClassGenerator {
      * Emits a FlowDef constructor call, using the canonical constructor when subscripts
      * are present.
      */
-    private void emitFlowDef(StringBuilder sb, FlowDef flow, String indent, String builderName) {
+    private void emitFlowDef(JavaCodeBuilder cb, FlowDef flow, String builderName) {
         if (!flow.subscripts().isEmpty()) {
-            sb.append(indent).append(builderName).append(".flow(new FlowDef(")
-                    .append(escapeString(flow.name())).append(", ")
-                    .append(escapeString(flow.comment())).append(", ")
-                    .append(escapeString(flow.equation())).append(", ")
-                    .append(escapeString(flow.timeUnit())).append(", ")
-                    .append(escapeString(flow.source())).append(", ")
-                    .append(escapeString(flow.sink())).append(", ")
-                    .append(emitStringList(flow.subscripts()))
-                    .append("));\n");
+            cb.line(builderName + ".flow(new FlowDef("
+                    + escapeString(flow.name()) + ", "
+                    + escapeString(flow.comment()) + ", "
+                    + escapeString(flow.equation()) + ", "
+                    + escapeString(flow.timeUnit()) + ", "
+                    + escapeString(flow.source()) + ", "
+                    + escapeString(flow.sink()) + ", "
+                    + emitStringList(flow.subscripts())
+                    + "));");
         } else {
-            sb.append(indent).append(builderName).append(".flow(new FlowDef(")
-                    .append(escapeString(flow.name())).append(", ")
-                    .append(escapeString(flow.comment())).append(", ")
-                    .append(escapeString(flow.equation())).append(", ")
-                    .append(escapeString(flow.timeUnit())).append(", ")
-                    .append(escapeString(flow.source())).append(", ")
-                    .append(escapeString(flow.sink()))
-                    .append("));\n");
+            cb.line(builderName + ".flow(new FlowDef("
+                    + escapeString(flow.name()) + ", "
+                    + escapeString(flow.comment()) + ", "
+                    + escapeString(flow.equation()) + ", "
+                    + escapeString(flow.timeUnit()) + ", "
+                    + escapeString(flow.source()) + ", "
+                    + escapeString(flow.sink())
+                    + "));");
         }
     }
 
     /**
      * Emits a LookupTableDef constructor call, including unit when present.
      */
-    private void emitLookupTableDef(StringBuilder sb, LookupTableDef table,
-                                     String indent, String builderName) {
-        sb.append(indent).append(builderName).append(".lookupTable(new LookupTableDef(")
-                .append(escapeString(table.name())).append(", ")
-                .append(escapeString(table.comment())).append(", ")
-                .append(doubleArrayLiteral(table.xValues())).append(", ")
-                .append(doubleArrayLiteral(table.yValues())).append(", ")
-                .append(escapeString(table.interpolation()));
+    private void emitLookupTableDef(JavaCodeBuilder cb, LookupTableDef table, String builderName) {
+        String line = builderName + ".lookupTable(new LookupTableDef("
+                + escapeString(table.name()) + ", "
+                + escapeString(table.comment()) + ", "
+                + doubleArrayLiteral(table.xValues()) + ", "
+                + doubleArrayLiteral(table.yValues()) + ", "
+                + escapeString(table.interpolation());
         if (table.unit() != null) {
-            sb.append(", ").append(escapeString(table.unit()));
+            line += ", " + escapeString(table.unit());
         }
-        sb.append("));\n");
+        cb.line(line + "));");
     }
 
     private static String formatDoubleForSource(double value) {
@@ -494,34 +496,34 @@ public class DemoClassGenerator {
         return sb.toString();
     }
 
-    private void emitMapLiteral(StringBuilder sb, Map<String, String> map, String indent) {
+    private void emitMapLiteral(JavaCodeBuilder cb, Map<String, String> map, String indent) {
         if (map.isEmpty()) {
-            sb.append(indent).append("Map.of()");
+            cb.raw(indent + "Map.of()");
         } else if (map.size() <= 10) {
-            sb.append(indent).append("Map.of(");
+            cb.raw(indent + "Map.of(");
             boolean first = true;
             for (var entry : map.entrySet()) {
                 if (!first) {
-                    sb.append(", ");
+                    cb.raw(", ");
                 }
-                sb.append(escapeString(entry.getKey())).append(", ")
-                        .append(escapeString(entry.getValue()));
+                cb.raw(escapeString(entry.getKey()) + ", "
+                        + escapeString(entry.getValue()));
                 first = false;
             }
-            sb.append(')');
+            cb.raw(")");
         } else {
-            sb.append(indent).append("Map.ofEntries(\n");
+            cb.raw(indent + "Map.ofEntries(\n");
             boolean first = true;
             for (var entry : map.entrySet()) {
                 if (!first) {
-                    sb.append(",\n");
+                    cb.raw(",\n");
                 }
-                sb.append(indent).append("    Map.entry(")
-                        .append(escapeString(entry.getKey())).append(", ")
-                        .append(escapeString(entry.getValue())).append(')');
+                cb.raw(indent + "    Map.entry("
+                        + escapeString(entry.getKey()) + ", "
+                        + escapeString(entry.getValue()) + ")");
                 first = false;
             }
-            sb.append(')');
+            cb.raw(")");
         }
     }
 
@@ -539,9 +541,5 @@ public class DemoClassGenerator {
                    .replace("<", "&lt;")
                    .replace(">", "&gt;")
                    .replace("*/", "&#42;/");
-    }
-
-    private void emitClassClose(StringBuilder sb) {
-        sb.append("}\n");
     }
 }

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/ImportPipelineCli.java
@@ -171,16 +171,16 @@ public class ImportPipelineCli implements Closeable {
         CliArgs parsed = new CliArgs();
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
-                case "--file" -> { parsed.file = requireValue(args, i); i++; }
-                case "--class-name" -> { parsed.className = requireValue(args, i); i++; }
-                case "--category" -> { parsed.category = requireValue(args, i); i++; }
-                case "--author" -> { parsed.author = requireValue(args, i); i++; }
-                case "--source" -> { parsed.source = requireValue(args, i); i++; }
-                case "--license" -> { parsed.license = requireValue(args, i); i++; }
-                case "--url" -> { parsed.url = requireValue(args, i); i++; }
-                case "--json-name" -> { parsed.jsonName = requireValue(args, i); i++; }
-                case "--output-dir" -> { parsed.outputDir = requireValue(args, i); i++; }
-                case "--metadata-file" -> { parsed.metadataFile = requireValue(args, i); i++; }
+                case "--file" -> { parsed.file = CliArgumentParser.requireValue(args, i); i++; }
+                case "--class-name" -> { parsed.className = CliArgumentParser.requireValue(args, i); i++; }
+                case "--category" -> { parsed.category = CliArgumentParser.requireValue(args, i); i++; }
+                case "--author" -> { parsed.author = CliArgumentParser.requireValue(args, i); i++; }
+                case "--source" -> { parsed.source = CliArgumentParser.requireValue(args, i); i++; }
+                case "--license" -> { parsed.license = CliArgumentParser.requireValue(args, i); i++; }
+                case "--url" -> { parsed.url = CliArgumentParser.requireValue(args, i); i++; }
+                case "--json-name" -> { parsed.jsonName = CliArgumentParser.requireValue(args, i); i++; }
+                case "--output-dir" -> { parsed.outputDir = CliArgumentParser.requireValue(args, i); i++; }
+                case "--metadata-file" -> { parsed.metadataFile = CliArgumentParser.requireValue(args, i); i++; }
                 case "--dry-run" -> parsed.dryRun = true;
                 case "--overwrite" -> parsed.overwrite = true;
                 case "--json-only" -> parsed.jsonOnly = true;
@@ -190,15 +190,6 @@ public class ImportPipelineCli implements Closeable {
             }
         }
         return parsed;
-    }
-
-    private static String requireValue(String[] args, int flagIndex) {
-        int valueIndex = flagIndex + 1;
-        if (valueIndex >= args.length) {
-            throw new IllegalArgumentException(
-                    args[flagIndex] + " requires a value");
-        }
-        return args[valueIndex];
     }
 
     private static void printUsage() {

--- a/courant-tools/src/main/java/systems/courant/sd/tools/importer/JavaCodeBuilder.java
+++ b/courant-tools/src/main/java/systems/courant/sd/tools/importer/JavaCodeBuilder.java
@@ -1,0 +1,94 @@
+package systems.courant.sd.tools.importer;
+
+import java.util.function.Consumer;
+
+/**
+ * Fluent builder for generating Java source code with automatic indentation.
+ *
+ * <p>Tracks an indent level (each level = 4 spaces) and provides convenience
+ * methods for emitting indented lines, blank lines, and block structures.
+ */
+public class JavaCodeBuilder {
+
+    private final StringBuilder sb;
+    private int indentLevel;
+    private static final String INDENT_UNIT = "    ";
+
+    public JavaCodeBuilder() {
+        this.sb = new StringBuilder(4096);
+    }
+
+    /**
+     * Appends an indented line followed by a newline.
+     */
+    public JavaCodeBuilder line(String code) {
+        sb.append(currentIndent()).append(code).append('\n');
+        return this;
+    }
+
+    /**
+     * Appends a blank line (no indent).
+     */
+    public JavaCodeBuilder blankLine() {
+        sb.append('\n');
+        return this;
+    }
+
+    /**
+     * Appends raw text without indent or newline.
+     */
+    public JavaCodeBuilder raw(String text) {
+        sb.append(text);
+        return this;
+    }
+
+    /**
+     * Increases the indent level by one (4 spaces).
+     */
+    public JavaCodeBuilder indent() {
+        indentLevel++;
+        return this;
+    }
+
+    /**
+     * Decreases the indent level by one (clamped to 0).
+     */
+    public JavaCodeBuilder dedent() {
+        if (indentLevel > 0) {
+            indentLevel--;
+        }
+        return this;
+    }
+
+    /**
+     * Emits a block: {@code header + " {\n"} at the current indent, increases
+     * indent, runs the body, decreases indent, and emits {@code "}\n"}.
+     */
+    public JavaCodeBuilder block(String header, Consumer<JavaCodeBuilder> body) {
+        line(header + " {");
+        indent();
+        body.accept(this);
+        dedent();
+        line("}");
+        return this;
+    }
+
+    /**
+     * Returns the current indent string.
+     */
+    public String currentIndent() {
+        return INDENT_UNIT.repeat(indentLevel);
+    }
+
+    /**
+     * Returns the indent string at the given number of extra levels beyond current.
+     */
+    public String indentAt(int extraLevels) {
+        return INDENT_UNIT.repeat(indentLevel + extraLevels);
+    }
+
+    @Override
+    public String toString() {
+        return sb.toString();
+    }
+}

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/CliArgumentParserTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/CliArgumentParserTest.java
@@ -1,0 +1,41 @@
+package systems.courant.sd.tools.importer;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("CliArgumentParser")
+class CliArgumentParserTest {
+
+    @Test
+    void shouldReturnValueFollowingFlag() {
+        String[] args = {"--file", "model.mdl", "--class", "Demo"};
+        assertThat(CliArgumentParser.requireValue(args, 0)).isEqualTo("model.mdl");
+        assertThat(CliArgumentParser.requireValue(args, 2)).isEqualTo("Demo");
+    }
+
+    @Test
+    void shouldThrowWhenNoValueFollowsFlag() {
+        String[] args = {"--file"};
+        assertThatThrownBy(() -> CliArgumentParser.requireValue(args, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("--file")
+                .hasMessageContaining("requires a value");
+    }
+
+    @Test
+    void shouldThrowWhenFlagIsLastElement() {
+        String[] args = {"--output-dir", "/tmp", "--verbose"};
+        assertThatThrownBy(() -> CliArgumentParser.requireValue(args, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("--verbose");
+    }
+
+    @Test
+    void shouldReturnValueAtMiddleOfArray() {
+        String[] args = {"--a", "1", "--b", "2", "--c", "3"};
+        assertThat(CliArgumentParser.requireValue(args, 2)).isEqualTo("2");
+    }
+}

--- a/courant-tools/src/test/java/systems/courant/sd/tools/importer/JavaCodeBuilderTest.java
+++ b/courant-tools/src/test/java/systems/courant/sd/tools/importer/JavaCodeBuilderTest.java
@@ -1,0 +1,179 @@
+package systems.courant.sd.tools.importer;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JavaCodeBuilder")
+class JavaCodeBuilderTest {
+
+    @Nested
+    @DisplayName("line()")
+    class Line {
+
+        @Test
+        void shouldEmitLineWithNewline() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.line("int x = 1;");
+            assertThat(cb.toString()).isEqualTo("int x = 1;\n");
+        }
+
+        @Test
+        void shouldIndentLineAtCurrentLevel() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.indent().indent();
+            cb.line("int x = 1;");
+            assertThat(cb.toString()).isEqualTo("        int x = 1;\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("blankLine()")
+    class BlankLine {
+
+        @Test
+        void shouldEmitEmptyNewline() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.blankLine();
+            assertThat(cb.toString()).isEqualTo("\n");
+        }
+
+        @Test
+        void shouldNotAddIndentToBlankLine() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.indent().indent();
+            cb.blankLine();
+            assertThat(cb.toString()).isEqualTo("\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("raw()")
+    class Raw {
+
+        @Test
+        void shouldAppendWithoutIndentOrNewline() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.indent();
+            cb.raw("hello");
+            assertThat(cb.toString()).isEqualTo("hello");
+        }
+
+        @Test
+        void shouldAppendExactText() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.raw("first");
+            cb.raw(" second");
+            assertThat(cb.toString()).isEqualTo("first second");
+        }
+    }
+
+    @Nested
+    @DisplayName("indent/dedent")
+    class IndentDedent {
+
+        @Test
+        void shouldIncreaseAndDecreaseIndent() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.indent();
+            cb.line("level 1");
+            cb.indent();
+            cb.line("level 2");
+            cb.dedent();
+            cb.line("back to 1");
+            cb.dedent();
+            cb.line("back to 0");
+            assertThat(cb.toString()).isEqualTo(
+                    "    level 1\n"
+                    + "        level 2\n"
+                    + "    back to 1\n"
+                    + "back to 0\n");
+        }
+
+        @Test
+        void shouldClampDedentAtZero() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.dedent();
+            cb.line("still at zero");
+            assertThat(cb.toString()).isEqualTo("still at zero\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("block()")
+    class Block {
+
+        @Test
+        void shouldEmitBlockWithBraces() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.block("public class Foo", inner -> inner.line("int x = 1;"));
+            assertThat(cb.toString()).isEqualTo(
+                    "public class Foo {\n"
+                    + "    int x = 1;\n"
+                    + "}\n");
+        }
+
+        @Test
+        void shouldNestBlocks() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.block("class Foo", outer ->
+                    outer.block("void bar()", inner ->
+                            inner.line("return;")));
+            assertThat(cb.toString()).isEqualTo(
+                    "class Foo {\n"
+                    + "    void bar() {\n"
+                    + "        return;\n"
+                    + "    }\n"
+                    + "}\n");
+        }
+
+        @Test
+        void shouldRestoreIndentAfterBlock() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.indent();
+            cb.block("if (true)", inner -> inner.line("x++;"));
+            cb.line("next;");
+            assertThat(cb.toString()).isEqualTo(
+                    "    if (true) {\n"
+                    + "        x++;\n"
+                    + "    }\n"
+                    + "    next;\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("currentIndent and indentAt")
+    class IndentStrings {
+
+        @Test
+        void shouldReturnCurrentIndentString() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            assertThat(cb.currentIndent()).isEmpty();
+            cb.indent().indent();
+            assertThat(cb.currentIndent()).isEqualTo("        ");
+        }
+
+        @Test
+        void shouldReturnIndentAtExtraLevels() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.indent().indent();
+            assertThat(cb.indentAt(2)).isEqualTo("                ");
+        }
+
+        @Test
+        void shouldReturnIndentAtZeroExtraLevels() {
+            JavaCodeBuilder cb = new JavaCodeBuilder();
+            cb.indent();
+            assertThat(cb.indentAt(0)).isEqualTo("    ");
+        }
+    }
+
+    @Test
+    void shouldSupportFluentChaining() {
+        JavaCodeBuilder cb = new JavaCodeBuilder();
+        String result = cb.line("a").indent().line("b").dedent().line("c").toString();
+        assertThat(result).isEqualTo("a\n    b\nc\n");
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts `JavaCodeBuilder` from `DemoClassGenerator` to replace raw `StringBuilder` with 115+ manual `sb.append()` calls. The builder tracks indent level automatically, eliminating error-prone `INDENT`/`INDENT2` constants and `String indent` parameters.
- Extracts `CliArgumentParser` utility to deduplicate the identical `requireValue()` methods in `BatchImportCli` and `ImportPipelineCli`.
- Adds unit tests for both new classes.

Closes #1448

## Test plan
- [x] All 181 existing tests pass (output-preserving refactor)
- [x] New JavaCodeBuilderTest covers line, blankLine, raw, indent/dedent, block, indentAt
- [x] New CliArgumentParserTest covers happy path and error cases
- [x] SpotBugs clean