### PR TITLE
Allow users to change the color of links, elements, and text (#1436)

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasCallbacks.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasCallbacks.java
@@ -179,4 +179,14 @@ final class CanvasCallbacks implements InlineEditController.Callbacks,
     public void showUses(String name) {
         canvas.analysis().showUses(name);
     }
+
+    @Override
+    public void setElementColor(String elementName, String hexColor) {
+        canvas.canvasState().setColor(elementName, hexColor);
+    }
+
+    @Override
+    public void setCausalLinkColor(ConnectionId link, String hexColor) {
+        canvas.getEditor().setCausalLinkColor(link.from(), link.to(), hexColor);
+    }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/CanvasState.java
@@ -37,6 +37,7 @@ public class CanvasState {
 
     private final Map<String, Position> positions = new LinkedHashMap<>();
     private final Map<String, Size> sizes = new LinkedHashMap<>();
+    private final Map<String, String> colors = new LinkedHashMap<>();
     private final Map<String, ElementType> types = new LinkedHashMap<>();
     private final Set<String> selection = new LinkedHashSet<>();
     private final SequencedSet<String> drawOrder = new LinkedHashSet<>();
@@ -53,6 +54,7 @@ public class CanvasState {
         positions.clear();
         types.clear();
         sizes.clear();
+        colors.clear();
         selection.clear();
         cldLoopInfo = null;
         loopNames.clear();
@@ -65,6 +67,9 @@ public class CanvasState {
             for (ElementPlacement ep : view.elements()) {
                 positions.put(ep.name(), new Position(ep.x(), ep.y()));
                 types.put(ep.name(), ep.type());
+                if (ep.hasColor()) {
+                    colors.put(ep.name(), ep.color());
+                }
                 if (ep.hasCustomSize()) {
                     sizes.put(ep.name(), new Size(ep.width(), ep.height()));
                 } else if (ep.type() == ElementType.CLD_VARIABLE) {
@@ -147,6 +152,27 @@ public class CanvasState {
     public boolean hasCustomSize(String name) {
         Size size = sizes.get(name);
         return size != null && size.width() > 0 && size.height() > 0;
+    }
+
+    /**
+     * Returns the custom color hex string for the named element, or empty if using default.
+     */
+    public Optional<String> getColor(String name) {
+        return Optional.ofNullable(colors.get(name));
+    }
+
+    /**
+     * Sets or clears the custom color for the named element.
+     *
+     * @param name the element name
+     * @param hex  a hex color string (e.g. "#FF0000"), or null to reset to default
+     */
+    public void setColor(String name, String hex) {
+        if (hex == null) {
+            colors.remove(name);
+        } else {
+            colors.put(name, hex);
+        }
     }
 
     /**
@@ -347,11 +373,13 @@ public class CanvasState {
             }
             Position pos = positions.get(name);
             Size size = sizes.get(name);
+            String color = colors.get(name);
             if (size != null && size.width() > 0 && size.height() > 0) {
                 placements.add(new ElementPlacement(
-                        name, type, pos.x(), pos.y(), size.width(), size.height()));
+                        name, type, pos.x(), pos.y(), size.width(), size.height(), color));
             } else {
-                placements.add(new ElementPlacement(name, type, pos.x(), pos.y()));
+                placements.add(new ElementPlacement(
+                        name, type, pos.x(), pos.y(), 0, 0, color));
             }
         }
         return new ViewDef(viewName, placements, List.of(), List.of(), loopNames);
@@ -364,6 +392,7 @@ public class CanvasState {
         positions.remove(name);
         types.remove(name);
         sizes.remove(name);
+        colors.remove(name);
         synchronized (drawOrderLock) {
             drawOrder.remove(name);
             drawOrderCache = null;

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/ModelEditor.java
@@ -584,7 +584,20 @@ public class ModelEditor {
             CausalLinkDef link = causalLinks.get(i);
             if (link.from().equals(from) && link.to().equals(to)) {
                 causalLinks.set(i, new CausalLinkDef(from, to, polarity, link.comment(),
-                        link.strength(), link.bias()));
+                        link.strength(), link.bias(), link.color()));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** @return true if the causal link was found and its color updated */
+    public boolean setCausalLinkColor(String from, String to, String color) {
+        checkFxThread();
+        for (int i = 0; i < causalLinks.size(); i++) {
+            CausalLinkDef link = causalLinks.get(i);
+            if (link.from().equals(from) && link.to().equals(to)) {
+                causalLinks.set(i, link.withColor(color));
                 return true;
             }
         }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CanvasContextMenuController.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/controllers/CanvasContextMenuController.java
@@ -4,10 +4,15 @@ import systems.courant.sd.model.def.CausalLinkDef;
 import systems.courant.sd.model.def.ElementType;
 
 import javafx.scene.canvas.Canvas;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ColorPicker;
 import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Dialog;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.CanvasToolBar;
 import systems.courant.sd.app.canvas.ConnectionId;
@@ -52,6 +57,8 @@ public final class CanvasContextMenuController {
         void showWhereUsed(String elementName);
         void showUses(String elementName);
         void convertVariableToComment(String variableName);
+        void setElementColor(String elementName, String hexColor);
+        void setCausalLinkColor(ConnectionId link, String hexColor);
     }
 
     private final ModuleNavigationController navController;
@@ -138,6 +145,16 @@ public final class CanvasContextMenuController {
             menu.getItems().addAll(new SeparatorMenuItem(), convertItem);
         }
 
+        // Color submenu
+        String currentHex = canvasState.getColor(elementName).orElse(null);
+        Menu colorMenu = buildColorMenu(currentHex, hex -> {
+            callbacks.saveUndoState("Change color");
+            callbacks.setElementColor(elementName, hex);
+            callbacks.redraw();
+            callbacks.fireStatusChanged();
+        });
+        menu.getItems().addAll(new SeparatorMenuItem(), colorMenu);
+
         menu.getItems().addAll(new SeparatorMenuItem(),
                 cutItem, copyItem, new SeparatorMenuItem(), deleteItem);
         menu.show(canvas, screenX, screenY);
@@ -163,6 +180,17 @@ public final class CanvasContextMenuController {
             polarityMenu.getItems().add(item);
         }
         menu.getItems().add(polarityMenu);
+
+        // Color submenu
+        String currentLinkColor = editor.getCausalLinks().stream()
+                .filter(cl -> cl.from().equals(link.from()) && cl.to().equals(link.to()))
+                .findFirst().map(cl -> cl.hasColor() ? cl.color() : null).orElse(null);
+        Menu colorMenu = buildColorMenu(currentLinkColor, hex -> {
+            callbacks.saveUndoState("Change link color");
+            callbacks.setCausalLinkColor(link, hex);
+            callbacks.redraw();
+        });
+        menu.getItems().add(colorMenu);
 
         MenuItem deleteItem = new MenuItem("Delete");
         deleteItem.setOnAction(e -> {
@@ -198,6 +226,64 @@ public final class CanvasContextMenuController {
         menu.getItems().add(deleteItem);
 
         menu.show(canvas, screenX, screenY);
+    }
+
+    // ── Color menu helpers ─────────────────────────────────────────────
+
+    private static final String[][] COLOR_SWATCHES = {
+            {"Black",  "#2C3E50"},
+            {"Red",    "#E74C3C"},
+            {"Blue",   "#2980B9"},
+            {"Green",  "#27AE60"},
+            {"Orange", "#E67E22"},
+            {"Purple", "#8E44AD"},
+    };
+
+    /**
+     * Builds a "Color" submenu with preset swatches, a "Custom..." option, and "Default".
+     *
+     * @param currentHex the currently applied hex color, or null for default
+     * @param onColor    callback receiving the chosen hex string, or null for "Default"
+     */
+    private static Menu buildColorMenu(String currentHex, java.util.function.Consumer<String> onColor) {
+        Menu menu = new Menu("Color");
+        for (String[] swatch : COLOR_SWATCHES) {
+            MenuItem item = new MenuItem(swatch[0]);
+            Rectangle rect = new Rectangle(12, 12, Color.web(swatch[1]));
+            item.setGraphic(rect);
+            String hex = swatch[1];
+            item.setOnAction(e -> onColor.accept(hex));
+            menu.getItems().add(item);
+        }
+        menu.getItems().add(new SeparatorMenuItem());
+
+        MenuItem customItem = new MenuItem("Custom\u2026");
+        customItem.setOnAction(e -> {
+            Color initial = currentHex != null ? Color.web(currentHex) : Color.web("#2C3E50");
+            Dialog<Color> dialog = new Dialog<>();
+            dialog.setTitle("Choose Color");
+            dialog.setHeaderText(null);
+            ColorPicker picker = new ColorPicker(initial);
+            dialog.getDialogPane().setContent(picker);
+            dialog.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+            dialog.setResultConverter(btn -> btn == ButtonType.OK ? picker.getValue() : null);
+            dialog.showAndWait().ifPresent(color -> {
+                String hex = String.format("#%02X%02X%02X",
+                        (int) (color.getRed() * 255),
+                        (int) (color.getGreen() * 255),
+                        (int) (color.getBlue() * 255));
+                onColor.accept(hex);
+            });
+        });
+        menu.getItems().add(customItem);
+
+        menu.getItems().add(new SeparatorMenuItem());
+        MenuItem defaultItem = new MenuItem("Default");
+        defaultItem.setDisable(currentHex == null);
+        defaultItem.setOnAction(e -> onColor.accept(null));
+        menu.getItems().add(defaultItem);
+
+        return menu;
     }
 
     /**

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/AuxRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/AuxRenderer.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.app.canvas.renderers;
 
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
 
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.LayoutMetrics;
@@ -27,7 +28,8 @@ final class AuxRenderer implements ElementTypeRenderer {
         boolean hasDelay = showDelay
                 && DelayDetector.equationContainsDelay(equation);
         List<String> subscripts = editor.getElementSubscripts(name);
+        Color customColor = canvasState.getColor(name).map(Color::web).orElse(null);
         ElementRenderer.drawAux(gc, name, isLiteral, equation, hasDelay, subscripts,
-                cx - w / 2, cy - h / 2, w, h);
+                cx - w / 2, cy - h / 2, w, h, false, customColor);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CausalLinkPass.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CausalLinkPass.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.app.canvas.renderers;
 
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
 
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.CausalLinkGeometry;
@@ -56,12 +57,14 @@ final class CausalLinkPass implements RenderPass {
             double fromX = canvasState.getX(fromName);
             double fromY = canvasState.getY(fromName);
 
+            Color customColor = link.hasColor() ? Color.web(link.color()) : null;
+
             // Self-loop: use cubic Bézier loop above the element
             if (fromName.equals(toName)) {
                 double halfW = LayoutMetrics.effectiveWidth(canvasState, fromName) / 2;
                 double halfH = LayoutMetrics.effectiveHeight(canvasState, fromName) / 2;
                 double[] loopPts = CausalLinkGeometry.selfLoopPoints(fromX, fromY, halfW, halfH, loopCtx, fromName);
-                ConnectionRenderer.drawCausalLinkSelfLoop(gc, loopPts, link.polarity());
+                ConnectionRenderer.drawCausalLinkSelfLoop(gc, loopPts, link.polarity(), customColor);
                 if (dim) {
                     gc.restore();
                 }
@@ -83,7 +86,7 @@ final class CausalLinkPass implements RenderPass {
                     canvasState, toName, cp.x(), cp.y());
 
             ConnectionRenderer.drawCausalLink(gc, clippedFrom.x(), clippedFrom.y(),
-                    clippedTo.x(), clippedTo.y(), cp, link.polarity());
+                    clippedTo.x(), clippedTo.y(), cp, link.polarity(), customColor);
             if (dim) {
                 gc.restore();
             }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CldVariableRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CldVariableRenderer.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.app.canvas.renderers;
 
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
 
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.LayoutMetrics;
@@ -17,6 +18,7 @@ final class CldVariableRenderer implements ElementTypeRenderer {
                        CanvasState canvasState, ModelEditor editor, boolean showDelay) {
         double w = LayoutMetrics.effectiveWidth(canvasState, name);
         double h = LayoutMetrics.effectiveHeight(canvasState, name);
-        ElementRenderer.drawCldVariable(gc, name, cx - w / 2, cy - h / 2, w, h);
+        Color customColor = canvasState.getColor(name).map(Color::web).orElse(null);
+        ElementRenderer.drawCldVariable(gc, name, cx - w / 2, cy - h / 2, w, h, customColor);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CommentRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/CommentRenderer.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.app.canvas.renderers;
 
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
 
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.ModelEditor;
@@ -28,6 +29,7 @@ final class CommentRenderer implements ElementTypeRenderer {
             h = auto[1];
             canvasState.setSize(name, w, h);
         }
-        ElementRenderer.drawComment(gc, text, cx - w / 2, cy - h / 2, w, h);
+        Color customColor = canvasState.getColor(name).map(Color::web).orElse(null);
+        ElementRenderer.drawComment(gc, text, cx - w / 2, cy - h / 2, w, h, customColor);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ConnectionRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ConnectionRenderer.java
@@ -139,6 +139,18 @@ public final class ConnectionRenderer {
                                       double toX, double toY,
                                       CausalLinkGeometry.ControlPoint cp,
                                       CausalLinkDef.Polarity polarity) {
+        drawCausalLink(gc, fromX, fromY, toX, toY, cp, polarity, null);
+    }
+
+    /**
+     * Draws a causal link with an optional custom color override.
+     */
+    public static void drawCausalLink(GraphicsContext gc,
+                                      double fromX, double fromY,
+                                      double toX, double toY,
+                                      CausalLinkGeometry.ControlPoint cp,
+                                      CausalLinkDef.Polarity polarity,
+                                      Color customColor) {
         // Compute arrowhead placement along the curve
         double[] ah = CausalLinkGeometry.arrowheadPoint(fromX, fromY, cp.x(), cp.y(),
                 toX, toY, LayoutMetrics.CAUSAL_ARROWHEAD_LENGTH);
@@ -149,11 +161,16 @@ public final class ConnectionRenderer {
         double stopT = ah[4];
 
         // Draw the curved line, stopping at the arrowhead base
-        Color linkColor = polarity == CausalLinkDef.Polarity.UNKNOWN
-                ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
+        Color linkColor;
+        if (customColor != null) {
+            linkColor = customColor;
+        } else {
+            linkColor = polarity == CausalLinkDef.Polarity.UNKNOWN
+                    ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
+        }
         gc.setStroke(linkColor);
         gc.setLineWidth(LayoutMetrics.CAUSAL_LINK_WIDTH);
-        if (polarity == CausalLinkDef.Polarity.UNKNOWN) {
+        if (customColor == null && polarity == CausalLinkDef.Polarity.UNKNOWN) {
             gc.setLineDashes(4, 3);
         } else {
             gc.setLineDashes();
@@ -173,7 +190,7 @@ public final class ConnectionRenderer {
         PolarityLabelLayout labelLayout = PolarityLabelLayout.forQuadratic(
                 fromX, fromY, cp.x(), cp.y(), toX, toY);
         if (labelLayout.valid()) {
-            Color labelColor = PolarityLabelLayout.colorFor(polarity);
+            Color labelColor = customColor != null ? customColor : PolarityLabelLayout.colorFor(polarity);
             Font labelFont = polarity == CausalLinkDef.Polarity.UNKNOWN
                     ? LayoutMetrics.CAUSAL_UNKNOWN_FONT : LayoutMetrics.CAUSAL_POLARITY_FONT;
             gc.setFill(labelColor);
@@ -190,6 +207,16 @@ public final class ConnectionRenderer {
     public static void drawCausalLinkSelfLoop(GraphicsContext gc,
                                                double[] loopPts,
                                                CausalLinkDef.Polarity polarity) {
+        drawCausalLinkSelfLoop(gc, loopPts, polarity, null);
+    }
+
+    /**
+     * Draws a self-loop causal link with an optional custom color override.
+     */
+    public static void drawCausalLinkSelfLoop(GraphicsContext gc,
+                                               double[] loopPts,
+                                               CausalLinkDef.Polarity polarity,
+                                               Color customColor) {
         double startX = loopPts[0];
         double startY = loopPts[1];
         double cp1X = loopPts[2];
@@ -200,11 +227,16 @@ public final class ConnectionRenderer {
         double endY = loopPts[7];
 
         // Draw curve
-        Color linkColor = polarity == CausalLinkDef.Polarity.UNKNOWN
-                ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
+        Color linkColor;
+        if (customColor != null) {
+            linkColor = customColor;
+        } else {
+            linkColor = polarity == CausalLinkDef.Polarity.UNKNOWN
+                    ? ColorPalette.CAUSAL_UNKNOWN : ColorPalette.CAUSAL_LINK;
+        }
         gc.setStroke(linkColor);
         gc.setLineWidth(LayoutMetrics.CAUSAL_LINK_WIDTH);
-        if (polarity == CausalLinkDef.Polarity.UNKNOWN) {
+        if (customColor == null && polarity == CausalLinkDef.Polarity.UNKNOWN) {
             gc.setLineDashes(4, 3);
         } else {
             gc.setLineDashes();
@@ -227,7 +259,7 @@ public final class ConnectionRenderer {
 
         // Polarity label at the top of the loop
         PolarityLabelLayout labelLayout = PolarityLabelLayout.forSelfLoop(loopPts);
-        Color labelColor = PolarityLabelLayout.colorFor(polarity);
+        Color labelColor = customColor != null ? customColor : PolarityLabelLayout.colorFor(polarity);
         Font labelFont = polarity == CausalLinkDef.Polarity.UNKNOWN
                 ? LayoutMetrics.CAUSAL_UNKNOWN_FONT : LayoutMetrics.CAUSAL_POLARITY_FONT;
         gc.setFill(labelColor);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ElementRenderer.java
@@ -66,20 +66,32 @@ public final class ElementRenderer {
     public static void drawStock(GraphicsContext gc, String name, String unit,
                                  List<String> subscripts,
                                  double x, double y, double width, double height) {
+        drawStock(gc, name, unit, subscripts, x, y, width, height, null);
+    }
+
+    /**
+     * Draws a stock with an optional custom color override for border and text.
+     */
+    public static void drawStock(GraphicsContext gc, String name, String unit,
+                                 List<String> subscripts,
+                                 double x, double y, double width, double height,
+                                 Color customColor) {
         double r = LayoutMetrics.STOCK_CORNER_RADIUS;
+        Color borderColor = customColor != null ? customColor : ColorPalette.STOCK_BORDER;
+        Color textColor = customColor != null ? customColor : ColorPalette.TEXT;
 
         // Fill
         gc.setFill(ColorPalette.STOCK_FILL);
         gc.fillRoundRect(x, y, width, height, r, r);
 
         // Border
-        gc.setStroke(ColorPalette.STOCK_BORDER);
+        gc.setStroke(borderColor);
         gc.setLineWidth(LayoutMetrics.STOCK_BORDER_WIDTH);
         gc.setLineDashes();
         gc.strokeRoundRect(x, y, width, height, r, r);
 
         // Name centered (truncated to fit)
-        gc.setFill(ColorPalette.TEXT);
+        gc.setFill(textColor);
         gc.setFont(LayoutMetrics.STOCK_NAME_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
@@ -88,7 +100,7 @@ public final class ElementRenderer {
 
         // Unit badge centered below name
         if (unit != null && !unit.isBlank()) {
-            gc.setFill(ColorPalette.BADGE_TEXT);
+            gc.setFill(customColor != null ? customColor : ColorPalette.BADGE_TEXT);
             gc.setFont(LayoutMetrics.UNIT_BADGE_FONT);
             gc.setTextAlign(TextAlignment.CENTER);
             gc.setTextBaseline(VPos.BOTTOM);
@@ -115,9 +127,21 @@ public final class ElementRenderer {
     public static void drawFlow(GraphicsContext gc, String name, boolean hasDelay,
                                 List<String> subscripts,
                                 double x, double y, double width, double height) {
+        drawFlow(gc, name, hasDelay, subscripts, x, y, width, height, null);
+    }
+
+    /**
+     * Draws a flow with an optional custom color override for border and text.
+     */
+    public static void drawFlow(GraphicsContext gc, String name, boolean hasDelay,
+                                List<String> subscripts,
+                                double x, double y, double width, double height,
+                                Color customColor) {
         double cx = x + width / 2;
         double cy = y + height / 2;
         double half = Math.min(width, height) / 2;
+        Color borderColor = customColor != null ? customColor : ColorPalette.AUX_BORDER;
+        Color textColor = customColor != null ? customColor : ColorPalette.TEXT;
 
         // Diamond shape (rotated square with rounded appearance)
         double[] xPoints = {cx, cx + half, cx, cx - half};
@@ -125,13 +149,13 @@ public final class ElementRenderer {
 
         gc.setFill(ColorPalette.ELEMENT_FILL);
         gc.fillPolygon(xPoints, yPoints, 4);
-        gc.setStroke(ColorPalette.AUX_BORDER);
+        gc.setStroke(borderColor);
         gc.setLineWidth(1.5);
         gc.setLineDashes();
         gc.strokePolygon(xPoints, yPoints, 4);
 
         // Name below the diamond (truncated to reasonable width)
-        gc.setFill(ColorPalette.TEXT);
+        gc.setFill(textColor);
         gc.setFont(LayoutMetrics.FLOW_NAME_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.TOP);
@@ -188,14 +212,26 @@ public final class ElementRenderer {
                                boolean hasDelay, List<String> subscripts,
                                double x, double y, double width, double height,
                                boolean hovered) {
+        drawAux(gc, name, isLiteral, equation, hasDelay, subscripts, x, y, width, height, hovered, null);
+    }
+
+    /**
+     * Draws a variable with an optional custom color override for text.
+     */
+    public static void drawAux(GraphicsContext gc, String name, boolean isLiteral, String equation,
+                               boolean hasDelay, List<String> subscripts,
+                               double x, double y, double width, double height,
+                               boolean hovered, Color customColor) {
         double r = LayoutMetrics.AUX_CORNER_RADIUS;
+        Color textColor = customColor != null ? customColor : ColorPalette.TEXT;
+        Color badgeColor = customColor != null ? customColor : ColorPalette.BADGE_TEXT;
 
         // Fill: hover fill when hovered, subtle gray otherwise
         gc.setFill(hovered ? ColorPalette.HOVER_FILL : ColorPalette.VARIABLE_FILL);
         gc.fillRoundRect(x, y, width, height, r, r);
 
         // Badge top-left: value for literals, "fx" for formulas
-        gc.setFill(ColorPalette.BADGE_TEXT);
+        gc.setFill(badgeColor);
         gc.setFont(LayoutMetrics.BADGE_FONT);
         gc.setTextAlign(TextAlignment.LEFT);
         gc.setTextBaseline(VPos.TOP);
@@ -211,7 +247,7 @@ public final class ElementRenderer {
         }
 
         // Name centered — wrap to two lines if needed
-        gc.setFill(ColorPalette.TEXT);
+        gc.setFill(textColor);
         gc.setFont(LayoutMetrics.AUX_NAME_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
@@ -237,27 +273,39 @@ public final class ElementRenderer {
     public static void drawModule(GraphicsContext gc, String name,
                                   List<String> inputPorts, List<String> outputPorts,
                                   double x, double y, double width, double height) {
+        drawModule(gc, name, inputPorts, outputPorts, x, y, width, height, null);
+    }
+
+    /**
+     * Draws a module with an optional custom color override for border and text.
+     */
+    public static void drawModule(GraphicsContext gc, String name,
+                                  List<String> inputPorts, List<String> outputPorts,
+                                  double x, double y, double width, double height,
+                                  Color customColor) {
         double r = LayoutMetrics.MODULE_CORNER_RADIUS;
+        Color borderColor = customColor != null ? customColor : ColorPalette.STOCK_BORDER;
+        Color textColor = customColor != null ? customColor : ColorPalette.TEXT;
 
         // Fill
         gc.setFill(ColorPalette.ELEMENT_FILL);
         gc.fillRoundRect(x, y, width, height, r, r);
 
         // Border
-        gc.setStroke(ColorPalette.STOCK_BORDER);
+        gc.setStroke(borderColor);
         gc.setLineWidth(LayoutMetrics.MODULE_BORDER_WIDTH);
         gc.setLineDashes();
         gc.strokeRoundRect(x, y, width, height, r, r);
 
         // Module badge top-left
-        gc.setFill(ColorPalette.BADGE_TEXT);
+        gc.setFill(customColor != null ? customColor : ColorPalette.BADGE_TEXT);
         gc.setFont(LayoutMetrics.BADGE_FONT);
         gc.setTextAlign(TextAlignment.LEFT);
         gc.setTextBaseline(VPos.TOP);
         gc.fillText(BADGE_MODULE, x + 5, y + 3);
 
         // Name centered (truncated to fit)
-        gc.setFill(ColorPalette.TEXT);
+        gc.setFill(textColor);
         gc.setFont(LayoutMetrics.MODULE_NAME_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
@@ -322,21 +370,32 @@ public final class ElementRenderer {
     public static void drawLookup(GraphicsContext gc, String name,
                                   double x, double y, double width, double height,
                                   boolean hovered) {
+        drawLookup(gc, name, x, y, width, height, hovered, null);
+    }
+
+    /**
+     * Draws a lookup table with an optional custom color override for text.
+     */
+    public static void drawLookup(GraphicsContext gc, String name,
+                                  double x, double y, double width, double height,
+                                  boolean hovered, Color customColor) {
         double r = LayoutMetrics.LOOKUP_CORNER_RADIUS;
+        Color textColor = customColor != null ? customColor : ColorPalette.TEXT;
+        Color badgeColor = customColor != null ? customColor : ColorPalette.BADGE_TEXT;
 
         // Fill: hover fill when hovered, subtle gray otherwise
         gc.setFill(hovered ? ColorPalette.HOVER_FILL : ColorPalette.LOOKUP_FILL);
         gc.fillRoundRect(x, y, width, height, r, r);
 
         // Table badge top-left
-        gc.setFill(ColorPalette.BADGE_TEXT);
+        gc.setFill(badgeColor);
         gc.setFont(LayoutMetrics.BADGE_FONT);
         gc.setTextAlign(TextAlignment.LEFT);
         gc.setTextBaseline(VPos.TOP);
         gc.fillText(BADGE_LOOKUP, x + 4, y + 3);
 
         // Name centered vertically — wrap to two lines if needed
-        gc.setFill(ColorPalette.TEXT);
+        gc.setFill(textColor);
         gc.setFont(LayoutMetrics.LOOKUP_NAME_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
@@ -352,15 +411,24 @@ public final class ElementRenderer {
      */
     public static void drawComment(GraphicsContext gc, String text,
                                    double x, double y, double width, double height) {
+        drawComment(gc, text, x, y, width, height, null);
+    }
+
+    /**
+     * Draws a comment with an optional custom color override for accent and text.
+     */
+    public static void drawComment(GraphicsContext gc, String text,
+                                   double x, double y, double width, double height,
+                                   Color customColor) {
         double r = LayoutMetrics.COMMENT_CORNER_RADIUS;
 
         // Left accent bar
-        gc.setFill(ColorPalette.COMMENT_ACCENT);
+        gc.setFill(customColor != null ? customColor : ColorPalette.COMMENT_ACCENT);
         gc.fillRect(x, y + r, LayoutMetrics.COMMENT_ACCENT_WIDTH, height - r * 2);
 
         // Text content (word-wrapped, top-left aligned)
         if (text != null && !text.isBlank()) {
-            gc.setFill(ColorPalette.COMMENT_TEXT);
+            gc.setFill(customColor != null ? customColor : ColorPalette.COMMENT_TEXT);
             gc.setFont(LayoutMetrics.COMMENT_TEXT_FONT);
             gc.setTextAlign(TextAlignment.LEFT);
             gc.setTextBaseline(VPos.TOP);
@@ -387,7 +455,16 @@ public final class ElementRenderer {
      */
     public static void drawCldVariable(GraphicsContext gc, String name,
                                        double x, double y, double width, double height) {
-        gc.setFill(ColorPalette.TEXT);
+        drawCldVariable(gc, name, x, y, width, height, null);
+    }
+
+    /**
+     * Draws a CLD variable with an optional custom color override for text.
+     */
+    public static void drawCldVariable(GraphicsContext gc, String name,
+                                       double x, double y, double width, double height,
+                                       Color customColor) {
+        gc.setFill(customColor != null ? customColor : ColorPalette.TEXT);
         gc.setFont(LayoutMetrics.AUX_NAME_FONT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/FlowRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/FlowRenderer.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.app.canvas.renderers;
 
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
 
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.LayoutMetrics;
@@ -22,7 +23,8 @@ final class FlowRenderer implements ElementTypeRenderer {
                         .map(DelayDetector::equationContainsDelay).orElse(false);
         List<String> subscripts = editor.getElementSubscripts(name);
         double size = LayoutMetrics.FLOW_INDICATOR_SIZE;
+        Color customColor = canvasState.getColor(name).map(Color::web).orElse(null);
         ElementRenderer.drawFlow(gc, name, hasDelay, subscripts,
-                cx - size / 2, cy - size / 2, size, size);
+                cx - size / 2, cy - size / 2, size, size, customColor);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/LookupRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/LookupRenderer.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.app.canvas.renderers;
 
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
 
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.LayoutMetrics;
@@ -16,6 +17,7 @@ final class LookupRenderer implements ElementTypeRenderer {
                        CanvasState canvasState, ModelEditor editor, boolean showDelay) {
         double w = LayoutMetrics.effectiveWidth(canvasState, name);
         double h = LayoutMetrics.effectiveHeight(canvasState, name);
-        ElementRenderer.drawLookup(gc, name, cx - w / 2, cy - h / 2, w, h);
+        Color customColor = canvasState.getColor(name).map(Color::web).orElse(null);
+        ElementRenderer.drawLookup(gc, name, cx - w / 2, cy - h / 2, w, h, false, customColor);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/MaterialFlowPass.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/MaterialFlowPass.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.app.canvas.renderers;
 
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
 
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.ColorPalette;
@@ -36,20 +37,19 @@ final class MaterialFlowPass implements RenderPass {
 
             boolean mismatch = maturity != null
                     && maturity.unitMismatchFlows().contains(flow.name());
+            Color flowColor;
             if (mismatch) {
-                ConnectionRenderer.drawMaterialFlow(gc,
-                        endpoints.sourceX(), endpoints.sourceY(),
-                        endpoints.midX(), endpoints.midY(),
-                        endpoints.sinkX(), endpoints.sinkY(),
-                        endpoints.sourceIsCloud(), endpoints.sinkIsCloud(),
-                        ColorPalette.UNIT_MISMATCH);
+                flowColor = ColorPalette.UNIT_MISMATCH;
             } else {
-                ConnectionRenderer.drawMaterialFlow(gc,
-                        endpoints.sourceX(), endpoints.sourceY(),
-                        endpoints.midX(), endpoints.midY(),
-                        endpoints.sinkX(), endpoints.sinkY(),
-                        endpoints.sourceIsCloud(), endpoints.sinkIsCloud());
+                flowColor = canvasState.getColor(flow.name())
+                        .map(Color::web).orElse(ColorPalette.MATERIAL_FLOW);
             }
+            ConnectionRenderer.drawMaterialFlow(gc,
+                    endpoints.sourceX(), endpoints.sourceY(),
+                    endpoints.midX(), endpoints.midY(),
+                    endpoints.sinkX(), endpoints.sinkY(),
+                    endpoints.sourceIsCloud(), endpoints.sinkIsCloud(),
+                    flowColor);
         }
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ModuleRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/ModuleRenderer.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.app.canvas.renderers;
 
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
 
 import java.util.List;
 
@@ -33,7 +34,8 @@ final class ModuleRenderer implements ElementTypeRenderer {
                         .map(PortDef::name).toList();
             }
         }
+        Color customColor = canvasState.getColor(name).map(Color::web).orElse(null);
         ElementRenderer.drawModule(gc, name, inputPorts, outputPorts,
-                cx - w / 2, cy - h / 2, w, h);
+                cx - w / 2, cy - h / 2, w, h, customColor);
     }
 }

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/SelectionRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/SelectionRenderer.java
@@ -158,15 +158,17 @@ public final class SelectionRenderer {
     }
 
     /**
-     * Draws a circular drag handle for adjusting causal link curvature.
+     * Draws a rectangular drag handle for adjusting causal link curvature,
+     * matching the Vensim-style control point indicator.
      */
     public static void drawCurveHandle(GraphicsContext gc, double x, double y, double radius) {
+        double size = radius * 2;
         gc.setFill(Color.WHITE);
-        gc.fillOval(x - radius, y - radius, radius * 2, radius * 2);
+        gc.fillRect(x - radius, y - radius, size, size);
         gc.setStroke(SELECTION_COLOR);
         gc.setLineWidth(1.5);
         gc.setLineDashes();
-        gc.strokeOval(x - radius, y - radius, radius * 2, radius * 2);
+        gc.strokeRect(x - radius, y - radius, size, size);
     }
 
     private static void drawHandle(GraphicsContext gc, double x, double y) {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/StockRenderer.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/renderers/StockRenderer.java
@@ -1,6 +1,7 @@
 package systems.courant.sd.app.canvas.renderers;
 
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
 
 import systems.courant.sd.app.canvas.CanvasState;
 import systems.courant.sd.app.canvas.LayoutMetrics;
@@ -20,6 +21,8 @@ final class StockRenderer implements ElementTypeRenderer {
         double h = LayoutMetrics.effectiveHeight(canvasState, name);
         String unit = editor.getStockUnit(name).orElse(null);
         List<String> subscripts = editor.getElementSubscripts(name);
-        ElementRenderer.drawStock(gc, name, unit, subscripts, cx - w / 2, cy - h / 2, w, h);
+        Color customColor = canvasState.getColor(name).map(Color::web).orElse(null);
+        ElementRenderer.drawStock(gc, name, unit, subscripts, cx - w / 2, cy - h / 2, w, h,
+                customColor);
     }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
+++ b/courant-engine/src/main/java/systems/courant/sd/io/json/ModelDefinitionSerializer.java
@@ -341,6 +341,9 @@ public class ModelDefinitionSerializer {
                         epNode.put("width", ep.width());
                         epNode.put("height", ep.height());
                     }
+                    if (ep.hasColor()) {
+                        epNode.put("color", ep.color());
+                    }
                     elements.add(epNode);
                 }
                 node.set("elements", elements);
@@ -481,6 +484,9 @@ public class ModelDefinitionSerializer {
             }
             if (link.hasBias()) {
                 node.put("bias", link.bias());
+            }
+            if (link.hasColor()) {
+                node.put("color", link.color());
             }
             arr.add(node);
         }
@@ -723,13 +729,15 @@ public class ModelDefinitionSerializer {
                         ? n.get("strength").asDouble() : Double.NaN;
                 double bias = n.has("bias")
                         ? n.get("bias").asDouble() : 0.0;
+                String linkColor = textOrNull(n, "color");
                 causalLinks.add(new CausalLinkDef(
                         requiredText(n, "from"),
                         requiredText(n, "to"),
                         polarity,
                         textOrNull(n, "comment"),
                         strength,
-                        bias));
+                        bias,
+                        linkColor));
             }
         }
         return causalLinks;
@@ -806,12 +814,13 @@ public class ModelDefinitionSerializer {
             for (JsonNode ep : n.get("elements")) {
                 double w = ep.has("width") ? ep.get("width").asDouble() : 0;
                 double h = ep.has("height") ? ep.get("height").asDouble() : 0;
+                String color = textOrNull(ep, "color");
                 elements.add(new ElementPlacement(
                         requiredText(ep, "name"),
                         ElementType.fromLabel(requiredText(ep, "type")),
                         requiredDouble(ep, "x"),
                         requiredDouble(ep, "y"),
-                        w, h));
+                        w, h, color));
             }
         }
         List<ConnectorRoute> connectors = new ArrayList<>();

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/CausalLinkDef.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/CausalLinkDef.java
@@ -11,6 +11,7 @@ package systems.courant.sd.model.def;
  * @param comment optional annotation (e.g., "after a delay")
  * @param strength curve strength override ({@code NaN} = auto-computed curvature)
  * @param bias control point offset along the chord direction ({@code 0.0} = centered)
+ * @param color optional custom color as a hex string (e.g. "#FF0000"), or null for default
  */
 public record CausalLinkDef(
         String from,
@@ -18,7 +19,8 @@ public record CausalLinkDef(
         Polarity polarity,
         String comment,
         double strength,
-        double bias
+        double bias,
+        String color
 ) {
 
     public enum Polarity {
@@ -87,70 +89,74 @@ public record CausalLinkDef(
     }
 
     /**
-     * Creates a causal link with default (auto) curve strength and no bias.
-     *
-     * @param from     the source variable name
-     * @param to       the target variable name
-     * @param polarity the direction of influence
-     * @param comment  optional annotation
-     * @param strength curve strength override
+     * Returns true if this link has a custom color.
+     */
+    public boolean hasColor() {
+        return color != null && !color.isBlank();
+    }
+
+    /**
+     * Backward-compatible constructor without color.
      */
     public CausalLinkDef(String from, String to, Polarity polarity, String comment,
-                          double strength) {
-        this(from, to, polarity, comment, strength, 0.0);
+                          double strength, double bias) {
+        this(from, to, polarity, comment, strength, bias, null);
     }
 
     /**
      * Creates a causal link with default (auto) curve strength and no bias.
-     *
-     * @param from     the source variable name
-     * @param to       the target variable name
-     * @param polarity the direction of influence
-     * @param comment  optional annotation
+     */
+    public CausalLinkDef(String from, String to, Polarity polarity, String comment,
+                          double strength) {
+        this(from, to, polarity, comment, strength, 0.0, null);
+    }
+
+    /**
+     * Creates a causal link with default (auto) curve strength and no bias.
      */
     public CausalLinkDef(String from, String to, Polarity polarity, String comment) {
-        this(from, to, polarity, comment, Double.NaN, 0.0);
+        this(from, to, polarity, comment, Double.NaN, 0.0, null);
     }
 
     /**
      * Creates a causal link without a comment.
-     *
-     * @param from     the source variable name
-     * @param to       the target variable name
-     * @param polarity the direction of influence
      */
     public CausalLinkDef(String from, String to, Polarity polarity) {
-        this(from, to, polarity, null, Double.NaN, 0.0);
+        this(from, to, polarity, null, Double.NaN, 0.0, null);
     }
 
     /**
      * Creates a causal link with {@link Polarity#UNKNOWN} polarity and no comment.
-     *
-     * @param from the source variable name
-     * @param to   the target variable name
      */
     public CausalLinkDef(String from, String to) {
-        this(from, to, Polarity.UNKNOWN, null, Double.NaN, 0.0);
+        this(from, to, Polarity.UNKNOWN, null, Double.NaN, 0.0, null);
     }
 
     /**
-     * Returns a copy of this link with a different strength value, preserving bias.
+     * Returns a copy of this link with a different strength value, preserving bias and color.
      */
     public CausalLinkDef withStrength(double newStrength) {
-        return new CausalLinkDef(from, to, polarity, comment, newStrength, bias);
+        return new CausalLinkDef(from, to, polarity, comment, newStrength, bias, color);
     }
 
     /**
-     * Returns a copy of this link with a different bias value, preserving strength.
+     * Returns a copy of this link with a different bias value, preserving strength and color.
      */
     public CausalLinkDef withBias(double newBias) {
-        return new CausalLinkDef(from, to, polarity, comment, strength, newBias);
+        return new CausalLinkDef(from, to, polarity, comment, strength, newBias, color);
     }
 
     /**
-     * Returns a copy of this link with both strength and bias replaced.
+     * Returns a copy of this link with both strength and bias replaced, preserving color.
      */
     public CausalLinkDef withStrengthAndBias(double newStrength, double newBias) {
-        return new CausalLinkDef(from, to, polarity, comment, newStrength, newBias);
+        return new CausalLinkDef(from, to, polarity, comment, newStrength, newBias, color);
+    }
+
+    /**
+     * Returns a copy of this link with a different color, preserving all other fields.
+     */
+    public CausalLinkDef withColor(String newColor) {
+        return new CausalLinkDef(from, to, polarity, comment, strength, bias, newColor);
     }
 }

--- a/courant-engine/src/main/java/systems/courant/sd/model/def/ElementPlacement.java
+++ b/courant-engine/src/main/java/systems/courant/sd/model/def/ElementPlacement.java
@@ -9,6 +9,7 @@ package systems.courant.sd.model.def;
  * @param y the y-coordinate
  * @param width custom width (0 = use default for the element type)
  * @param height custom height (0 = use default for the element type)
+ * @param color optional custom color as a hex string (e.g. "#FF0000"), or null for default
  */
 public record ElementPlacement(
         String name,
@@ -16,14 +17,23 @@ public record ElementPlacement(
         double x,
         double y,
         double width,
-        double height
+        double height,
+        String color
 ) {
+
+    /**
+     * Backward-compatible constructor without color.
+     */
+    public ElementPlacement(String name, ElementType type, double x, double y,
+                            double width, double height) {
+        this(name, type, x, y, width, height, null);
+    }
 
     /**
      * Backward-compatible constructor that uses default (0) width and height.
      */
     public ElementPlacement(String name, ElementType type, double x, double y) {
-        this(name, type, x, y, 0, 0);
+        this(name, type, x, y, 0, 0, null);
     }
 
     public ElementPlacement {
@@ -40,5 +50,12 @@ public record ElementPlacement(
      */
     public boolean hasCustomSize() {
         return width > 0 && height > 0;
+    }
+
+    /**
+     * Returns true if this placement has a custom color.
+     */
+    public boolean hasColor() {
+        return color != null && !color.isBlank();
     }
 }


### PR DESCRIPTION
## Summary
- Add optional `color` field to `ElementPlacement` and `CausalLinkDef` records with backward-compatible constructors
- Persist colors in JSON via `ModelDefinitionSerializer`; track element colors in `CanvasState` at runtime
- All renderers (Stock, Flow, Aux, Module, Lookup, Comment, CldVariable, CausalLink, MaterialFlow) respect custom colors
- Right-click context menu on elements and causal links includes a "Color" submenu with 6 preset swatches, a "Custom..." ColorPicker dialog, and a "Default" reset option
- Bonus: causal link curvature drag handle changed from circle to rectangle (Vensim style)

## Test plan
- [x] Full reactor build passes (`mvn clean compile`)
- [x] All tests pass (`mvn clean test`)
- [x] SpotBugs clean (`mvn spotbugs:check`)
- [ ] Manual: right-click element -> Color -> pick color -> element redraws in chosen color
- [ ] Manual: right-click causal link -> Color -> pick color -> link redraws
- [ ] Manual: save and reload model -> colors persist
- [ ] Manual: undo/redo -> colors revert correctly

Closes #1436