### PR TITLE
Don't close current model when opening a tutorial

### DIFF
--- a/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
+++ b/courant-app/src/main/java/systems/courant/sd/app/ModelWindow.java
@@ -825,11 +825,7 @@ public class ModelWindow {
     private void showCurriculumBrowser() {
         helpWindows.showOrBring("curriculum-browser", () -> {
             CurriculumBrowserDialog browser = new CurriculumBrowserDialog();
-            browser.setOnLaunchTutorial(jsonPath -> {
-                showEditor();
-                fileController.newModel();
-                showContentTutorial(jsonPath);
-            });
+            browser.setOnLaunchTutorial(this::showContentTutorial);
             return browser;
         });
     }


### PR DESCRIPTION
## Summary
- Remove `fileController.newModel()` call from curriculum browser's tutorial launch callback — tutorials are independent dialogs that don't need to replace the current model

Fixes #1478