### PR TITLE
Add filterable Document dialog for inspecting model elements

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/MenuBarBuilder.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/MenuBarBuilder.java
@@ -159,6 +159,9 @@ final class MenuBarBuilder {
                 "Validation Issues\u2026");
         validationIssuesItem.setDisable(true);
 
+        MenuItem documentItem = registry.toMenuItem("Document",
+                "Document\u2026");
+
         CheckMenuItem activityLogItem = checkItem("Activity Log", null,
                 new KeyCodeCombination(KeyCode.L,
                         KeyCombination.SHORTCUT_DOWN),
@@ -182,7 +185,7 @@ final class MenuBarBuilder {
                 new SeparatorMenuItem(),
                 hideAuxItem, hideInfoLinksItem, showDelayItem,
                 new SeparatorMenuItem(),
-                validationIssuesItem,
+                validationIssuesItem, documentItem,
                 new SeparatorMenuItem(),
                 activityLogItem, popOutDashboardItem);
         viewMenu.setDisable(true);

--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -30,6 +30,7 @@ import systems.courant.sd.app.canvas.dialogs.TutorialContentLoader;
 import systems.courant.sd.app.canvas.StatusBar;
 import systems.courant.sd.app.canvas.UndoHistoryPopup;
 import systems.courant.sd.app.canvas.UndoManager;
+import systems.courant.sd.app.canvas.dialogs.DocumentDialog;
 import systems.courant.sd.app.canvas.dialogs.ValidationDialog;
 import systems.courant.sd.app.canvas.ZoomOverlay;
 import systems.courant.sd.model.def.ElementType;
@@ -497,6 +498,8 @@ public class ModelWindow {
                     canvas.zoomOut(); canvas.requestFocus(); });
         commandRegistry.add("Validation Issues", "View",
                 this::showValidationDialog, null, "menuValidationIssues");
+        commandRegistry.add("Document", "View",
+                this::showDocumentDialog, null, "menuDocument");
         commandRegistry.add("Toggle Hide Variables", "View", () -> {
                     canvas.setHideVariables(!canvas.isHideVariables());
                     canvas.requestFocus(); });
@@ -952,6 +955,13 @@ public class ModelWindow {
             return;
         }
         ValidationDialog.showOrUpdate(result, canvas.elements()::selectElement, stage);
