### PR TITLE
Format simulation field entries as bullet list in tutorial

### DIFF
--- a/courant-app/src/main/resources/tutorials/modeling/first-model/04-simulate.md
+++ b/courant-app/src/main/resources/tutorials/modeling/first-model/04-simulate.md
@@ -2,9 +2,9 @@
 
 Go to **Simulate → Simulation Settings** and enter:
 
-  Time step:      `Minute`
-  Duration:       `60`
-  Duration unit:  `Minute`
+- **Time step:** `Minute`
+- **Duration:** `60`
+- **Duration unit:** `Minute`
 
 This simulates one hour of cooling, one minute at a time.
 


### PR DESCRIPTION
## Summary
- Convert indented plain-text field entries to a Markdown bullet list so each instruction renders on its own line in the tutorial dialog

Closes #1475