+    }
+
+    private void showDocumentDialog() {
+        if (editor == null) {
+            return;
+        }
+        DocumentDialog.showOrUpdate(editor, canvas.elements()::selectElement, stage);
     }
 
     private void updateTitle() {

--- a/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/DocumentDialog.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/canvas/dialogs/DocumentDialog.java
@@ -1,0 +1,301 @@
+package systems.courant.sd.app.canvas.dialogs;
+
+import systems.courant.sd.app.canvas.ModelEditor;
+import systems.courant.sd.app.canvas.Styles;
+import systems.courant.sd.model.def.FlowDef;
+import systems.courant.sd.model.def.LookupTableDef;
+import systems.courant.sd.model.def.ModuleInstanceDef;
+import systems.courant.sd.model.def.StockDef;
+import systems.courant.sd.model.def.VariableDef;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.function.Consumer;
+
+/**
+ * A non-modal dialog that displays all model elements in a filterable, sortable table.
+ * Each row shows the element's name, type, and equation/value. Clicking a row selects
+ * the corresponding element on the canvas.
+ *
+ * <p>Modeled after Vensim's "Document" tool — provides a structured, non-graphical
+ * way to inspect model elements, review equations, and navigate to specific variables.
+ *
+ * <p>Only one document dialog may be open per window. Use {@link #showOrUpdate} to
+ * create a new dialog or refresh and bring an existing one to the front.
+ */
+public class DocumentDialog extends Dialog<Void> {
+
+    /** One dialog instance per owner stage. */
+    private static final Map<Stage, DocumentDialog> OPEN_INSTANCES = new WeakHashMap<>();
+
+    private static final String ALL_TYPES = "All Types";
+
+    private final TableView<ElementRow> table;
+    private final ObservableList<ElementRow> allRows;
+    private final FilteredList<ElementRow> filteredRows;
+    private final TextField searchField;
+    private final ComboBox<String> typeFilter;
+    private final Label summaryLabel;
+    private Consumer<String> onSelectElement;
+
+    /**
+     * A single row in the document table.
+     *
+     * @param name     the element name
+     * @param type     display label for the element type
+     * @param equation the equation, value, or description
+     */
+    public record ElementRow(String name, String type, String equation) {}
+
+    /**
+     * Shows a document dialog for the given editor. If one is already open for the
+     * given owner, refreshes its contents and brings it to the front.
+     */
+    public static void showOrUpdate(ModelEditor editor, Consumer<String> onSelectElement,
+                                    Stage owner) {
+        DocumentDialog existing = OPEN_INSTANCES.get(owner);
+        if (existing != null && existing.isShowing()) {
+            existing.refresh(editor);
+            existing.onSelectElement = onSelectElement;
+            Stage window = (Stage) existing.getDialogPane().getScene().getWindow();
+            window.toFront();
+            window.requestFocus();
+            return;
+        }
+        DocumentDialog dialog = new DocumentDialog(editor, onSelectElement, owner);
+        OPEN_INSTANCES.put(owner, dialog);
+        dialog.show();
+    }
+
+    /**
+     * Returns the currently open document dialog for the given owner,
+     * or {@code null} if none is showing. Visible for testing.
+     */
+    public static DocumentDialog getOpenInstance(Stage owner) {
+        DocumentDialog instance = OPEN_INSTANCES.get(owner);
+        if (instance != null && !instance.isShowing()) {
+            OPEN_INSTANCES.remove(owner);
+            return null;
+        }
+        return instance;
+    }
+
+    public DocumentDialog(ModelEditor editor, Consumer<String> onSelectElement,
+                          Stage owner) {
+        initModality(Modality.NONE);
+        setTitle("Document");
+        this.onSelectElement = onSelectElement;
+
+        // --- Search field ---
+        searchField = new TextField();
+        searchField.setId("documentSearch");
+        searchField.setPromptText("Search by name\u2026");
+        HBox.setHgrow(searchField, Priority.ALWAYS);
+
+        // --- Type filter ---
+        typeFilter = new ComboBox<>();
+        typeFilter.setId("documentTypeFilter");
+        typeFilter.getItems().addAll(ALL_TYPES, "Stock", "Flow", "Variable",
+                "Constant", "Lookup Table", "Module");
+        typeFilter.setValue(ALL_TYPES);
+
+        HBox filterBar = new HBox(8, searchField, typeFilter);
+        filterBar.setAlignment(Pos.CENTER_LEFT);
+        filterBar.setPadding(new Insets(8, 8, 4, 8));
+
+        // --- Table ---
+        allRows = FXCollections.observableArrayList();
+        filteredRows = new FilteredList<>(allRows, row -> true);
+        SortedList<ElementRow> sortedRows = new SortedList<>(filteredRows);
+
+        table = new TableView<>();
+        table.setId("documentTable");
+        table.setPlaceholder(new Label("No model elements."));
+
+        TableColumn<ElementRow, String> nameCol = new TableColumn<>("Name");
+        nameCol.setCellValueFactory(data ->
+                new SimpleStringProperty(data.getValue().name()));
+        nameCol.setPrefWidth(180);
+
+        TableColumn<ElementRow, String> typeCol = new TableColumn<>("Type");
+        typeCol.setCellValueFactory(data ->
+                new SimpleStringProperty(data.getValue().type()));
+        typeCol.setPrefWidth(100);
+
+        TableColumn<ElementRow, String> equationCol = new TableColumn<>("Equation / Value");
+        equationCol.setCellValueFactory(data ->
+                new SimpleStringProperty(data.getValue().equation()));
+        equationCol.setPrefWidth(360);
+
+        table.getColumns().add(nameCol);
+        table.getColumns().add(typeCol);
+        table.getColumns().add(equationCol);
+
+        sortedRows.comparatorProperty().bind(table.comparatorProperty());
+        table.setItems(sortedRows);
+
+        // Row click → select element on canvas
+        table.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
+            if (newVal != null && this.onSelectElement != null) {
+                this.onSelectElement.accept(newVal.name());
+            }
+        });
+
+        // --- Filter logic ---
+        searchField.textProperty().addListener((obs, oldVal, newVal) -> applyFilter());
+        typeFilter.valueProperty().addListener((obs, oldVal, newVal) -> applyFilter());
+
+        // --- Summary ---
+        summaryLabel = new Label();
+        summaryLabel.setId("documentSummary");
+        summaryLabel.setPadding(new Insets(6, 8, 6, 8));
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        HBox bottomBar = new HBox(summaryLabel, spacer);
+        bottomBar.setAlignment(Pos.CENTER_LEFT);
+        bottomBar.setPadding(new Insets(4, 8, 4, 0));
+
+        // --- Layout ---
+        BorderPane root = new BorderPane();
+        root.setTop(filterBar);
+        root.setCenter(table);
+        root.setBottom(bottomBar);
+
+        getDialogPane().setContent(root);
+        getDialogPane().setPrefWidth(Styles.screenAwareWidth(700));
+        getDialogPane().setPrefHeight(Styles.screenAwareHeight(500));
+        getDialogPane().getButtonTypes().add(ButtonType.CLOSE);
+
+        setResultConverter(button -> null);
+        setOnHidden(e -> OPEN_INSTANCES.values().remove(this));
+
+        // Populate
+        refresh(editor);
+    }
+
+    /**
+     * Refreshes the table contents from the given editor.
+     */
+    public void refresh(ModelEditor editor) {
+        allRows.setAll(buildRows(editor));
+        updateSummary();
+    }
+
+    /**
+     * Returns a snapshot of the rows currently visible (after filtering).
+     * Visible for testing.
+     */
+    public List<ElementRow> getVisibleRows() {
+        return List.copyOf(filteredRows);
+    }
+
+    /**
+     * Returns the search text field. Visible for testing.
+     */
+    public TextField getSearchField() {
+        return searchField;
+    }
+
+    /**
+     * Returns the type filter combo box. Visible for testing.
+     */
+    public ComboBox<String> getTypeFilter() {
+        return typeFilter;
+    }
+
+    /**
+     * Returns the table view. Visible for testing.
+     */
+    public TableView<ElementRow> getTable() {
+        return table;
+    }
+
+    private void applyFilter() {
+        String search = searchField.getText();
+        String searchLower = (search == null || search.isBlank())
+                ? null : search.toLowerCase(Locale.ROOT);
+        String selectedType = typeFilter.getValue();
+        boolean filterByType = selectedType != null && !ALL_TYPES.equals(selectedType);
+
+        filteredRows.setPredicate(row -> {
+            if (searchLower != null
+                    && !row.name().toLowerCase(Locale.ROOT).contains(searchLower)) {
+                return false;
+            }
+            if (filterByType && !row.type().equals(selectedType)) {
+                return false;
+            }
+            return true;
+        });
+        updateSummary();
+    }
+
+    private void updateSummary() {
+        int showing = filteredRows.size();
+        int total = allRows.size();
+        if (showing == total) {
+            summaryLabel.setText(total + " elements");
+        } else {
+            summaryLabel.setText(showing + " of " + total + " elements");
+        }
+    }
+
+    static List<ElementRow> buildRows(ModelEditor editor) {
+        List<ElementRow> rows = new ArrayList<>();
+
+        for (StockDef s : editor.getStocks()) {
+            String equation = s.initialExpression() != null
+                    ? s.initialExpression()
+                    : String.valueOf(s.initialValue());
+            rows.add(new ElementRow(s.name(), "Stock", equation));
+        }
+
+        for (FlowDef f : editor.getFlows()) {
+            rows.add(new ElementRow(f.name(), "Flow", f.equation()));
+        }
+
+        for (VariableDef v : editor.getVariables()) {
+            String type = v.isLiteral() ? "Constant" : "Variable";
+            rows.add(new ElementRow(v.name(), type, v.equation()));
+        }
+
+        for (LookupTableDef lt : editor.getLookupTables()) {
+            String desc = "(" + lt.xValues().length + " points, " + lt.interpolation() + ")";
+            rows.add(new ElementRow(lt.name(), "Lookup Table", desc));
+        }
+
+        for (ModuleInstanceDef m : editor.getModules()) {
+            String desc = m.definition().name() != null ? m.definition().name() : "";
+            rows.add(new ElementRow(m.instanceName(), "Module", desc));
+        }
+
+        rows.sort((a, b) -> a.name().compareToIgnoreCase(b.name()));
+        return rows;
+    }
+}

--- a/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/DocumentDialogTest.java
+++ b/courant-app/src/test/java/systems/courant/sd/app/canvas/dialogs/DocumentDialogTest.java
@@ -1,0 +1,380 @@
+package systems.courant.sd.app.canvas.dialogs;
+
+import systems.courant.sd.app.canvas.ModelEditor;
+import systems.courant.sd.app.canvas.dialogs.DocumentDialog.ElementRow;
+import systems.courant.sd.model.def.ModelDefinition;
+import systems.courant.sd.model.def.ModelDefinitionBuilder;
+
+import javafx.application.Platform;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DocumentDialog")
+@ExtendWith(ApplicationExtension.class)
+class DocumentDialogTest {
+
+    @Start
+    void start(Stage stage) {
+        // No-op — tests create their own DocumentDialog instances
+    }
+
+    private ModelEditor editorWith(ModelDefinition def) {
+        ModelEditor editor = new ModelEditor();
+        editor.loadFrom(def);
+        return editor;
+    }
+
+    private ModelDefinition sampleModel() {
+        ModelDefinition innerDef = new ModelDefinitionBuilder()
+                .name("Inner")
+                .variable("x", "1", "")
+                .build();
+
+        return new ModelDefinitionBuilder()
+                .name("Test Model")
+                .stock("Population", 1000, "people")
+                .stock("Pollution", 0, "tons")
+                .flow("Birth Rate", "Population * birth_fraction", "year",
+                        null, "Population")
+                .variable("birth_fraction", "0.03", "1/year")
+                .variable("net_growth", "Birth Rate - death_rate", "people/year")
+                .lookupTable("effect_of_pollution",
+                        new double[]{0, 1, 2, 3}, new double[]{1.0, 0.8, 0.5, 0.1},
+                        "LINEAR")
+                .module("Inner Module", innerDef, Map.of(), Map.of())
+                .build();
+    }
+
+    @Nested
+    @DisplayName("buildRows")
+    class BuildRowsTests {
+
+        @Test
+        @DisplayName("should include all element types")
+        void shouldIncludeAllElementTypes() {
+            ModelEditor editor = editorWith(sampleModel());
+            List<ElementRow> rows = DocumentDialog.buildRows(editor);
+
+            assertThat(rows).extracting(ElementRow::type)
+                    .contains("Stock", "Flow", "Constant", "Variable", "Lookup Table", "Module");
+        }
+
+        @Test
+        @DisplayName("should return rows sorted by name (case-insensitive)")
+        void shouldSortByName() {
+            ModelEditor editor = editorWith(sampleModel());
+            List<ElementRow> rows = DocumentDialog.buildRows(editor);
+
+            List<String> names = rows.stream().map(ElementRow::name).toList();
+            List<String> sorted = names.stream()
+                    .sorted(String.CASE_INSENSITIVE_ORDER)
+                    .toList();
+            assertThat(names).isEqualTo(sorted);
+        }
+
+        @Test
+        @DisplayName("should show stock initial value as equation")
+        void shouldShowStockInitialValue() {
+            ModelEditor editor = editorWith(sampleModel());
+            List<ElementRow> rows = DocumentDialog.buildRows(editor);
+
+            ElementRow pop = rows.stream()
+                    .filter(r -> r.name().equals("Population"))
+                    .findFirst().orElseThrow();
+            assertThat(pop.type()).isEqualTo("Stock");
+            assertThat(pop.equation()).isEqualTo("1000.0");
+        }
+
+        @Test
+        @DisplayName("should show flow equation")
+        void shouldShowFlowEquation() {
+            ModelEditor editor = editorWith(sampleModel());
+            List<ElementRow> rows = DocumentDialog.buildRows(editor);
+
+            ElementRow flow = rows.stream()
+                    .filter(r -> r.name().equals("Birth Rate"))
+                    .findFirst().orElseThrow();
+            assertThat(flow.type()).isEqualTo("Flow");
+            assertThat(flow.equation()).isEqualTo("Population * birth_fraction");
+        }
+
+        @Test
+        @DisplayName("should classify literal variables as Constant")
+        void shouldClassifyLiteralAsConstant() {
+            ModelEditor editor = editorWith(sampleModel());
+            List<ElementRow> rows = DocumentDialog.buildRows(editor);
+
+            ElementRow constant = rows.stream()
+                    .filter(r -> r.name().equals("birth_fraction"))
+                    .findFirst().orElseThrow();
+            assertThat(constant.type()).isEqualTo("Constant");
+        }
+
+        @Test
+        @DisplayName("should classify formula variables as Variable")
+        void shouldClassifyFormulaAsVariable() {
+            ModelEditor editor = editorWith(sampleModel());
+            List<ElementRow> rows = DocumentDialog.buildRows(editor);
+
+            ElementRow variable = rows.stream()
+                    .filter(r -> r.name().equals("net_growth"))
+                    .findFirst().orElseThrow();
+            assertThat(variable.type()).isEqualTo("Variable");
+        }
+
+        @Test
+        @DisplayName("should show lookup table summary")
+        void shouldShowLookupSummary() {
+            ModelEditor editor = editorWith(sampleModel());
+            List<ElementRow> rows = DocumentDialog.buildRows(editor);
+
+            ElementRow lookup = rows.stream()
+                    .filter(r -> r.name().equals("effect_of_pollution"))
+                    .findFirst().orElseThrow();
+            assertThat(lookup.type()).isEqualTo("Lookup Table");
+            assertThat(lookup.equation()).contains("4 points").contains("LINEAR");
+        }
+
+        @Test
+        @DisplayName("should show module instance")
+        void shouldShowModuleInstance() {
+            ModelEditor editor = editorWith(sampleModel());
+            List<ElementRow> rows = DocumentDialog.buildRows(editor);
+
+            ElementRow module = rows.stream()
+                    .filter(r -> r.name().equals("Inner Module"))
+                    .findFirst().orElseThrow();
+            assertThat(module.type()).isEqualTo("Module");
+            assertThat(module.equation()).isEqualTo("Inner");
+        }
+
+        @Test
+        @DisplayName("should return empty list for empty model")
+        void shouldReturnEmptyForEmptyModel() {
+            ModelDefinition empty = new ModelDefinitionBuilder()
+                    .name("Empty")
+                    .build();
+            ModelEditor editor = editorWith(empty);
+            List<ElementRow> rows = DocumentDialog.buildRows(editor);
+
+            assertThat(rows).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Dialog lifecycle")
+    class LifecycleTests {
+
+        @Test
+        @DisplayName("showOrUpdate creates a new dialog when none is open")
+        void shouldCreateNewDialog() {
+            assertThat(DocumentDialog.getOpenInstance(null)).isNull();
+
+            ModelEditor editor = editorWith(sampleModel());
+            Platform.runLater(() ->
+                    DocumentDialog.showOrUpdate(editor, name -> {}, null));
+            WaitForAsyncUtils.waitForFxEvents();
+
+            DocumentDialog instance = DocumentDialog.getOpenInstance(null);
+            assertThat(instance).isNotNull();
+            assertThat(instance.isShowing()).isTrue();
+
+            Platform.runLater(() -> instance.close());
+            WaitForAsyncUtils.waitForFxEvents();
+        }
+
+        @Test
+        @DisplayName("showOrUpdate reuses existing dialog")
+        void shouldReuseExistingDialog() {
+            ModelEditor editor = editorWith(sampleModel());
+            Platform.runLater(() ->
+                    DocumentDialog.showOrUpdate(editor, name -> {}, null));
+            WaitForAsyncUtils.waitForFxEvents();
+
+            DocumentDialog first = DocumentDialog.getOpenInstance(null);
+
+            Platform.runLater(() ->
+                    DocumentDialog.showOrUpdate(editor, name -> {}, null));
+            WaitForAsyncUtils.waitForFxEvents();
+
+            assertThat(DocumentDialog.getOpenInstance(null)).isSameAs(first);
+
+            Platform.runLater(() -> first.close());
+            WaitForAsyncUtils.waitForFxEvents();
+        }
+
+        @Test
+        @DisplayName("closing clears the open instance")
+        void shouldClearOnClose() {
+            ModelEditor editor = editorWith(sampleModel());
+            Platform.runLater(() ->
+                    DocumentDialog.showOrUpdate(editor, name -> {}, null));
+            WaitForAsyncUtils.waitForFxEvents();
+
+            DocumentDialog instance = DocumentDialog.getOpenInstance(null);
+            Platform.runLater(() -> instance.close());
+            WaitForAsyncUtils.waitForFxEvents();
+
+            assertThat(DocumentDialog.getOpenInstance(null)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Filtering")
+    class FilteringTests {
+
+        @Test
+        @DisplayName("should filter by name search text")
+        void shouldFilterByName() {
+            ModelEditor editor = editorWith(sampleModel());
+            final DocumentDialog[] holder = new DocumentDialog[1];
+
+            Platform.runLater(() -> {
+                holder[0] = new DocumentDialog(editor, name -> {}, null);
+                holder[0].show();
+            });
+            WaitForAsyncUtils.waitForFxEvents();
+
+            DocumentDialog dialog = holder[0];
+
+            Platform.runLater(() -> dialog.getSearchField().setText("birth"));
+            WaitForAsyncUtils.waitForFxEvents();
+
+            List<ElementRow> visible = dialog.getVisibleRows();
+            assertThat(visible).allSatisfy(row ->
+                    assertThat(row.name().toLowerCase()).contains("birth"));
+
+            Platform.runLater(() -> dialog.close());
+            WaitForAsyncUtils.waitForFxEvents();
+        }
+
+        @Test
+        @DisplayName("should filter by type")
+        void shouldFilterByType() {
+            ModelEditor editor = editorWith(sampleModel());
+            final DocumentDialog[] holder = new DocumentDialog[1];
+
+            Platform.runLater(() -> {
+                holder[0] = new DocumentDialog(editor, name -> {}, null);
+                holder[0].show();
+            });
+            WaitForAsyncUtils.waitForFxEvents();
+
+            DocumentDialog dialog = holder[0];
+
+            Platform.runLater(() -> dialog.getTypeFilter().setValue("Stock"));
+            WaitForAsyncUtils.waitForFxEvents();
+
+            List<ElementRow> visible = dialog.getVisibleRows();
+            assertThat(visible).allSatisfy(row ->
+                    assertThat(row.type()).isEqualTo("Stock"));
+            assertThat(visible).hasSize(2); // Population, Pollution
+
+            Platform.runLater(() -> dialog.close());
+            WaitForAsyncUtils.waitForFxEvents();
+        }
+
+        @Test
+        @DisplayName("should combine name and type filters")
+        void shouldCombineFilters() {
+            ModelEditor editor = editorWith(sampleModel());
+            final DocumentDialog[] holder = new DocumentDialog[1];
+
+            Platform.runLater(() -> {
+                holder[0] = new DocumentDialog(editor, name -> {}, null);
+                holder[0].show();
+            });
+            WaitForAsyncUtils.waitForFxEvents();
+
+            DocumentDialog dialog = holder[0];
+
+            Platform.runLater(() -> {
+                dialog.getSearchField().setText("pop");
+                dialog.getTypeFilter().setValue("Stock");
+            });
+            WaitForAsyncUtils.waitForFxEvents();
+
+            List<ElementRow> visible = dialog.getVisibleRows();
+            assertThat(visible).hasSize(1);
+            assertThat(visible.getFirst().name()).isEqualTo("Population");
+
+            Platform.runLater(() -> dialog.close());
+            WaitForAsyncUtils.waitForFxEvents();
+        }
+
+        @Test
+        @DisplayName("clearing filters should show all elements")
+        void shouldShowAllWhenFiltersCleared() {
+            ModelEditor editor = editorWith(sampleModel());
+            final DocumentDialog[] holder = new DocumentDialog[1];
+
+            Platform.runLater(() -> {
+                holder[0] = new DocumentDialog(editor, name -> {}, null);
+                holder[0].show();
+            });
+            WaitForAsyncUtils.waitForFxEvents();
+
+            DocumentDialog dialog = holder[0];
+            int totalRows = dialog.getVisibleRows().size();
+
+            Platform.runLater(() -> {
+                dialog.getSearchField().setText("Population");
+                dialog.getTypeFilter().setValue("Stock");
+            });
+            WaitForAsyncUtils.waitForFxEvents();
+            assertThat(dialog.getVisibleRows().size()).isLessThan(totalRows);
+
+            Platform.runLater(() -> {
+                dialog.getSearchField().clear();
+                dialog.getTypeFilter().setValue("All Types");
+            });
+            WaitForAsyncUtils.waitForFxEvents();
+
+            assertThat(dialog.getVisibleRows()).hasSize(totalRows);
+
+            Platform.runLater(() -> dialog.close());
+            WaitForAsyncUtils.waitForFxEvents();
+        }
+    }
+
+    @Nested
+    @DisplayName("Element selection")
+    class SelectionTests {
+
+        @Test
+        @DisplayName("should invoke callback when row is selected")
+        void shouldInvokeCallbackOnSelect() {
+            ModelEditor editor = editorWith(sampleModel());
+            String[] selected = {null};
+            final DocumentDialog[] holder = new DocumentDialog[1];
+
+            Platform.runLater(() -> {
+                holder[0] = new DocumentDialog(editor, name -> selected[0] = name, null);
+                holder[0].show();
+            });
+            WaitForAsyncUtils.waitForFxEvents();
+
+            DocumentDialog dialog = holder[0];
+
+            Platform.runLater(() -> dialog.getTable().getSelectionModel().select(0));
+            WaitForAsyncUtils.waitForFxEvents();
+
+            assertThat(selected[0]).isNotNull();
+
+            Platform.runLater(() -> dialog.close());
+            WaitForAsyncUtils.waitForFxEvents();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a non-modal Document dialog (View > Document…) that displays all model elements in a filterable, sortable table with Name, Type, and Equation/Value columns (#1473)
- Supports text search by name and combo box filtering by type (Stock, Flow, Variable, Constant, Lookup Table, Module)
- Clicking a row selects the corresponding element on the canvas

## Test plan
- [x] 13 new tests covering row building, type classification, dialog lifecycle, filtering, and selection callback
- [x] All existing tests pass
- [x] SpotBugs clean